### PR TITLE
feat: add Sparkle 2 in-app auto-updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Full history for git rev-list --count
 
       - name: Select Xcode
         run: sudo xcode-select -s /Applications/Xcode_16.3.app/Contents/Developer
@@ -32,11 +34,29 @@ jobs:
         id: version
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
+          BUILD_NUMBER=$(git rev-list --count HEAD)
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "Building version: $VERSION"
+          echo "build_number=$BUILD_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "Building version: $VERSION (build $BUILD_NUMBER)"
+
+      - name: Download Sparkle
+        id: sparkle
+        run: |
+          SPARKLE_VERSION="2.7.5"
+          curl -L -o /tmp/Sparkle.tar.xz "https://github.com/sparkle-project/Sparkle/releases/download/${SPARKLE_VERSION}/Sparkle-${SPARKLE_VERSION}.tar.xz"
+          mkdir -p /tmp/sparkle
+          tar -xf /tmp/Sparkle.tar.xz -C /tmp/sparkle
+          echo "bin=/tmp/sparkle/bin" >> "$GITHUB_OUTPUT"
 
       - name: Build universal app bundle
-        run: ./scripts/package.sh --release --universal --version "${{ steps.version.outputs.version }}"
+        run: |
+          ./scripts/package.sh \
+            --release \
+            --universal \
+            --version "${{ steps.version.outputs.version }}" \
+            --build-number "${{ steps.version.outputs.build_number }}" \
+            --sparkle-feed-url "${{ vars.SPARKLE_FEED_URL }}" \
+            --sparkle-public-key "${{ vars.SPARKLE_PUBLIC_KEY }}"
 
       - name: Create DMG
         run: ./scripts/create-dmg.sh
@@ -48,6 +68,42 @@ jobs:
           ditto -c -k --keepParent Runway.app "$ZIP_NAME"
           echo "Created $ZIP_NAME"
 
+      - name: Sign update with Sparkle EdDSA
+        if: ${{ secrets.SPARKLE_PRIVATE_KEY != '' }}
+        id: sparkle_sign
+        env:
+          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          ARCHIVE="build/Runway-${VERSION}-universal.app.zip"
+
+          # sign_update reads SPARKLE_PRIVATE_KEY from the environment
+          SIGN_OUTPUT=$("${{ steps.sparkle.outputs.bin }}/sign_update" "$ARCHIVE")
+          echo "signature=$SIGN_OUTPUT" >> "$GITHUB_OUTPUT"
+          echo "Signed: $SIGN_OUTPUT"
+
+      - name: Generate appcast
+        if: ${{ secrets.SPARKLE_PRIVATE_KEY != '' }}
+        env:
+          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          REPO="${{ github.repository }}"
+          TAG="${{ github.ref_name }}"
+
+          # generate_appcast needs archives in a directory
+          mkdir -p /tmp/appcast-archives
+          cp "build/Runway-${VERSION}-universal.app.zip" /tmp/appcast-archives/
+
+          "${{ steps.sparkle.outputs.bin }}/generate_appcast" \
+            --download-url-prefix "https://github.com/${REPO}/releases/download/${TAG}/" \
+            --link "https://github.com/${REPO}/releases" \
+            /tmp/appcast-archives/
+
+          cp /tmp/appcast-archives/appcast.xml build/appcast.xml
+          echo "Generated appcast.xml"
+          cat build/appcast.xml
+
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -58,9 +114,46 @@ jobs:
           if [ -n "$PREV_TAG" ]; then
             NOTES_FLAG="--notes-start-tag $PREV_TAG"
           fi
+
+          ASSETS=(
+            "build/Runway-${VERSION}-universal.dmg#Runway-${VERSION}-universal.dmg (installer)"
+            "build/Runway-${VERSION}-universal.app.zip#Runway-${VERSION}-universal.app.zip (app bundle)"
+          )
+
+          # Include appcast.xml as a release asset if it was generated
+          if [ -f "build/appcast.xml" ]; then
+            ASSETS+=("build/appcast.xml#appcast.xml (Sparkle feed)")
+          fi
+
           gh release create "$GITHUB_REF_NAME" \
             --title "Runway v${VERSION}" \
             --generate-notes \
             $NOTES_FLAG \
-            "build/Runway-${VERSION}-universal.dmg#Runway-${VERSION}-universal.dmg (installer)" \
-            "build/Runway-${VERSION}-universal.app.zip#Runway-${VERSION}-universal.app.zip (app bundle)"
+            "${ASSETS[@]}"
+
+      - name: Publish appcast to GitHub Pages
+        if: ${{ secrets.SPARKLE_PRIVATE_KEY != '' && hashFiles('build/appcast.xml') != '' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Create/update appcast.xml on gh-pages branch
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Fetch gh-pages if it exists, or create it
+          if git ls-remote --exit-code origin gh-pages >/dev/null 2>&1; then
+            git fetch origin gh-pages
+            git worktree add /tmp/gh-pages gh-pages
+          else
+            git worktree add --detach /tmp/gh-pages
+            cd /tmp/gh-pages
+            git checkout --orphan gh-pages
+            git rm -rf . 2>/dev/null || true
+            cd -
+          fi
+
+          cp build/appcast.xml /tmp/gh-pages/appcast.xml
+          cd /tmp/gh-pages
+          git add appcast.xml
+          git commit -m "Update appcast for ${{ github.ref_name }}" || echo "No changes to commit"
+          git push origin gh-pages

--- a/Package.swift
+++ b/Package.swift
@@ -12,6 +12,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/groue/GRDB.swift.git", from: "7.4.0"),
         .package(url: "https://github.com/migueldeicaza/SwiftTerm.git", from: "1.2.0"),
+        .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.0.0"),
     ],
     targets: [
         // MARK: - App Entry Point
@@ -27,6 +28,7 @@ let package = Package(
                 "StatusDetection",
                 "Theme",
                 "Views",
+                .product(name: "Sparkle", package: "Sparkle"),
             ],
             path: "Sources/App"
         ),
@@ -107,6 +109,7 @@ let package = Package(
                 "GitHubOperations",
                 "StatusDetection",
                 "Theme",
+                .product(name: "Sparkle", package: "Sparkle"),
             ],
             path: "Sources/Views"
         ),

--- a/Sources/App/MenuBarView.swift
+++ b/Sources/App/MenuBarView.swift
@@ -1,9 +1,11 @@
 import Models
+import Sparkle
 import SwiftUI
 
 /// Mini status view shown in the macOS menu bar extra.
 struct MenuBarView: View {
     @Environment(RunwayStore.self) private var store
+    var updater: SPUUpdater?
 
     private var activeSessions: [Session] {
         store.sessions.filter { $0.status == .running || $0.status == .waiting }
@@ -58,6 +60,12 @@ struct MenuBarView: View {
             }
             .padding(.horizontal, 12)
             .padding(.bottom, 4)
+
+            if let updater {
+                CheckForUpdatesView(updater: updater)
+                    .padding(.horizontal, 12)
+                    .padding(.bottom, 4)
+            }
 
             Button("Open Runway") {
                 NSApplication.shared.activate(ignoringOtherApps: true)

--- a/Sources/App/RunwayApp.swift
+++ b/Sources/App/RunwayApp.swift
@@ -1,6 +1,7 @@
 import GitHubOperations
 import Models
 import Persistence
+import Sparkle
 import StatusDetection
 import SwiftUI
 import Terminal
@@ -10,6 +11,7 @@ import Views
 @main
 struct RunwayApp: App {
     @State private var store: RunwayStore
+    private let updaterController: AppUpdaterController
 
     init() {
         // .app bundles from Finder/Dock inherit a minimal PATH from launchd.
@@ -19,6 +21,7 @@ struct RunwayApp: App {
         ShellRunner.enrichPath()
 
         _store = State(initialValue: RunwayStore())
+        updaterController = AppUpdaterController()
 
         // SPM executables don't get a proper .app bundle, so macOS doesn't
         // activate them as GUI apps. Force regular activation policy so
@@ -40,6 +43,9 @@ struct RunwayApp: App {
         .windowToolbarStyle(.unified)
         .defaultSize(width: 1200, height: 800)
         .commands {
+            CommandGroup(after: .appInfo) {
+                CheckForUpdatesView(updater: updaterController.updater)
+            }
             CommandGroup(after: .sidebar) {
                 Button("Sessions") { store.currentView = .sessions }
                     .keyboardShortcut("1", modifiers: .command)
@@ -71,12 +77,12 @@ struct RunwayApp: App {
         }
 
         Settings {
-            SettingsView()
+            SettingsView(updater: updaterController.updater)
                 .environment(store.themeManager)
         }
 
         MenuBarExtra {
-            MenuBarView()
+            MenuBarView(updater: updaterController.updater)
                 .environment(store)
         } label: {
             menuBarLabel

--- a/Sources/App/UpdaterController.swift
+++ b/Sources/App/UpdaterController.swift
@@ -1,0 +1,77 @@
+import Combine
+import Sparkle
+import SwiftUI
+
+/// Wraps Sparkle's SPUStandardUpdaterController for SwiftUI consumption.
+///
+/// Instantiate once in `RunwayApp` and pass the `.updater` to views that
+/// need check-for-updates or auto-update-toggle functionality.
+@MainActor
+final class AppUpdaterController {
+    let controller: SPUStandardUpdaterController
+
+    var updater: SPUUpdater { controller.updater }
+
+    init() {
+        // startingUpdater: true → begins automatic background checks on launch
+        controller = SPUStandardUpdaterController(
+            startingUpdater: true,
+            updaterDelegate: nil,
+            userDriverDelegate: nil
+        )
+    }
+}
+
+// MARK: - CheckForUpdatesViewModel
+
+/// Bridges Sparkle's KVO `canCheckForUpdates` into a SwiftUI-observable property.
+@MainActor
+final class CheckForUpdatesViewModel: ObservableObject {
+    @Published var canCheckForUpdates = false
+
+    private var cancellable: AnyCancellable?
+
+    init(updater: SPUUpdater) {
+        cancellable = updater.publisher(for: \.canCheckForUpdates)
+            .receive(on: RunLoop.main)
+            .assign(to: \.canCheckForUpdates, on: self)
+    }
+}
+
+// MARK: - CheckForUpdatesView
+
+/// A button that triggers a manual update check. Suitable for menus and settings.
+struct CheckForUpdatesView: View {
+    @ObservedObject private var viewModel: CheckForUpdatesViewModel
+    private let updater: SPUUpdater
+
+    init(updater: SPUUpdater) {
+        self.updater = updater
+        self.viewModel = CheckForUpdatesViewModel(updater: updater)
+    }
+
+    var body: some View {
+        Button("Check for Updates\u{2026}", action: updater.checkForUpdates)
+            .disabled(!viewModel.canCheckForUpdates)
+    }
+}
+
+// MARK: - AutoUpdateToggleView
+
+/// A toggle that controls Sparkle's automatic update checking preference.
+struct AutoUpdateToggleView: View {
+    private let updater: SPUUpdater
+    @State private var automaticallyChecks: Bool
+
+    init(updater: SPUUpdater) {
+        self.updater = updater
+        self._automaticallyChecks = State(initialValue: updater.automaticallyChecksForUpdates)
+    }
+
+    var body: some View {
+        Toggle("Automatically check for updates", isOn: $automaticallyChecks)
+            .onChange(of: automaticallyChecks) { _, newValue in
+                updater.automaticallyChecksForUpdates = newValue
+            }
+    }
+}

--- a/Sources/Views/Settings/SettingsPlaceholder.swift
+++ b/Sources/Views/Settings/SettingsPlaceholder.swift
@@ -1,4 +1,5 @@
 import Models
+import Sparkle
 import SwiftUI
 import Theme
 
@@ -9,7 +10,11 @@ public struct SettingsView: View {
     @AppStorage("terminalFontSize") private var fontSize: Double = 13
     @AppStorage("defaultPermissionMode") private var defaultPermissionMode: PermissionMode = .default
 
-    public init() {}
+    private let updater: SPUUpdater?
+
+    public init(updater: SPUUpdater? = nil) {
+        self.updater = updater
+    }
 
     public var body: some View {
         TabView {
@@ -210,9 +215,29 @@ public struct SettingsView: View {
                 }
             }
 
+            if let updater {
+                Section("Updates") {
+                    Toggle(
+                        "Automatically check for updates",
+                        isOn: Binding(
+                            get: { updater.automaticallyChecksForUpdates },
+                            set: { updater.automaticallyChecksForUpdates = $0 }
+                        )
+                    )
+
+                    LabeledContent("Check Now") {
+                        UpdateCheckButton(updater: updater)
+                    }
+                }
+            }
+
             Section("About") {
                 LabeledContent("Version") {
-                    Text("0.1.0")
+                    Text(Self.appVersion)
+                        .foregroundColor(.secondary)
+                }
+                LabeledContent("Build") {
+                    Text(Self.buildNumber)
                         .foregroundColor(.secondary)
                 }
                 LabeledContent("Config Directory") {
@@ -223,5 +248,33 @@ public struct SettingsView: View {
         }
         .formStyle(.grouped)
         .padding()
+    }
+
+    // MARK: - Version Helpers
+
+    private static var appVersion: String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "dev"
+    }
+
+    private static var buildNumber: String {
+        Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "—"
+    }
+}
+
+// MARK: - UpdateCheckButton
+
+/// A settings-appropriate "Check for Updates" button that respects Sparkle's ready state.
+private struct UpdateCheckButton: View {
+    let updater: SPUUpdater
+    @State private var canCheck = false
+
+    var body: some View {
+        Button("Check for Updates\u{2026}") {
+            updater.checkForUpdates()
+        }
+        .disabled(!canCheck)
+        .onReceive(updater.publisher(for: \.canCheckForUpdates)) { value in
+            canCheck = value
+        }
     }
 }

--- a/scripts/Info.plist
+++ b/scripts/Info.plist
@@ -9,7 +9,7 @@
     <key>CFBundleIdentifier</key>
     <string>com.runway.app</string>
     <key>CFBundleVersion</key>
-    <string>__VERSION__</string>
+    <string>__BUILD_NUMBER__</string>
     <key>CFBundleShortVersionString</key>
     <string>__VERSION__</string>
     <key>CFBundlePackageType</key>
@@ -32,5 +32,14 @@
     <string>NSApplication</string>
     <key>NSHumanReadableCopyright</key>
     <string>Copyright © 2025 Matthew Nicholson. All rights reserved.</string>
+    <!-- Sparkle auto-update configuration -->
+    <key>SUFeedURL</key>
+    <string>__SPARKLE_FEED_URL__</string>
+    <key>SUPublicEDKey</key>
+    <string>__SPARKLE_PUBLIC_KEY__</string>
+    <key>SUScheduledCheckInterval</key>
+    <integer>86400</integer>
+    <key>SUAllowsAutomaticUpdates</key>
+    <true/>
 </dict>
 </plist>

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
 # Package Runway as a macOS .app bundle
 #
-# Usage: ./scripts/package.sh [--release] [--universal] [--version <ver>]
+# Usage: ./scripts/package.sh [--release] [--universal] [--version <ver>] [--build-number <n>]
 #
 # Flags:
-#   --release     Build with optimizations (-c release)
-#   --universal   Build arm64 + x86_64 and merge with lipo
-#   --version X   Stamp version X into Info.plist (default: 0.0.0-dev)
+#   --release              Build with optimizations (-c release)
+#   --universal            Build arm64 + x86_64 and merge with lipo
+#   --version X            Stamp version X into Info.plist (default: 0.0.0-dev)
+#   --build-number N       Numeric build number for CFBundleVersion (default: git commit count)
+#   --sparkle-feed-url U   Sparkle appcast feed URL
+#   --sparkle-public-key K Sparkle EdDSA public key (base64)
 #
 # Creates: build/Runway.app
 
@@ -26,6 +29,9 @@ BUILD_CONFIG="debug"
 SWIFT_CONFIG_FLAGS=()
 UNIVERSAL=false
 VERSION="0.0.0-dev"
+BUILD_NUMBER=""
+SPARKLE_FEED_URL=""
+SPARKLE_PUBLIC_KEY=""
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -42,6 +48,18 @@ while [[ $# -gt 0 ]]; do
             VERSION="$2"
             shift 2
             ;;
+        --build-number)
+            BUILD_NUMBER="$2"
+            shift 2
+            ;;
+        --sparkle-feed-url)
+            SPARKLE_FEED_URL="$2"
+            shift 2
+            ;;
+        --sparkle-public-key)
+            SPARKLE_PUBLIC_KEY="$2"
+            shift 2
+            ;;
         *)
             echo "Unknown flag: $1" >&2
             exit 1
@@ -49,7 +67,12 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-echo "==> Building Runway ($BUILD_CONFIG, universal=$UNIVERSAL, version=$VERSION)..."
+# Default build number: git commit count (monotonically increasing)
+if [[ -z "$BUILD_NUMBER" ]]; then
+    BUILD_NUMBER=$(git rev-list --count HEAD 2>/dev/null || echo "1")
+fi
+
+echo "==> Building Runway ($BUILD_CONFIG, universal=$UNIVERSAL, version=$VERSION, build=$BUILD_NUMBER)..."
 cd "$PROJECT_DIR"
 
 if $UNIVERSAL; then
@@ -91,8 +114,12 @@ mkdir -p "$MACOS" "$RESOURCES"
 # Copy executable
 cp "$EXECUTABLE" "$MACOS/$APP_NAME"
 
-# Stamp version into Info.plist
-sed -e "s/__VERSION__/$VERSION/g" "$SCRIPT_DIR/Info.plist" > "$CONTENTS/Info.plist"
+# Stamp version, build number, and Sparkle config into Info.plist
+sed -e "s/__VERSION__/$VERSION/g" \
+    -e "s/__BUILD_NUMBER__/$BUILD_NUMBER/g" \
+    -e "s|__SPARKLE_FEED_URL__|$SPARKLE_FEED_URL|g" \
+    -e "s|__SPARKLE_PUBLIC_KEY__|$SPARKLE_PUBLIC_KEY|g" \
+    "$SCRIPT_DIR/Info.plist" > "$CONTENTS/Info.plist"
 
 # Copy icon and app image resources
 cp "$PROJECT_DIR/images/Runway.icns" "$RESOURCES/Runway.icns"


### PR DESCRIPTION
## Summary

- Integrate [Sparkle 2](https://sparkle-project.org/) for native macOS in-app auto-updates
- Add "Check for Updates…" to the app menu bar and menu bar extra
- Add auto-update toggle and version/build display in Settings → General
- Update release workflow to sign updates with EdDSA, generate `appcast.xml`, and publish to GitHub Pages

## How it works

On launch, Sparkle checks `appcast.xml` (served via GitHub Pages) once per day. When a new version is found, users see a native update sheet with release notes and Install/Skip/Remind options. Updates are verified via EdDSA signatures before installation.

## Changes

| Area | What |
|------|------|
| `Package.swift` | Sparkle 2 SPM dependency on App + Views |
| `UpdaterController.swift` | New — SwiftUI wrapper bridging Sparkle's KVO to @Published |
| `RunwayApp.swift` | Wire updater into app menu and settings |
| `MenuBarView.swift` | Optional "Check for Updates…" in menu bar extra |
| `SettingsPlaceholder.swift` | Dynamic version from Bundle, build number, update toggle |
| `Info.plist` | Split CFBundleVersion (build#) from short version, add SUFeedURL/SUPublicEDKey |
| `package.sh` | New flags: --build-number, --sparkle-feed-url, --sparkle-public-key |
| `release.yml` | Download Sparkle tools, EdDSA sign, generate appcast, publish to gh-pages |

## Repo configuration required

- [x] Secret: `SPARKLE_PRIVATE_KEY` (base64 EdDSA private key)
- [x] Variable: `SPARKLE_FEED_URL` (GitHub Pages appcast URL)
- [x] Variable: `SPARKLE_PUBLIC_KEY` (base64 EdDSA public key)
- [x] GitHub Pages enabled on `gh-pages` branch

## Test plan

- [ ] `swift build` succeeds
- [ ] `swift test` — all 134 tests pass
- [ ] Tag `v*` release and verify workflow completes: DMG + zip + appcast generated
- [ ] Verify `appcast.xml` is accessible at GitHub Pages URL
- [ ] Install built app, confirm "Check for Updates…" appears in Runway menu
- [ ] Confirm Settings → General shows version, build number, and auto-update toggle