### PR TITLE
feat: add tmux pane splitting support

### DIFF
--- a/Sources/App/RunwayApp.swift
+++ b/Sources/App/RunwayApp.swift
@@ -68,6 +68,14 @@ struct RunwayApp: App {
                 Button("Find in Terminal") { store.showTerminalSearch.toggle() }
                     .keyboardShortcut("f", modifiers: .command)
 
+                Divider()
+
+                Button("Split Pane Down") { store.splitHorizontalTrigger += 1 }
+                    .keyboardShortcut("d", modifiers: [.command, .shift])
+
+                Button("Split Pane Right") { store.splitVerticalTrigger += 1 }
+                    .keyboardShortcut("d", modifiers: .command)
+
                 Button("Search Sessions") { store.focusSidebarSearch = true }
                     .keyboardShortcut("k", modifiers: .command)
 
@@ -379,6 +387,14 @@ struct ContentView: View {
                     showTerminalSearch: Binding(
                         get: { store.showTerminalSearch },
                         set: { store.showTerminalSearch = $0 }
+                    ),
+                    splitHorizontalTrigger: Binding(
+                        get: { store.splitHorizontalTrigger },
+                        set: { store.splitHorizontalTrigger = $0 }
+                    ),
+                    splitVerticalTrigger: Binding(
+                        get: { store.splitVerticalTrigger },
+                        set: { store.splitVerticalTrigger = $0 }
                     )
                 )
             } else {

--- a/Sources/App/RunwayStore.swift
+++ b/Sources/App/RunwayStore.swift
@@ -43,6 +43,10 @@ public final class RunwayStore {
     var tmuxAvailable: Bool = false
     var showSendBar: Bool = false
     var showTerminalSearch: Bool = false
+    /// Incremented to trigger a horizontal split in the active terminal tab.
+    var splitHorizontalTrigger: Int = 0
+    /// Incremented to trigger a vertical split in the active terminal tab.
+    var splitVerticalTrigger: Int = 0
     var sidebarSearchQuery: String = ""
     var focusSidebarSearch: Bool = false
     var showReviewPRDialog: Bool = false

--- a/Sources/Terminal/TmuxSessionManager.swift
+++ b/Sources/Terminal/TmuxSessionManager.swift
@@ -132,11 +132,39 @@ public actor TmuxSessionManager {
         try await runTmux(args: ["send-keys", "-t", sessionName, "-l", text])
     }
 
+    /// Split the current pane in a tmux session.
+    ///
+    /// - Parameters:
+    ///   - sessionName: The tmux session to split a pane in.
+    ///   - direction: `.horizontal` splits top/bottom, `.vertical` splits left/right.
+    public func splitWindow(sessionName: String, direction: TmuxSplitDirection) async throws {
+        try await runTmux(args: [
+            "split-window", direction.flag, "-t", sessionName,
+        ])
+    }
+
     // MARK: - Private
 
     @discardableResult
     private func runTmux(args: [String]) async throws -> String {
         try await ShellRunner.runTmux(args: args)
+    }
+}
+
+// MARK: - Split Direction
+
+/// Direction for splitting a tmux pane.
+public enum TmuxSplitDirection: Sendable {
+    /// Split left/right (vertical divider).
+    case vertical
+    /// Split top/bottom (horizontal divider).
+    case horizontal
+
+    var flag: String {
+        switch self {
+        case .vertical: "-h"
+        case .horizontal: "-v"
+        }
     }
 }
 

--- a/Sources/Views/SessionDetail/SessionDetailView.swift
+++ b/Sources/Views/SessionDetail/SessionDetailView.swift
@@ -9,22 +9,33 @@ public struct SessionDetailView: View {
     var onSelectPR: ((PullRequest) -> Void)?
     @Binding var showSendBar: Bool
     @Binding var showTerminalSearch: Bool
+    @Binding var splitHorizontalTrigger: Int
+    @Binding var splitVerticalTrigger: Int
 
     public init(
         session: Session, linkedPR: PullRequest? = nil, onSelectPR: ((PullRequest) -> Void)? = nil, showSendBar: Binding<Bool>,
-        showTerminalSearch: Binding<Bool>
+        showTerminalSearch: Binding<Bool>,
+        splitHorizontalTrigger: Binding<Int> = .constant(0),
+        splitVerticalTrigger: Binding<Int> = .constant(0)
     ) {
         self.session = session
         self.linkedPR = linkedPR
         self.onSelectPR = onSelectPR
         self._showSendBar = showSendBar
         self._showTerminalSearch = showTerminalSearch
+        self._splitHorizontalTrigger = splitHorizontalTrigger
+        self._splitVerticalTrigger = splitVerticalTrigger
     }
 
     public var body: some View {
         VStack(spacing: 0) {
             SessionHeaderView(session: session, linkedPR: linkedPR, onSelectPR: onSelectPR)
-            TerminalTabView(session: session, showSearch: $showTerminalSearch)
+            TerminalTabView(
+                session: session,
+                showSearch: $showTerminalSearch,
+                splitHorizontalTrigger: $splitHorizontalTrigger,
+                splitVerticalTrigger: $splitVerticalTrigger
+            )
             SendTextBar(isVisible: $showSendBar) { text in
                 if let terminal = TerminalSessionCache.shared.mainTerminal(forSessionID: session.id) {
                     terminal.send(txt: text + "\r")

--- a/Sources/Views/SessionDetail/TerminalTabView.swift
+++ b/Sources/Views/SessionDetail/TerminalTabView.swift
@@ -24,6 +24,8 @@ public struct TerminalTabView: View {
     let session: Session
     let tmuxManager: TmuxSessionManager
     @Binding var showSearch: Bool
+    @Binding var splitHorizontalTrigger: Int
+    @Binding var splitVerticalTrigger: Int
     @State private var tabs: [TerminalTab] = []
     @State private var selectedTabID: String?
     @State private var shellCounter: Int = 0
@@ -31,10 +33,18 @@ public struct TerminalTabView: View {
     @AppStorage("terminalFontFamily") private var fontFamily: String = "MesloLGS Nerd Font"
     @AppStorage("terminalFontSize") private var fontSize: Double = 13
 
-    public init(session: Session, tmuxManager: TmuxSessionManager = TmuxSessionManager(), showSearch: Binding<Bool>) {
+    public init(
+        session: Session,
+        tmuxManager: TmuxSessionManager = TmuxSessionManager(),
+        showSearch: Binding<Bool>,
+        splitHorizontalTrigger: Binding<Int> = .constant(0),
+        splitVerticalTrigger: Binding<Int> = .constant(0)
+    ) {
         self.session = session
         self.tmuxManager = tmuxManager
         self._showSearch = showSearch
+        self._splitHorizontalTrigger = splitHorizontalTrigger
+        self._splitVerticalTrigger = splitVerticalTrigger
     }
 
     public var body: some View {
@@ -97,6 +107,8 @@ public struct TerminalTabView: View {
             selectedTabID = nil
             initializeTabsIfReady()
         }
+        .onChange(of: splitHorizontalTrigger) { _, _ in splitVertical() }
+        .onChange(of: splitVerticalTrigger) { _, _ in splitHorizontal() }
         .onChange(of: session.status) { _, newStatus in
             // Wait for the tmux session to be created before attaching.
             // TerminalPane calls `tmux attach-session` immediately, so we
@@ -128,6 +140,30 @@ public struct TerminalTabView: View {
             .help("New shell tab")
 
             Spacer()
+
+            // Split pane buttons
+            if selectedTab != nil {
+                HStack(spacing: 2) {
+                    Button(action: splitVertical) {
+                        Image(systemName: "rectangle.split.1x2")
+                            .font(.caption)
+                            .foregroundColor(theme.chrome.textDim)
+                            .frame(width: 28, height: 28)
+                    }
+                    .buttonStyle(.plain)
+                    .help("Split pane horizontally (top/bottom)")
+
+                    Button(action: splitHorizontal) {
+                        Image(systemName: "rectangle.split.2x1")
+                            .font(.caption)
+                            .foregroundColor(theme.chrome.textDim)
+                            .frame(width: 28, height: 28)
+                    }
+                    .buttonStyle(.plain)
+                    .help("Split pane vertically (left/right)")
+                }
+                .padding(.trailing, 4)
+            }
         }
         .padding(.horizontal, 4)
         .padding(.vertical, 2)
@@ -299,6 +335,20 @@ public struct TerminalTabView: View {
 
             tabs.append(tab)
             selectedTabID = tab.id
+        }
+    }
+
+    private func splitVertical() {
+        guard let tab = selectedTab, let tmuxName = tab.config.tmuxSessionName else { return }
+        Task {
+            try? await tmuxManager.splitWindow(sessionName: tmuxName, direction: .horizontal)
+        }
+    }
+
+    private func splitHorizontal() {
+        guard let tab = selectedTab, let tmuxName = tab.config.tmuxSessionName else { return }
+        Task {
+            try? await tmuxManager.splitWindow(sessionName: tmuxName, direction: .vertical)
         }
     }
 


### PR DESCRIPTION
## Summary

- Adds toolbar buttons and keyboard shortcuts (`Cmd+D` / `Cmd+Shift+D`) to split terminal panes via `tmux split-window`
- Leverages existing tmux session management — splits are rendered natively by tmux within the SwiftTerm view
- No changes to the terminal rendering layer; tmux handles all pane layout, borders, and navigation

## Test plan

- [ ] Open a session, verify split buttons appear in the tab bar (right side)
- [ ] Click the horizontal split button — terminal should split top/bottom
- [ ] Click the vertical split button — terminal should split left/right
- [ ] Test `Cmd+D` and `Cmd+Shift+D` keyboard shortcuts from the menu
- [ ] Verify native tmux keybindings (`Ctrl+B %`, `Ctrl+B "`) still work
- [ ] Navigate between panes with `Ctrl+B Arrow`
- [ ] Verify buttons don't appear when no tab is selected (error/stopped state)
- [ ] All 160 existing tests pass