### PR TITLE
feat: resizable PR/issue detail panels

### DIFF
--- a/Sources/Views/PRDashboard/PRDashboardView.swift
+++ b/Sources/Views/PRDashboard/PRDashboardView.swift
@@ -276,7 +276,7 @@ public struct PRDashboardView: View {
 
             // Right: PR detail drawer
             if let pr = selectedPR {
-                Divider()
+                ResizableDivider(width: $prListWidth)
                 PRDetailDrawer(
                     pr: pr,
                     detail: detail,

--- a/Sources/Views/ProjectPage/ProjectIssuesTab.swift
+++ b/Sources/Views/ProjectPage/ProjectIssuesTab.swift
@@ -31,6 +31,7 @@ public struct ProjectIssuesTab: View {
     var onUpdateLabels: ((GitHubIssue, [String], [String]) -> Void)?
     var onUpdateAssignees: ((GitHubIssue, [String], [String]) -> Void)?
 
+    @AppStorage("issueListWidth") private var issueListWidth: Double = 320
     @Environment(\.theme) private var theme
     @State private var filter: IssueFilter = .open
     @State private var showNewIssue: Bool = false
@@ -132,8 +133,8 @@ public struct ProjectIssuesTab: View {
             } else if let issue = selectedIssue {
                 HStack(spacing: 0) {
                     issuesList
-                        .frame(maxWidth: 320)
-                    Divider()
+                        .frame(maxWidth: CGFloat(issueListWidth))
+                    ResizableDivider(width: $issueListWidth)
                     IssueDetailDrawer(
                         issue: issue,
                         detail: issueDetail,

--- a/Sources/Views/ProjectPage/ProjectPRsTab.swift
+++ b/Sources/Views/ProjectPage/ProjectPRsTab.swift
@@ -21,6 +21,7 @@ public struct ProjectPRsTab: View {
     var onDisableAutoMerge: ((PullRequest) -> Void)?
 
     @AppStorage("hideDrafts") private var hideDrafts: Bool = false
+    @AppStorage("projectPRListWidth") private var projectPRListWidth: Double = 320
     @Environment(\.theme) private var theme
 
     public init(
@@ -106,8 +107,8 @@ public struct ProjectPRsTab: View {
             } else if let pr = selectedPR {
                 HStack(spacing: 0) {
                     prList
-                        .frame(maxWidth: 320)
-                    Divider()
+                        .frame(maxWidth: CGFloat(projectPRListWidth))
+                    ResizableDivider(width: $projectPRListWidth)
                     PRDetailDrawer(
                         pr: pr,
                         detail: detail,

--- a/Sources/Views/Shared/ResizableDivider.swift
+++ b/Sources/Views/Shared/ResizableDivider.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+import Theme
+
+/// A vertical divider that can be dragged to resize adjacent panels.
+struct ResizableDivider: View {
+    @Binding var width: Double
+    var minWidth: Double = 200
+    var maxWidth: Double = 600
+
+    @State private var isDragging = false
+    @State private var dragStart: Double = 0
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        Rectangle()
+            .fill(isDragging ? Color.accentColor.opacity(0.5) : theme.chrome.border)
+            .frame(width: isDragging ? 3 : 1)
+            .contentShape(Rectangle().inset(by: -3))
+            .onHover { hovering in
+                if hovering {
+                    NSCursor.resizeLeftRight.push()
+                } else {
+                    NSCursor.pop()
+                }
+            }
+            .gesture(
+                DragGesture(minimumDistance: 1)
+                    .onChanged { value in
+                        if !isDragging {
+                            isDragging = true
+                            dragStart = width
+                        }
+                        let new = dragStart + value.translation.width
+                        width = min(max(new, minWidth), maxWidth)
+                    }
+                    .onEnded { _ in
+                        isDragging = false
+                    }
+            )
+            .animation(.easeOut(duration: 0.15), value: isDragging)
+    }
+}


### PR DESCRIPTION
## Summary
- Add a draggable `ResizableDivider` component that replaces the static `Divider()` between list and detail panels
- Applied to PRDashboardView, ProjectPRsTab, and ProjectIssuesTab — all three list/detail splits are now user-resizable
- Panel widths persist across sessions via `@AppStorage` (keys: `prListWidth`, `projectPRListWidth`, `issueListWidth`)
- Divider shows hover cursor, visual highlight on drag, and clamps between 200–600pt

## Test plan
- [x] `swift build` passes
- [x] `swift test` passes (160 tests)
- [x] Pre-commit lint + format checks pass
- [ ] Manual: open PR dashboard, drag divider between list and detail — verify smooth resize and persistence on relaunch
- [ ] Manual: open project PRs tab, same drag test
- [ ] Manual: open project issues tab, same drag test