### PR TITLE
feat: show PR age in list views

### DIFF
--- a/Sources/Views/PRDashboard/PRDashboardView.swift
+++ b/Sources/Views/PRDashboard/PRDashboardView.swift
@@ -211,6 +211,9 @@ struct PRRowView: View {
                             .font(.caption)
                             .foregroundColor(theme.chrome.accent)
                     }
+                    Text(pr.ageText)
+                        .font(.caption)
+                        .foregroundColor(theme.chrome.textDim)
                     CheckSummaryBadge(checks: pr.checks)
                     ReviewDecisionBadge(decision: pr.reviewDecision)
                 }

--- a/Sources/Views/ProjectPage/ProjectPRsTab.swift
+++ b/Sources/Views/ProjectPage/ProjectPRsTab.swift
@@ -168,6 +168,9 @@ private struct ProjectPRRowView: View {
                             .fontDesign(.monospaced)
                             .foregroundColor(theme.chrome.cyan)
                     }
+                    Text(pr.ageText)
+                        .font(.caption)
+                        .foregroundColor(theme.chrome.textDim)
                     CheckSummaryBadge(checks: pr.checks)
                     ReviewDecisionBadge(decision: pr.reviewDecision)
                 }

--- a/Sources/Views/Shared/PullRequest+ViewHelpers.swift
+++ b/Sources/Views/Shared/PullRequest+ViewHelpers.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Models
 import SwiftUI
 import Theme
@@ -13,5 +14,16 @@ extension PullRequest {
         case .merged: return chrome.purple
         case .closed: return chrome.red
         }
+    }
+
+    nonisolated(unsafe) private static let ageFormatter: RelativeDateTimeFormatter = {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter
+    }()
+
+    /// Human-readable age string relative to now, e.g. "3d ago" or "2h ago".
+    public var ageText: String {
+        Self.ageFormatter.localizedString(for: createdAt, relativeTo: Date())
     }
 }


### PR DESCRIPTION
## Summary

Adds relative time labels (e.g. "3d ago", "2h ago") to PR rows in both the main PR dashboard and the project-level PR tab, so you can quickly see how old each PR is at a glance.

## What Changed

- **`PullRequest+ViewHelpers.swift`** — Added `ageText` computed property using `RelativeDateTimeFormatter` with abbreviated style
- **`PRDashboardView.swift`** — Display `pr.ageText` in the `PRRowView` subtitle row
- **`ProjectPRsTab.swift`** — Display `pr.ageText` in the `ProjectPRRowView` subtitle row

## Test plan

- [ ] Open the PR dashboard — verify each PR row shows a relative age label (e.g. "3d ago")
- [ ] Open a project's PR tab — verify same age labels appear
- [ ] Confirm age updates on refresh