### PR TITLE
Add detailed CI checks tab to PR detail drawer

### DIFF
--- a/Sources/GitHubOperations/PRManager.swift
+++ b/Sources/GitHubOperations/PRManager.swift
@@ -542,7 +542,9 @@ private struct GHPRDetailResponse: Decodable {
     let changedFiles: Int?
 
     func toPRDetail() -> PRDetail {
-        let checks = parseChecks(statusCheckRollup ?? [])
+        let rollup = statusCheckRollup ?? []
+        let checks = parseChecks(rollup)
+        let runs = parseCheckRuns(rollup)
 
         let review: ReviewDecision
         switch reviewDecision?.uppercased() {
@@ -568,6 +570,7 @@ private struct GHPRDetailResponse: Decodable {
             comments: mappedComments,
             files: mappedFiles,
             checks: checks,
+            checkRuns: runs,
             reviewDecision: review,
             headBranch: headRefName ?? "",
             baseBranch: baseRefName ?? "",
@@ -580,10 +583,19 @@ private struct GHPRDetailResponse: Decodable {
 }
 
 private struct GHCheck: Decodable {
-    let name: String?
+    let name: String?  // CheckRun display name
+    let context: String?  // StatusContext display name
     let status: String?
     let conclusion: String?
     let state: String?  // For StatusContext type checks
+    let detailsUrl: String?  // CheckRun detail link
+    let targetUrl: String?  // StatusContext detail link
+
+    /// Display name — CheckRun uses `name`, StatusContext uses `context`.
+    var displayName: String? { name ?? context }
+
+    /// URL to the check's detail page (works for both CheckRun and StatusContext).
+    var url: String? { detailsUrl ?? targetUrl }
 }
 
 private struct GHReview: Decodable {
@@ -669,32 +681,59 @@ private struct GHFile: Decodable {
 
 // MARK: - Shared Helpers
 
+private func classifyCheck(_ check: GHCheck) -> CheckStatus {
+    let status = check.status?.uppercased() ?? ""
+    let conclusion = check.conclusion?.uppercased() ?? ""
+    let checkState = check.state?.uppercased() ?? ""
+
+    if status == "COMPLETED" {
+        if conclusion == "SUCCESS" || conclusion == "NEUTRAL" || conclusion == "SKIPPED" {
+            return .passed
+        } else if conclusion == "FAILURE" || conclusion == "TIMED_OUT" || conclusion == "CANCELLED" {
+            return .failed
+        } else {
+            return .pending
+        }
+    } else if checkState == "SUCCESS" {
+        return .passed
+    } else if checkState == "FAILURE" || checkState == "ERROR" {
+        return .failed
+    } else {
+        return .pending
+    }
+}
+
 private func parseChecks(_ checks: [GHCheck]) -> CheckSummary {
     var passed = 0
     var failed = 0
     var pending = 0
     for check in checks {
-        let status = check.status?.uppercased() ?? ""
-        let conclusion = check.conclusion?.uppercased() ?? ""
-        let checkState = check.state?.uppercased() ?? ""
-
-        if status == "COMPLETED" {
-            if conclusion == "SUCCESS" || conclusion == "NEUTRAL" || conclusion == "SKIPPED" {
-                passed += 1
-            } else if conclusion == "FAILURE" || conclusion == "TIMED_OUT" || conclusion == "CANCELLED" {
-                failed += 1
-            } else {
-                pending += 1
-            }
-        } else if checkState == "SUCCESS" {
-            passed += 1
-        } else if checkState == "FAILURE" || checkState == "ERROR" {
-            failed += 1
-        } else {
-            pending += 1
+        switch classifyCheck(check) {
+        case .passed: passed += 1
+        case .failed: failed += 1
+        case .pending: pending += 1
         }
     }
     return CheckSummary(passed: passed, failed: failed, pending: pending)
+}
+
+private func parseCheckRuns(_ checks: [GHCheck]) -> [CheckRun] {
+    checks.compactMap { check in
+        guard let name = check.displayName, !name.isEmpty else { return nil }
+        return CheckRun(
+            name: name,
+            status: classifyCheck(check),
+            detailsURL: check.url
+        )
+    }
+    .sorted { lhs, rhs in
+        // Failed first, then pending, then passed
+        let order: [CheckStatus] = [.failed, .pending, .passed]
+        let li = order.firstIndex(of: lhs.status) ?? 2
+        let ri = order.firstIndex(of: rhs.status) ?? 2
+        if li != ri { return li < ri }
+        return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+    }
 }
 
 /// REST API response for /repos/:owner/:repo/pulls/:number/files

--- a/Sources/Models/PullRequest.swift
+++ b/Sources/Models/PullRequest.swift
@@ -136,6 +136,36 @@ public struct CheckSummary: Codable, Sendable {
     public var hasFailed: Bool { failed > 0 }
 }
 
+// MARK: - Check Run (individual check detail)
+
+public struct CheckRun: Identifiable, Codable, Sendable {
+    public let id: String
+    public var name: String
+    public var status: CheckStatus
+    public var detailsURL: String?
+
+    public init(name: String, status: CheckStatus, detailsURL: String? = nil) {
+        self.id = name
+        self.name = name
+        self.status = status
+        self.detailsURL = detailsURL
+    }
+}
+
+public enum CheckStatus: String, Codable, Sendable {
+    case passed
+    case failed
+    case pending
+
+    public var label: String {
+        switch self {
+        case .passed: "Passed"
+        case .failed: "Failed"
+        case .pending: "Pending"
+        }
+    }
+}
+
 // MARK: - PR Detail (lazy-loaded)
 
 public struct PRDetail: Codable, Sendable {
@@ -144,6 +174,7 @@ public struct PRDetail: Codable, Sendable {
     public var comments: [PRComment]
     public var files: [PRFileChange]
     public var checks: CheckSummary
+    public var checkRuns: [CheckRun]
     public var reviewDecision: ReviewDecision
     public var headBranch: String
     public var baseBranch: String
@@ -157,6 +188,7 @@ public struct PRDetail: Codable, Sendable {
         comments: [PRComment] = [],
         files: [PRFileChange] = [],
         checks: CheckSummary = CheckSummary(),
+        checkRuns: [CheckRun] = [],
         reviewDecision: ReviewDecision = .none,
         headBranch: String = "",
         baseBranch: String = "",
@@ -169,6 +201,7 @@ public struct PRDetail: Codable, Sendable {
         self.comments = comments
         self.files = files
         self.checks = checks
+        self.checkRuns = checkRuns
         self.reviewDecision = reviewDecision
         self.headBranch = headBranch
         self.baseBranch = baseBranch

--- a/Sources/Views/PRDashboard/PRDetailDrawer.swift
+++ b/Sources/Views/PRDashboard/PRDetailDrawer.swift
@@ -312,6 +312,9 @@ public struct PRDetailDrawer: View {
         switch tab {
         case .overview:
             return "Overview"
+        case .checks:
+            let checks = detail?.checks ?? pr.checks
+            return checks.total > 0 ? "Checks (\(checks.total))" : "Checks"
         case .diff:
             let count = detail?.files.count ?? pr.changedFiles
             return count > 0 ? "Diff (\(count))" : "Diff"
@@ -328,6 +331,8 @@ public struct PRDetailDrawer: View {
         switch selectedTab {
         case .overview:
             overviewTab
+        case .checks:
+            checksTab
         case .diff:
             diffTab
         case .conversation:
@@ -351,6 +356,101 @@ public struct PRDetailDrawer: View {
             }
             .padding(12)
             .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private var checksTab: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 2) {
+                if let runs = detail?.checkRuns, !runs.isEmpty {
+                    // Summary bar at top
+                    let checks = detail?.checks ?? pr.checks
+                    detailChecksBar(checks)
+                        .padding(.bottom, 8)
+
+                    ForEach(runs) { run in
+                        checkRunRow(run)
+                    }
+                } else {
+                    let checks = detail?.checks ?? pr.checks
+                    if checks.total > 0 {
+                        // Have summary counts but no individual runs yet
+                        detailChecksBar(checks)
+                            .padding(.bottom, 8)
+                        Text("Loading check details…")
+                            .foregroundStyle(.secondary)
+                            .italic()
+                    } else {
+                        EmptyStateView(
+                            title: "No Checks",
+                            subtitle: "No CI checks are configured for this PR",
+                            systemImage: "checkmark.shield"
+                        )
+                    }
+                }
+            }
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private func checkRunRow(_ run: CheckRun) -> some View {
+        HStack(spacing: 8) {
+            checkStatusIcon(run.status)
+                .frame(width: 16)
+
+            Text(run.name)
+                .font(.callout)
+                .lineLimit(1)
+                .truncationMode(.middle)
+
+            Spacer()
+
+            Text(run.status.label)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            if let urlString = run.detailsURL, let url = URL(string: urlString) {
+                Button {
+                    NSWorkspace.shared.open(url)
+                } label: {
+                    Image(systemName: "arrow.up.right.square")
+                        .font(.caption)
+                        .foregroundColor(theme.chrome.accent)
+                }
+                .buttonStyle(.plain)
+                .help("Open check details")
+            }
+        }
+        .padding(.vertical, 6)
+        .padding(.horizontal, 8)
+        .background(checkRunBackground(run.status))
+        .cornerRadius(6)
+    }
+
+    @ViewBuilder
+    private func checkStatusIcon(_ status: CheckStatus) -> some View {
+        switch status {
+        case .passed:
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundColor(theme.chrome.green)
+        case .failed:
+            Image(systemName: "xmark.circle.fill")
+                .foregroundColor(theme.chrome.red)
+        case .pending:
+            Image(systemName: "clock.fill")
+                .foregroundColor(theme.chrome.yellow)
+        }
+    }
+
+    private func checkRunBackground(_ status: CheckStatus) -> some View {
+        switch status {
+        case .failed:
+            return theme.chrome.red.opacity(0.08)
+        case .pending:
+            return theme.chrome.yellow.opacity(0.05)
+        case .passed:
+            return theme.chrome.surface.opacity(1.0)
         }
     }
 
@@ -608,6 +708,7 @@ public struct PRDetailDrawer: View {
 
 enum PRDetailTab: String, CaseIterable {
     case overview
+    case checks
     case diff
     case conversation
 }


### PR DESCRIPTION
## Summary

- Adds a **Checks** tab to the PR detail drawer showing individual CI check runs with name, status icon, and link to the check's detail page
- Handles both GitHub Actions (`CheckRun` with `name`/`detailsUrl`) and external CI systems (`StatusContext` with `context`/`targetUrl`)
- Failed checks sort to the top with a subtle red background tint for quick scanning
- Extracts shared `classifyCheck()` helper to deduplicate status classification logic between summary counts and individual check parsing

## Test plan

- [x] `swift build` passes
- [x] `swift test` — all 134 tests pass
- [ ] Open a PR with mixed check statuses (passed/failed/pending) and verify all appear individually in the Checks tab
- [ ] Verify external CI checks (StatusContext) show names correctly
- [ ] Verify "Open check details" link opens the correct URL in browser
- [ ] Verify failed checks appear first with red tint background