### PR TITLE
fix: always write hook events in array format for Claude Code compatibility

### DIFF
--- a/Sources/StatusDetection/HookInjector.swift
+++ b/Sources/StatusDetection/HookInjector.swift
@@ -204,14 +204,15 @@ public struct HookInjector: Sendable {
     }
 
     /// Remove Runway hooks from an event's matcher blocks. Returns nil if event should be removed entirely.
-    private func removeRunwayHooksFromEvent(_ eventData: Any) -> Any? {
+    /// Always returns [[String: Any]] to maintain array format required by Claude Code.
+    private func removeRunwayHooksFromEvent(_ eventData: Any) -> [[String: Any]]? {
         let blocks: [[String: Any]]
         if let single = eventData as? [String: Any] {
             blocks = [single]
         } else if let array = eventData as? [[String: Any]] {
             blocks = array
         } else {
-            return eventData
+            return nil
         }
 
         var cleaned: [[String: Any]] = []
@@ -224,19 +225,19 @@ public struct HookInjector: Sendable {
             cleaned.append(block)
         }
 
-        if cleaned.isEmpty { return nil }
-        return cleaned.count == 1 ? cleaned[0] : cleaned
+        return cleaned.isEmpty ? nil : cleaned
     }
 
     /// Merge our hook entry into an event's existing matcher blocks.
-    private func mergeHookEvent(existing: Any?, matcher: String?, hook: [String: Any]) -> Any {
+    /// Always returns [[String: Any]] — Claude Code requires the array format for all hook events.
+    private func mergeHookEvent(existing: Any?, matcher: String?, hook: [String: Any]) -> [[String: Any]] {
         var block: [String: Any] = [:]
         if let matcher {
             block["matcher"] = matcher
         }
 
         if let existing {
-            // Append to existing blocks
+            // Normalise to array (handle legacy object format written by older versions)
             let blocks: [[String: Any]]
             if let single = existing as? [String: Any] {
                 blocks = [single]
@@ -246,7 +247,7 @@ public struct HookInjector: Sendable {
                 blocks = []
             }
 
-            // Find a block with matching matcher (or no matcher)
+            // Find a block with matching matcher (or no matcher) and append our hook
             var found = false
             var result = blocks
             for i in result.indices {
@@ -265,10 +266,10 @@ public struct HookInjector: Sendable {
                 result.append(block)
             }
 
-            return result.count == 1 ? result[0] : result
+            return result
         } else {
             block["hooks"] = [hook]
-            return block
+            return [block]
         }
     }
 }


### PR DESCRIPTION
### Summary

Claude Code requires all hook event values to be an **array** of matcher blocks: `[{ "hooks": [...] }]`. `HookInjector` was writing a plain object `{ "hooks": [...] }` (unwrapping single-element arrays), which caused Claude to error on launch. This fixes `mergeHookEvent` and `removeRunwayHooksFromEvent` to always return `[[String: Any]]`.

### What Changed

- `Sources/StatusDetection/HookInjector.swift`: changed `mergeHookEvent` return type from `Any` to `[[String: Any]]` — always returns array, never collapses single-block result to a plain object
- `Sources/StatusDetection/HookInjector.swift`: changed `removeRunwayHooksFromEvent` return type from `Any?` to `[[String: Any]]?` — same fix; also normalises legacy object-format events when reading existing settings (upgrade path handles old format)

### Behavioral Impact

- Breaking changes: No
- Migrations: No — the injector now normalises legacy object-format events when reading existing settings (upgrade path handles old format)

### Testing

- [x] All 120 tests pass (`swift test`)