### PR TITLE
fix: enrich PATH at startup so .app bundles find Homebrew tools

### DIFF
--- a/Sources/App/RunwayApp.swift
+++ b/Sources/App/RunwayApp.swift
@@ -12,6 +12,11 @@ struct RunwayApp: App {
     @State private var store = RunwayStore()
 
     init() {
+        // .app bundles from Finder/Dock inherit a minimal PATH from launchd.
+        // Enrich it with the user's login shell PATH so Homebrew tools
+        // (tmux, gh, claude, etc.) are found by /usr/bin/env.
+        ShellRunner.enrichPath()
+
         // SPM executables don't get a proper .app bundle, so macOS doesn't
         // activate them as GUI apps. Force regular activation policy so
         // the window, dock icon, and menu bar all appear.
@@ -29,6 +34,7 @@ struct RunwayApp: App {
                 .preferredColorScheme(store.themeManager.currentTheme.appearance == .dark ? .dark : .light)
         }
         .windowStyle(.titleBar)
+        .windowToolbarStyle(.unified)
         .defaultSize(width: 1200, height: 800)
         .commands {
             CommandGroup(after: .sidebar) {

--- a/Sources/Models/ShellRunner.swift
+++ b/Sources/Models/ShellRunner.swift
@@ -12,6 +12,55 @@ import Foundation
 /// release the cooperative thread while the subprocess runs.
 public enum ShellRunner {
 
+    /// Resolve the user's full PATH by running their login shell.
+    ///
+    /// macOS `.app` bundles launched from Finder/Dock inherit a minimal PATH
+    /// (`/usr/bin:/bin:/usr/sbin:/sbin`) from launchd. Tools installed via
+    /// Homebrew, MacPorts, nix, etc. aren't on this PATH, so `/usr/bin/env tmux`
+    /// (and `gh`, `claude`, etc.) fail with "No such file or directory".
+    ///
+    /// Call once at app startup. Uses `setenv` so all subsequent subprocess
+    /// launches — both inherited-env and `ProcessInfo.processInfo.environment` —
+    /// see the enriched PATH.
+    public static func enrichPath() {
+        let current = ProcessInfo.processInfo.environment["PATH"] ?? ""
+        // If common Homebrew paths are already present, we're running via
+        // `swift run` or the terminal — nothing to fix.
+        if current.contains("/opt/homebrew/bin") || current.contains("/usr/local/bin") {
+            return
+        }
+
+        let shell = ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: shell)
+        // -l = login shell (sources ~/.zprofile, ~/.zshenv → picks up PATH)
+        process.arguments = ["-l", "-c", "printf '%s' \"$PATH\""]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = FileHandle.nullDevice
+
+        guard (try? process.run()) != nil else {
+            applyFallbackPath(current)
+            return
+        }
+        process.waitUntilExit()
+
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        let resolved = String(data: data, encoding: .utf8) ?? ""
+
+        if process.terminationStatus == 0, !resolved.isEmpty {
+            setenv("PATH", resolved, 1)
+        } else {
+            applyFallbackPath(current)
+        }
+    }
+
+    private static func applyFallbackPath(_ current: String) {
+        let fallback =
+            "/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/local/sbin:\(current)"
+        setenv("PATH", fallback, 1)
+    }
+
     /// Run a shell command and return its stdout output.
     ///
     /// - Parameters:


### PR DESCRIPTION
### Summary

macOS `.app` bundles launched from Finder or a DMG inherit a minimal PATH from launchd (`/usr/bin:/bin:/usr/sbin:/sbin`), which means Homebrew-installed tools like `tmux`, `gh`, and `claude` aren't found. This broke both session creation and session resumption in the v0.0.1 packaged release. This PR also fixes an inconsistent toolbar appearance in the packaged app.

### What Changed

**Core logic (`Sources/Models/ShellRunner.swift`)**
- Added `ShellRunner.enrichPath()` — runs the user's login shell once at startup to capture their full `$PATH`, then calls `setenv()` so all subsequent subprocess launches see Homebrew (and nix, MacPorts, etc.) tools
- Includes a hardcoded Homebrew fallback (`/opt/homebrew/bin`, `/usr/local/bin`) if the login shell probe fails
- Short-circuits when common Homebrew paths are already present (i.e., running via `swift run` or from a terminal)

**App entry point (`Sources/App/RunwayApp.swift`)**
- Calls `ShellRunner.enrichPath()` in `init()` before any other setup
- Added `.windowToolbarStyle(.unified)` to the `WindowGroup` for consistent toolbar rendering between `swift run` and `.app` bundle contexts

### Behavioral Impact
- Breaking changes: No
- Migrations: No
- Feature flags: None

### Testing
- [x] All 134 tests passing (`swift test`)
- Manual verification: packaged `.app` successfully creates and resumes tmux sessions

### Review Guidance
Start with `Sources/Models/ShellRunner.swift` — the `enrichPath()` method (lines 25–56) and `applyFallbackPath()` (lines 58–62) are the core fix. Then check `Sources/App/RunwayApp.swift` for the call site and toolbar style addition.