### PR TITLE
fix: resolve race condition in PATH enrichment and DMG rendering

### DIFF
--- a/Sources/App/RunwayApp.swift
+++ b/Sources/App/RunwayApp.swift
@@ -9,13 +9,16 @@ import Views
 
 @main
 struct RunwayApp: App {
-    @State private var store = RunwayStore()
+    @State private var store: RunwayStore
 
     init() {
         // .app bundles from Finder/Dock inherit a minimal PATH from launchd.
-        // Enrich it with the user's login shell PATH so Homebrew tools
-        // (tmux, gh, claude, etc.) are found by /usr/bin/env.
+        // Enrich it BEFORE constructing RunwayStore — its init fires a Task
+        // that checks tmux availability, and waitUntilExit() pumps the
+        // RunLoop which can let that Task sneak in with the un-enriched PATH.
         ShellRunner.enrichPath()
+
+        _store = State(initialValue: RunwayStore())
 
         // SPM executables don't get a proper .app bundle, so macOS doesn't
         // activate them as GUI apps. Force regular activation policy so

--- a/Sources/App/RunwayStore.swift
+++ b/Sources/App/RunwayStore.swift
@@ -102,6 +102,7 @@ public final class RunwayStore {
         // has sessions available for PR-session linking)
         Task {
             tmuxAvailable = await tmuxManager.isAvailable()
+            print("[Runway] tmux available: \(tmuxAvailable)")
             await loadState()
             await fetchPRs()
             // Seed the fingerprint so the first poll doesn't trigger a redundant fetch
@@ -249,7 +250,11 @@ public final class RunwayStore {
 
     /// Creates the tmux session and updates the session status to .running.
     private func startTmuxSession(for session: inout Session, path: String) async {
-        guard tmuxAvailable else { return }
+        guard tmuxAvailable else {
+            updateSessionStatus(id: session.id, status: .error)
+            statusMessage = .error("tmux not found — install it with: brew install tmux")
+            return
+        }
 
         let tmuxName = "runway-\(session.id)"
         let command: String?
@@ -274,8 +279,8 @@ public final class RunwayStore {
             updateSessionStatus(id: session.id, status: .running)
         } catch {
             print("[Runway] Failed to create tmux session: \(error)")
+            updateSessionStatus(id: session.id, status: .error)
             statusMessage = .error("tmux session failed: \(error.localizedDescription)")
-            // Fall through — session still exists, TerminalPane will use direct spawn fallback
         }
     }
 

--- a/Sources/Models/ShellRunner.swift
+++ b/Sources/Models/ShellRunner.swift
@@ -27,9 +27,11 @@ public enum ShellRunner {
         // If common Homebrew paths are already present, we're running via
         // `swift run` or the terminal — nothing to fix.
         if current.contains("/opt/homebrew/bin") || current.contains("/usr/local/bin") {
+            print("[Runway] PATH already contains Homebrew dirs, skipping enrichment")
             return
         }
 
+        print("[Runway] Enriching PATH (launchd PATH: \(current))")
         let shell = ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
         let process = Process()
         process.executableURL = URL(fileURLWithPath: shell)
@@ -40,6 +42,7 @@ public enum ShellRunner {
         process.standardError = FileHandle.nullDevice
 
         guard (try? process.run()) != nil else {
+            print("[Runway] Login shell failed to launch, applying fallback PATH")
             applyFallbackPath(current)
             return
         }
@@ -50,7 +53,9 @@ public enum ShellRunner {
 
         if process.terminationStatus == 0, !resolved.isEmpty {
             setenv("PATH", resolved, 1)
+            print("[Runway] PATH enriched via login shell (\(resolved.components(separatedBy: ":").count) entries)")
         } else {
+            print("[Runway] Login shell exited \(process.terminationStatus), applying fallback PATH")
             applyFallbackPath(current)
         }
     }

--- a/scripts/Info.plist
+++ b/scripts/Info.plist
@@ -28,6 +28,8 @@
     <false/>
     <key>LSUIElement</key>
     <false/>
+    <key>NSPrincipalClass</key>
+    <string>NSApplication</string>
     <key>NSHumanReadableCopyright</key>
     <string>Copyright © 2025 Matthew Nicholson. All rights reserved.</string>
 </dict>


### PR DESCRIPTION
## Summary

- **Race condition fix**: Reorder `RunwayApp.init()` so `enrichPath()` completes before `RunwayStore` is constructed — `waitUntilExit()` pumps the RunLoop, which let the tmux availability Task execute with the un-enriched launchd PATH, causing `tmuxAvailable = false` in DMG-installed builds
- **Session error handling**: Set session status to `.error` (with user-visible toast) when tmux is unavailable or creation fails, instead of silently leaving sessions stuck in "Connecting..." forever
- **UI rendering fix**: Add `NSPrincipalClass = NSApplication` to Info.plist so macOS fully initializes the AppKit rendering layer for `.app` bundles installed from DMG — fixes rounded corners/pill buttons degrading to squares

## Test plan

- [x] Build with `make dist`, install DMG to `/Applications`, launch from there
- [x] Verify `[Runway] tmux available: true` in Console.app
- [x] Create a new session — transitions to running (not stuck on "Connecting...")
- [x] Verify rounded corners and capsule/pill buttons render correctly
- [x] Existing sessions still attach and work