### PR TITLE
fix: repair terminal scrollback with SwiftTerm update and mouse event race fix

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/groue/GRDB.swift.git", from: "7.4.0"),
-        .package(url: "https://github.com/migueldeicaza/SwiftTerm.git", from: "1.2.0"),
+        .package(url: "https://github.com/migueldeicaza/SwiftTerm.git", revision: "b6ce28a"),
         .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.0.0"),
     ],
     targets: [

--- a/Sources/TerminalView/TerminalPane.swift
+++ b/Sources/TerminalView/TerminalPane.swift
@@ -195,27 +195,60 @@ private func shellEscape(_ path: String) -> String {
 
 /// Intercepts mouse events via a local event monitor and temporarily disables
 /// SwiftTerm's mouse reporting so native text selection always works.
-/// Scroll wheel events are unaffected so tmux scrollback still functions.
+///
+/// Scroll wheel events are also monitored to ensure `allowMouseReporting` is
+/// restored before any scroll — this prevents a timing race where an async
+/// restore hasn't fired yet and the scroll falls to the wrong code path,
+/// knocking tmux out of copy-mode.
 @MainActor
 class MouseSelectionMonitor {
     static let shared = MouseSelectionMonitor()
     private var monitor: Any?
+    private var savedReporting = true
+    private var suppressed = false
 
     func start() {
         guard monitor == nil else { return }
         monitor = NSEvent.addLocalMonitorForEvents(
-            matching: [.leftMouseDown, .leftMouseDragged, .leftMouseUp]
-        ) { event in
-            if let terminal = NSApplication.shared.keyWindow?.firstResponder
-                as? LocalProcessTerminalView
-            {
-                let saved = terminal.allowMouseReporting
-                terminal.allowMouseReporting = false
-                // Restore after the event is dispatched (next run loop iteration)
-                DispatchQueue.main.async {
-                    terminal.allowMouseReporting = saved
+            matching: [.leftMouseDown, .leftMouseDragged, .leftMouseUp, .scrollWheel]
+        ) { [self] event in
+            guard
+                let terminal = NSApplication.shared.keyWindow?.firstResponder
+                    as? LocalProcessTerminalView
+            else { return event }
+
+            // Scroll events: if we're mid-selection with reporting suppressed,
+            // restore it immediately so SwiftTerm forwards the scroll to tmux.
+            if event.type == .scrollWheel {
+                if suppressed {
+                    terminal.allowMouseReporting = savedReporting
+                    suppressed = false
                 }
+                return event
             }
+
+            // Mouse-up: end the suppression window.
+            if event.type == .leftMouseUp {
+                if suppressed {
+                    // Restore after the event is dispatched so SwiftTerm's
+                    // mouseUp handler still sees reporting disabled (avoids
+                    // sending a spurious click to tmux).
+                    DispatchQueue.main.async { [self] in
+                        if suppressed {
+                            terminal.allowMouseReporting = savedReporting
+                            suppressed = false
+                        }
+                    }
+                }
+                return event
+            }
+
+            // Mouse-down / drag: suppress reporting for native text selection.
+            if !suppressed {
+                savedReporting = terminal.allowMouseReporting
+                suppressed = true
+            }
+            terminal.allowMouseReporting = false
             return event
         }
     }
@@ -223,6 +256,7 @@ class MouseSelectionMonitor {
     func stop() {
         if let m = monitor { NSEvent.removeMonitor(m) }
         monitor = nil
+        suppressed = false
     }
 }
 
@@ -284,6 +318,19 @@ class TerminalContainerView: NSView {
             terminal.leadingAnchor.constraint(equalTo: leadingAnchor),
             terminal.trailingAnchor.constraint(equalTo: trailingAnchor),
         ])
+        // Hide SwiftTerm's built-in NSScroller — tmux owns scrollback,
+        // so the scroller is misleading and causes users to get stuck
+        // in SwiftTerm's (empty) alternate-screen buffer scroll.
+        hideSwiftTermScroller(in: terminal)
+    }
+
+    private func hideSwiftTermScroller(in view: NSView) {
+        for subview in view.subviews {
+            if let scroller = subview as? NSScroller {
+                scroller.isHidden = true
+                return
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- **Update SwiftTerm** to commit `b6ce28a` (post-v1.13.0) which includes the `scrollWheel` three-way fix from PR #506/#518 — mouse wheel events are now forwarded to tmux as SGR button 4/5 sequences when mouse mode is active, sent as arrow keys on alternate screen, or scroll SwiftTerm's own buffer on normal screen
- **Fix race condition in MouseSelectionMonitor** where `DispatchQueue.main.async` restoration of `allowMouseReporting` fired too late — scroll events arriving before the restore fell to the arrow-key path and knocked tmux out of copy-mode. Now tracks suppression state explicitly and restores synchronously when a scroll event arrives mid-selection
- **Hide SwiftTerm's NSScroller** since tmux owns scrollback — the scroller was misleading and caused users to get stuck in SwiftTerm's empty alternate-screen buffer

## Test plan
- [x] Mouse wheel/trackpad scroll up enters tmux copy-mode and scrolls history
- [x] Scroll down returns to bottom and exits copy-mode
- [x] Drag-select text works for native text selection
- [x] Select text while in copy-mode, then scroll — continues scrolling (no broken state)
- [x] Esc/q exits copy-mode cleanly, no stuck scroll state
- [x] No scrollbar visible at any point
- [x] Verify SwiftTerm pin to `b6ce28a` — switch to `from: "1.14.0"` when that tag is released