### PR TITLE
fix: notification crash and sidebar disclosure arrow regression

### DIFF
--- a/Sources/App/NotificationManager.swift
+++ b/Sources/App/NotificationManager.swift
@@ -95,7 +95,8 @@ public final class NotificationManager: NSObject, UNUserNotificationCenterDelega
     func clearDeliveredNotifications(forSessionID sessionID: String) {
         guard isBundled else { return }
         let center = UNUserNotificationCenter.current()
-        center.getDeliveredNotifications { notifications in
+        Task {
+            let notifications = await center.deliveredNotifications()
             let matching =
                 notifications
                 .filter { $0.request.content.userInfo["sessionID"] as? String == sessionID }

--- a/Sources/Views/Sidebar/ProjectTreeView.swift
+++ b/Sources/Views/Sidebar/ProjectTreeView.swift
@@ -213,89 +213,60 @@ struct ProjectSection: View {
     }
 
     var body: some View {
-        Section {
-            if isExpanded {
-                ForEach(rootSessions) { session in
-                    SessionRowView(
-                        session: session,
-                        linkedPR: sessionPRs[session.id],
-                        isProvisioningWorktree: provisioningWorktreeIDs.contains(session.id),
-                        actions: actions
-                    )
-                    .tag(session.id)
-
-                    // Child sessions indented under parent
-                    ForEach(children(of: session.id)) { child in
-                        SessionRowView(
-                            session: child,
-                            linkedPR: sessionPRs[child.id],
-                            isProvisioningWorktree: provisioningWorktreeIDs.contains(child.id),
-                            actions: actions
-                        )
-                        .padding(.leading, 20)
-                        .tag(child.id)
+        // Project header as a plain list row — avoids Section's hover disclosure arrow
+        HStack(spacing: 4) {
+            Image(systemName: "chevron.right")
+                .font(.caption)
+                .foregroundColor(theme.chrome.textDim)
+                .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                .animation(.easeInOut(duration: 0.15), value: isExpanded)
+                .frame(width: 16)
+                .onTapGesture {
+                    withAnimation(.easeInOut(duration: 0.15)) {
+                        isExpanded.toggle()
                     }
                 }
-                .onMove { fromOffsets, toOffset in
-                    actions.reorderSessions(in: project.id, fromOffsets: fromOffsets, toOffset: toOffset)
-                }
-            }
-        } header: {
-            HStack(spacing: 4) {
-                Image(systemName: "chevron.right")
-                    .font(.caption)
-                    .foregroundColor(theme.chrome.textDim)
-                    .rotationEffect(.degrees(isExpanded ? 90 : 0))
-                    .animation(.easeInOut(duration: 0.15), value: isExpanded)
-                    .frame(width: 16)
+
+            if isRenaming {
+                TextField("Project name", text: $editName)
+                    .onSubmit {
+                        if !editName.isEmpty {
+                            actions.renameProject(id: project.id, name: editName)
+                        }
+                        isRenaming = false
+                    }
+                    .textFieldStyle(.plain)
+                    .font(.system(.callout, weight: .semibold))
+                    .onAppear { editName = project.name }
+            } else {
+                Text(project.name)
+                    .font(.system(.callout, weight: .semibold))
+                    .foregroundColor(theme.chrome.text)
+                    .accessibilityLabel("Project: \(project.name)")
+                    .accessibilityHint("Tap to open project settings")
                     .onTapGesture {
-                        withAnimation(.easeInOut(duration: 0.15)) {
-                            isExpanded.toggle()
-                        }
+                        actions.selectProject(project.id)
                     }
-
-                if isRenaming {
-                    TextField("Project name", text: $editName)
-                        .onSubmit {
-                            if !editName.isEmpty {
-                                actions.renameProject(id: project.id, name: editName)
-                            }
-                            isRenaming = false
-                        }
-                        .textFieldStyle(.plain)
-                        .font(.system(.callout, weight: .semibold))
-                        .onAppear { editName = project.name }
-                } else {
-                    Text(project.name)
-                        .font(.system(.callout, weight: .semibold))
-                        .foregroundColor(theme.chrome.text)
-                        .accessibilityLabel("Project: \(project.name)")
-                        .accessibilityHint("Tap to open project settings")
-                        .onTapGesture {
-                            actions.selectProject(project.id)
-                        }
-                }
-                Spacer()
-
-                if !isRenaming {
-                    Button {
-                        actions.newSession(projectID: project.id, parentID: nil)
-                    } label: {
-                        Image(systemName: "plus")
-                            .font(.callout)
-                            .foregroundColor(isHeaderHovered ? theme.chrome.text : theme.chrome.textDim)
-                            .frame(width: 26, height: 26)
-                            .contentShape(Rectangle())
-                    }
-                    .buttonStyle(.plain)
-                    .help("New session in \(project.name)")
-                }
             }
-            .onHover { hovering in
-                isHeaderHovered = hovering
+            Spacer()
+
+            if !isRenaming {
+                Button {
+                    actions.newSession(projectID: project.id, parentID: nil)
+                } label: {
+                    Image(systemName: "plus")
+                        .font(.callout)
+                        .foregroundColor(isHeaderHovered ? theme.chrome.text : theme.chrome.textDim)
+                        .frame(width: 26, height: 26)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .help("New session in \(project.name)")
             }
         }
-        .collapsible(false)
+        .onHover { hovering in
+            isHeaderHovered = hovering
+        }
         .contextMenu {
             Button {
                 isRenaming = true
@@ -341,6 +312,34 @@ struct ProjectSection: View {
             Button("Cancel", role: .cancel) {}
         } message: {
             Text("This will remove the project and all its sessions from Runway. Worktrees on disk will not be deleted.")
+        }
+
+        // Session rows (flat list items, not inside a Section)
+        if isExpanded {
+            ForEach(rootSessions) { session in
+                SessionRowView(
+                    session: session,
+                    linkedPR: sessionPRs[session.id],
+                    isProvisioningWorktree: provisioningWorktreeIDs.contains(session.id),
+                    actions: actions
+                )
+                .tag(session.id)
+
+                // Child sessions indented under parent
+                ForEach(children(of: session.id)) { child in
+                    SessionRowView(
+                        session: child,
+                        linkedPR: sessionPRs[child.id],
+                        isProvisioningWorktree: provisioningWorktreeIDs.contains(child.id),
+                        actions: actions
+                    )
+                    .padding(.leading, 20)
+                    .tag(child.id)
+                }
+            }
+            .onMove { fromOffsets, toOffset in
+                actions.reorderSessions(in: project.id, fromOffsets: fromOffsets, toOffset: toOffset)
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

- **Fix crash in `NotificationManager.clearDeliveredNotifications`**: The callback-based `getDeliveredNotifications` API dispatched its closure on a non-main queue, violating `@MainActor` isolation and causing a `dispatch_assert_queue_fail` trap. Replaced with the async `deliveredNotifications()` API inside a `Task` that inherits the actor context.
- **Fix sidebar disclosure arrow regression**: `.collapsible(false)` on `Section` prevented collapse behavior but didn't suppress the hover disclosure triangle rendered by `.listStyle(.sidebar)`. Replaced `Section` with flat list rows — the project header is now a plain row with the existing manual chevron, completely eliminating the system's disclosure mechanism.

Tagged as `v0.5.2`.

## Test plan

- [x] `swift build` passes
- [x] `swift test` — all 266 tests pass
- [ ] Launch app, hover over project headers in sidebar — no system disclosure arrow appears
- [ ] Verify project expand/collapse still works via the manual chevron
- [ ] Verify "+" new session button position is stable on hover
- [ ] Navigate away from a session that has delivered notifications — no crash
- [ ] Context menu on project headers still works (rename, copy path, settings, remove)