### PR TITLE
feat: restart-resume, fork session, and Happy indicators

### DIFF
--- a/Sources/App/RunwayApp.swift
+++ b/Sources/App/RunwayApp.swift
@@ -444,6 +444,10 @@ struct ContentView: View {
                         get: { store.splitVerticalTrigger },
                         set: { store.splitVerticalTrigger = $0 }
                     ),
+                    terminalRestartTrigger: Binding(
+                        get: { store.terminalRestartTrigger },
+                        set: { store.terminalRestartTrigger = $0 }
+                    ),
                     changesVisible: Binding(
                         get: { store.changesVisible },
                         set: { store.changesVisible = $0 }

--- a/Sources/App/RunwayApp.swift
+++ b/Sources/App/RunwayApp.swift
@@ -150,10 +150,12 @@ struct ContentView: View {
                     initialProjectID: store.newSessionProjectID,
                     parentID: store.newSessionParentID,
                     templates: store.availableTemplates(forProjectID: store.newSessionProjectID),
+                    forkSource: store.forkSourceSession,
                     onCreate: { request in
                         Task { await store.handleNewSessionRequest(request) }
                         store.newSessionProjectID = nil
                         store.newSessionParentID = nil
+                        store.forkSourceSession = nil
                     },
                     onCreateReview: { request in
                         try await store.handleReviewSessionRequest(request)

--- a/Sources/App/RunwayApp.swift
+++ b/Sources/App/RunwayApp.swift
@@ -423,6 +423,11 @@ struct ContentView: View {
                     linkedPR: store.sessionPRs[sessionID],
                     prDetail: store.prDetailForSession(sessionID),
                     onSelectPR: { pr in Task { await store.selectPR(pr) } },
+                    parentSession: {
+                        guard let parentID = session.parentID else { return nil }
+                        return store.sessions.first(where: { $0.id == parentID })
+                    }(),
+                    onSelectSession: { id in store.selectSession(id) },
                     showSendBar: Binding(
                         get: { store.showSendBar },
                         set: { store.showSendBar = $0 }

--- a/Sources/App/RunwayApp.swift
+++ b/Sources/App/RunwayApp.swift
@@ -141,7 +141,14 @@ struct ContentView: View {
             .sheet(
                 isPresented: Binding(
                     get: { store.showNewSessionDialog },
-                    set: { store.showNewSessionDialog = $0 }
+                    set: {
+                        store.showNewSessionDialog = $0
+                        if !$0 {
+                            store.newSessionProjectID = nil
+                            store.newSessionParentID = nil
+                            store.forkSourceSession = nil
+                        }
+                    }
                 )
             ) {
                 NewSessionDialog(

--- a/Sources/App/RunwayStore.swift
+++ b/Sources/App/RunwayStore.swift
@@ -394,12 +394,15 @@ public final class RunwayStore {
 
             Task {
                 let sessionPath: String
+                let actualBranch: String
                 do {
-                    sessionPath = try await worktreeManager.createWorktree(
+                    let result = try await worktreeManager.createWorktree(
                         repoPath: request.path,
                         branchName: branchName,
                         baseBranch: baseBranch
                     )
+                    sessionPath = result.path
+                    actualBranch = result.branch
                 } catch {
                     print("[Runway] Worktree creation failed: \(error)")
                     provisioningWorktreeIDs.remove(session.id)
@@ -410,8 +413,10 @@ public final class RunwayStore {
 
                 if let idx = sessions.firstIndex(where: { $0.id == session.id }) {
                     sessions[idx].path = sessionPath
+                    sessions[idx].worktreeBranch = actualBranch
                 }
                 try? database?.updateSessionPath(id: session.id, path: sessionPath)
+                try? database?.updateSessionBranch(id: session.id, branch: actualBranch)
 
                 provisioningWorktreeIDs.remove(session.id)
 
@@ -506,12 +511,10 @@ public final class RunwayStore {
     }
 
     public func restartSession(id: String) async {
-        guard let idx = sessions.firstIndex(where: { $0.id == id }) else { return }
-        let session = sessions[idx]
+        guard let session = sessions.first(where: { $0.id == id }) else { return }
 
         // Transition to .starting so TerminalTabView clears its tabs
-        sessions[idx].status = .starting
-        try? database?.updateSessionStatus(id: id, status: .starting)
+        updateSessionStatus(id: id, status: .starting)
 
         // Kill existing tmux sessions (main + shell tabs)
         let tmuxName = "runway-\(id)"
@@ -541,14 +544,12 @@ public final class RunwayStore {
                         "RUNWAY_TITLE": session.title,
                     ]
                 )
-                sessions[idx].status = .running
+                updateSessionStatus(id: id, status: .running)
             } catch {
                 print("[Runway] Failed to restart tmux session: \(error)")
-                sessions[idx].status = .error
+                updateSessionStatus(id: id, status: .error)
             }
         }
-
-        try? database?.updateSessionStatus(id: id, status: sessions[idx].status)
     }
 
     public func deleteSession(id: String, deleteWorktree: Bool = false) {

--- a/Sources/App/RunwayStore.swift
+++ b/Sources/App/RunwayStore.swift
@@ -509,6 +509,10 @@ public final class RunwayStore {
         guard let idx = sessions.firstIndex(where: { $0.id == id }) else { return }
         let session = sessions[idx]
 
+        // Transition to .starting so TerminalTabView clears its tabs
+        sessions[idx].status = .starting
+        try? database?.updateSessionStatus(id: id, status: .starting)
+
         // Kill existing tmux sessions (main + shell tabs)
         let tmuxName = "runway-\(id)"
         if tmuxAvailable {

--- a/Sources/App/RunwayStore.swift
+++ b/Sources/App/RunwayStore.swift
@@ -40,6 +40,7 @@ public final class RunwayStore {
     var showNewProjectDialog: Bool = false
     var newSessionProjectID: String?
     var newSessionParentID: String?
+    var forkSourceSession: Session?
     var statusMessage: StatusMessage?
     var tmuxAvailable: Bool = false
     var showSendBar: Bool = false
@@ -1547,6 +1548,16 @@ extension RunwayStore: SidebarActions {
     public func newSession(projectID: String?, parentID: String? = nil) {
         newSessionProjectID = projectID
         newSessionParentID = parentID
+        showNewSessionDialog = true
+    }
+
+    public func forkSession(id: String) {
+        guard let session = sessions.first(where: { $0.id == id }),
+            session.worktreeBranch != nil
+        else { return }
+        forkSourceSession = session
+        newSessionProjectID = session.projectID
+        newSessionParentID = session.id
         showNewSessionDialog = true
     }
 

--- a/Sources/App/RunwayStore.swift
+++ b/Sources/App/RunwayStore.swift
@@ -387,7 +387,7 @@ public final class RunwayStore {
         // If worktree needed, create it in the background then start the tmux session
         if needsWorktree, let branchName = request.branchName {
             let project = projects.first(where: { $0.id == request.projectID })
-            let baseBranch = project?.defaultBranch ?? "main"
+            let baseBranch = request.baseBranch ?? project?.defaultBranch ?? "main"
 
             provisioningWorktreeIDs.insert(session.id)
 

--- a/Sources/App/RunwayStore.swift
+++ b/Sources/App/RunwayStore.swift
@@ -49,6 +49,8 @@ public final class RunwayStore {
     var splitHorizontalTrigger: Int = 0
     /// Incremented to trigger a vertical split in the active terminal tab.
     var splitVerticalTrigger: Int = 0
+    /// Incremented to force terminal tab reinitialization after restart.
+    var terminalRestartTrigger: Int = 0
     var sidebarSearchQuery: String = ""
     var focusSidebarSearch: Bool = false
     var showReviewPRDialog: Bool = false
@@ -545,6 +547,7 @@ public final class RunwayStore {
                     ]
                 )
                 updateSessionStatus(id: id, status: .running)
+                terminalRestartTrigger += 1
             } catch {
                 print("[Runway] Failed to restart tmux session: \(error)")
                 updateSessionStatus(id: id, status: .error)

--- a/Sources/App/RunwayStore.swift
+++ b/Sources/App/RunwayStore.swift
@@ -423,6 +423,31 @@ public final class RunwayStore {
         }
     }
 
+    /// Builds the CLI command string for an agent session.
+    /// Returns nil for shell sessions (tmux uses its default shell).
+    private func buildAgentCommand(
+        session: Session,
+        profile: AgentProfile,
+        resume: Bool = false
+    ) -> String? {
+        guard profile.id != "shell" else { return nil }
+        var parts: [String] = []
+        if session.useHappy {
+            parts.append("happy")
+            parts.append(session.tool.command)
+        } else {
+            parts.append(profile.command)
+        }
+        parts.append(contentsOf: profile.arguments)
+        if resume {
+            parts.append(contentsOf: profile.resumeArguments)
+        }
+        if session.tool.supportsPermissionModes {
+            parts.append(contentsOf: session.permissionMode.cliFlags(for: session.tool))
+        }
+        return parts.joined(separator: " ")
+    }
+
     /// Creates the tmux session and updates the session status to .running.
     private func startTmuxSession(for session: Session, path: String, initialPrompt: String? = nil) async {
         guard tmuxAvailable else {
@@ -433,23 +458,7 @@ public final class RunwayStore {
 
         let tmuxName = "runway-\(session.id)"
         let profile = profileForSession(session)
-        let toolCommand: String?
-        if profile.id == "shell" {
-            toolCommand = nil  // shell sessions use tmux's default shell
-        } else {
-            var parts: [String] = []
-            if session.useHappy {
-                parts.append("happy")
-                parts.append(session.tool.command)
-            } else {
-                parts.append(profile.command)
-            }
-            parts.append(contentsOf: profile.arguments)
-            if session.tool.supportsPermissionModes {
-                parts.append(contentsOf: session.permissionMode.cliFlags(for: session.tool))
-            }
-            toolCommand = parts.joined(separator: " ")
-        }
+        let toolCommand = buildAgentCommand(session: session, profile: profile, resume: false)
 
         do {
             try await tmuxManager.createSession(
@@ -515,17 +524,7 @@ public final class RunwayStore {
         // Recreate tmux session
         if tmuxAvailable {
             let profile = profileForSession(session)
-            let toolCommand: String?
-            if profile.id == "shell" {
-                toolCommand = nil  // shell sessions use tmux's default shell
-            } else {
-                var parts = [profile.command]
-                parts.append(contentsOf: profile.arguments)
-                if session.tool.supportsPermissionModes {
-                    parts.append(contentsOf: session.permissionMode.cliFlags(for: session.tool))
-                }
-                toolCommand = parts.joined(separator: " ")
-            }
+            let toolCommand = buildAgentCommand(session: session, profile: profile, resume: true)
 
             do {
                 try await tmuxManager.createSession(

--- a/Sources/GitOperations/WorktreeManager.swift
+++ b/Sources/GitOperations/WorktreeManager.swift
@@ -26,8 +26,14 @@ public actor WorktreeManager {
             (try? await runGit(in: repoPath, args: ["remote"])).map { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty } ?? false
 
         if hasRemote {
-            _ = try? await runGit(in: repoPath, args: ["fetch", "origin", baseBranch])
-            try await runGit(in: repoPath, args: ["worktree", "add", "-b", sanitized, worktreePath, "origin/\(baseBranch)"])
+            let fetched = (try? await runGit(in: repoPath, args: ["fetch", "origin", baseBranch])) != nil
+            if fetched {
+                // Branch from the remote-tracking version
+                try await runGit(in: repoPath, args: ["worktree", "add", "-b", sanitized, worktreePath, "origin/\(baseBranch)"])
+            } else {
+                // baseBranch doesn't exist on origin (e.g., forking from a local worktree branch)
+                try await runGit(in: repoPath, args: ["worktree", "add", "-b", sanitized, worktreePath, baseBranch])
+            }
         } else {
             // No remote — branch from local base branch
             try await runGit(in: repoPath, args: ["worktree", "add", "-b", sanitized, worktreePath, baseBranch])

--- a/Sources/GitOperations/WorktreeManager.swift
+++ b/Sources/GitOperations/WorktreeManager.swift
@@ -13,11 +13,12 @@ public actor WorktreeManager {
     ///   - branchName: Name for the new branch (will be sanitized)
     ///   - baseBranch: Branch to base the worktree on (default: "main")
     /// - Returns: Path to the created worktree directory
+    /// Returns `(path, actualBranchName)` — the branch name may differ from input due to sanitization.
     public func createWorktree(
         repoPath: String,
         branchName: String,
         baseBranch: String = "main"
-    ) async throws -> String {
+    ) async throws -> (path: String, branch: String) {
         let sanitized = sanitizeBranchName(branchName)
         let worktreePath = "\(repoPath)/.worktrees/\(sanitized)"
 
@@ -25,21 +26,27 @@ public actor WorktreeManager {
         let hasRemote =
             (try? await runGit(in: repoPath, args: ["remote"])).map { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty } ?? false
 
+        // Also sanitize baseBranch in case it came from a stored worktreeBranch
+        // that wasn't sanitized (pre-existing sessions)
+        let sanitizedBase = sanitizeBranchName(baseBranch)
+
         if hasRemote {
+            // Try fetching the original baseBranch name from origin first
             let fetched = (try? await runGit(in: repoPath, args: ["fetch", "origin", baseBranch])) != nil
             if fetched {
-                // Branch from the remote-tracking version
                 try await runGit(in: repoPath, args: ["worktree", "add", "-b", sanitized, worktreePath, "origin/\(baseBranch)"])
             } else {
-                // baseBranch doesn't exist on origin (e.g., forking from a local worktree branch)
-                try await runGit(in: repoPath, args: ["worktree", "add", "-b", sanitized, worktreePath, baseBranch])
+                // baseBranch doesn't exist on origin — try local (sanitized form first, then raw)
+                let localRef = try? await runGit(in: repoPath, args: ["rev-parse", "--verify", sanitizedBase])
+                let refToUse = localRef != nil ? sanitizedBase : baseBranch
+                try await runGit(in: repoPath, args: ["worktree", "add", "-b", sanitized, worktreePath, refToUse])
             }
         } else {
             // No remote — branch from local base branch
             try await runGit(in: repoPath, args: ["worktree", "add", "-b", sanitized, worktreePath, baseBranch])
         }
 
-        return worktreePath
+        return (path: worktreePath, branch: sanitized)
     }
 
     /// Create a worktree for an existing branch (e.g., a PR's remote branch).

--- a/Sources/Models/AgentProfile.swift
+++ b/Sources/Models/AgentProfile.swift
@@ -17,6 +17,8 @@ public struct AgentProfile: Identifiable, Codable, Sendable {
     public let lineStartIdlePatterns: [String]
     /// Single characters used as spinner indicators (e.g., braille dots).
     public let spinnerChars: [String]
+    /// CLI arguments to pass when resuming a previous conversation.
+    public let resumeArguments: [String]
     /// Whether this agent supports Runway's HTTP hook protocol.
     public let hookEnabled: Bool
     /// SF Symbol name for the agent's icon.
@@ -32,6 +34,7 @@ public struct AgentProfile: Identifiable, Codable, Sendable {
         idlePatterns: [String] = [],
         lineStartIdlePatterns: [String] = [],
         spinnerChars: [String] = [],
+        resumeArguments: [String] = [],
         hookEnabled: Bool = false,
         icon: String = "terminal.fill"
     ) {
@@ -44,8 +47,31 @@ public struct AgentProfile: Identifiable, Codable, Sendable {
         self.idlePatterns = idlePatterns
         self.lineStartIdlePatterns = lineStartIdlePatterns
         self.spinnerChars = spinnerChars
+        self.resumeArguments = resumeArguments
         self.hookEnabled = hookEnabled
         self.icon = icon
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id, name, command, arguments, runningPatterns, waitingPatterns
+        case idlePatterns, lineStartIdlePatterns, spinnerChars, resumeArguments
+        case hookEnabled, icon
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        name = try container.decode(String.self, forKey: .name)
+        command = try container.decode(String.self, forKey: .command)
+        arguments = try container.decodeIfPresent([String].self, forKey: .arguments) ?? []
+        runningPatterns = try container.decodeIfPresent([String].self, forKey: .runningPatterns) ?? []
+        waitingPatterns = try container.decodeIfPresent([String].self, forKey: .waitingPatterns) ?? []
+        idlePatterns = try container.decodeIfPresent([String].self, forKey: .idlePatterns) ?? []
+        lineStartIdlePatterns = try container.decodeIfPresent([String].self, forKey: .lineStartIdlePatterns) ?? []
+        spinnerChars = try container.decodeIfPresent([String].self, forKey: .spinnerChars) ?? []
+        resumeArguments = try container.decodeIfPresent([String].self, forKey: .resumeArguments) ?? []
+        hookEnabled = try container.decodeIfPresent(Bool.self, forKey: .hookEnabled) ?? false
+        icon = try container.decodeIfPresent(String.self, forKey: .icon) ?? "terminal.fill"
     }
 }
 
@@ -92,6 +118,7 @@ extension AgentProfile {
         ],
         lineStartIdlePatterns: ["> ", "$ "],
         spinnerChars: ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"],
+        resumeArguments: ["--continue"],
         hookEnabled: true,
         icon: "sparkle"
     )
@@ -130,6 +157,7 @@ extension AgentProfile {
         idlePatterns: ["Type your message"],
         lineStartIdlePatterns: ["> "],
         spinnerChars: ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"],
+        resumeArguments: ["--resume"],
         hookEnabled: true,
         icon: "diamond.fill"
     )
@@ -152,6 +180,7 @@ extension AgentProfile {
         idlePatterns: ["Ask Codex to do anything"],
         lineStartIdlePatterns: [],
         spinnerChars: [],
+        resumeArguments: ["--continue"],
         hookEnabled: true,
         icon: "cpu"
     )

--- a/Sources/Models/NewSessionRequest.swift
+++ b/Sources/Models/NewSessionRequest.swift
@@ -13,6 +13,7 @@ public struct NewSessionRequest: Sendable {
     public let useHappy: Bool
     public let initialPrompt: String?
     public let issueNumber: Int?
+    public let baseBranch: String?
 
     public init(
         title: String,
@@ -25,7 +26,8 @@ public struct NewSessionRequest: Sendable {
         permissionMode: PermissionMode = .default,
         useHappy: Bool = false,
         initialPrompt: String? = nil,
-        issueNumber: Int? = nil
+        issueNumber: Int? = nil,
+        baseBranch: String? = nil
     ) {
         self.title = title
         self.projectID = projectID
@@ -38,5 +40,6 @@ public struct NewSessionRequest: Sendable {
         self.useHappy = useHappy
         self.initialPrompt = initialPrompt
         self.issueNumber = issueNumber
+        self.baseBranch = baseBranch
     }
 }

--- a/Sources/Persistence/Database.swift
+++ b/Sources/Persistence/Database.swift
@@ -296,6 +296,15 @@ public final class Database: Sendable {
         }
     }
 
+    public func updateSessionBranch(id: String, branch: String) throws {
+        try dbQueue.write { db in
+            try db.execute(
+                sql: "UPDATE sessions SET worktreeBranch = ?, lastAccessedAt = ? WHERE id = ?",
+                arguments: [branch, Date(), id]
+            )
+        }
+    }
+
     public func updateSessionSortOrder(id: String, sortOrder: Int) throws {
         try dbQueue.write { db in
             try db.execute(

--- a/Sources/Views/SessionDetail/SessionDetailView.swift
+++ b/Sources/Views/SessionDetail/SessionDetailView.swift
@@ -16,6 +16,7 @@ public struct SessionDetailView: View {
     @Binding var showTerminalSearch: Bool
     @Binding var splitHorizontalTrigger: Int
     @Binding var splitVerticalTrigger: Int
+    @Binding var terminalRestartTrigger: Int
     @Binding var changesVisible: Bool
     @Binding var changesMode: ChangesMode
     let changes: [FileChange]
@@ -39,6 +40,7 @@ public struct SessionDetailView: View {
         showTerminalSearch: Binding<Bool>,
         splitHorizontalTrigger: Binding<Int> = .constant(0),
         splitVerticalTrigger: Binding<Int> = .constant(0),
+        terminalRestartTrigger: Binding<Int> = .constant(0),
         changesVisible: Binding<Bool>,
         changesMode: Binding<ChangesMode>,
         changes: [FileChange] = [],
@@ -59,6 +61,7 @@ public struct SessionDetailView: View {
         self._showTerminalSearch = showTerminalSearch
         self._splitHorizontalTrigger = splitHorizontalTrigger
         self._splitVerticalTrigger = splitVerticalTrigger
+        self._terminalRestartTrigger = terminalRestartTrigger
         self._changesVisible = changesVisible
         self._changesMode = changesMode
         self.changes = changes
@@ -137,7 +140,8 @@ public struct SessionDetailView: View {
                 tmuxManager: tmuxManager,
                 showSearch: $showTerminalSearch,
                 splitHorizontalTrigger: $splitHorizontalTrigger,
-                splitVerticalTrigger: $splitVerticalTrigger
+                splitVerticalTrigger: $splitVerticalTrigger,
+                terminalRestartTrigger: $terminalRestartTrigger
             )
         }
     }

--- a/Sources/Views/SessionDetail/SessionDetailView.swift
+++ b/Sources/Views/SessionDetail/SessionDetailView.swift
@@ -10,6 +10,8 @@ public struct SessionDetailView: View {
     var linkedPR: PullRequest?
     var prDetail: PRDetail? = nil
     var onSelectPR: ((PullRequest) -> Void)?
+    var parentSession: Session? = nil
+    var onSelectSession: ((String) -> Void)? = nil
     @Binding var showSendBar: Bool
     @Binding var showTerminalSearch: Bool
     @Binding var splitHorizontalTrigger: Int
@@ -31,6 +33,8 @@ public struct SessionDetailView: View {
         linkedPR: PullRequest? = nil,
         prDetail: PRDetail? = nil,
         onSelectPR: ((PullRequest) -> Void)? = nil,
+        parentSession: Session? = nil,
+        onSelectSession: ((String) -> Void)? = nil,
         showSendBar: Binding<Bool>,
         showTerminalSearch: Binding<Bool>,
         splitHorizontalTrigger: Binding<Int> = .constant(0),
@@ -49,6 +53,8 @@ public struct SessionDetailView: View {
         self.linkedPR = linkedPR
         self.prDetail = prDetail
         self.onSelectPR = onSelectPR
+        self.parentSession = parentSession
+        self.onSelectSession = onSelectSession
         self._showSendBar = showSendBar
         self._showTerminalSearch = showTerminalSearch
         self._splitHorizontalTrigger = splitHorizontalTrigger
@@ -69,7 +75,9 @@ public struct SessionDetailView: View {
                 session: session,
                 linkedPR: linkedPR,
                 prDetail: prDetail,
+                parentSession: parentSession,
                 onSelectPR: onSelectPR,
+                onSelectSession: onSelectSession,
                 changesVisible: changesVisible,
                 onToggleChanges: onToggleChanges
             )

--- a/Sources/Views/SessionDetail/SessionDetailView.swift
+++ b/Sources/Views/SessionDetail/SessionDetailView.swift
@@ -143,6 +143,7 @@ public struct SessionDetailView: View {
                 splitVerticalTrigger: $splitVerticalTrigger,
                 terminalRestartTrigger: $terminalRestartTrigger
             )
+            .id("terminal-\(session.id)-\(terminalRestartTrigger)")
         }
     }
 }

--- a/Sources/Views/SessionDetail/SessionHeaderView.swift
+++ b/Sources/Views/SessionDetail/SessionHeaderView.swift
@@ -7,7 +7,9 @@ public struct SessionHeaderView: View {
     let session: Session
     var linkedPR: PullRequest?
     var prDetail: PRDetail? = nil
+    var parentSession: Session? = nil
     var onSelectPR: ((PullRequest) -> Void)?
+    var onSelectSession: ((String) -> Void)? = nil
     var changesVisible: Bool = false
     var onToggleChanges: (() -> Void)? = nil
     @Environment(\.theme) private var theme
@@ -16,14 +18,18 @@ public struct SessionHeaderView: View {
         session: Session,
         linkedPR: PullRequest? = nil,
         prDetail: PRDetail? = nil,
+        parentSession: Session? = nil,
         onSelectPR: ((PullRequest) -> Void)? = nil,
+        onSelectSession: ((String) -> Void)? = nil,
         changesVisible: Bool = false,
         onToggleChanges: (() -> Void)? = nil
     ) {
         self.session = session
         self.linkedPR = linkedPR
         self.prDetail = prDetail
+        self.parentSession = parentSession
         self.onSelectPR = onSelectPR
+        self.onSelectSession = onSelectSession
         self.changesVisible = changesVisible
         self.onToggleChanges = onToggleChanges
     }
@@ -48,13 +54,37 @@ public struct SessionHeaderView: View {
 
                     HStack(spacing: 8) {
                         // Tool + permission mode badge
-                        Text("\(session.tool.displayName.lowercased()) · \(session.permissionMode.badgeLabel)")
+                        Text(toolBadgeText)
                             .font(.caption)
-                            .foregroundColor(session.permissionMode.badgeForeground(chrome: theme.chrome))
+                            .foregroundColor(
+                                session.useHappy ? theme.chrome.cyan : session.permissionMode.badgeForeground(chrome: theme.chrome)
+                            )
                             .padding(.horizontal, 7)
                             .padding(.vertical, 3)
-                            .background(session.permissionMode.badgeBackground(chrome: theme.chrome))
+                            .background(
+                                session.useHappy
+                                    ? theme.chrome.cyan.opacity(0.15) : session.permissionMode.badgeBackground(chrome: theme.chrome)
+                            )
                             .clipShape(Capsule())
+                    }
+                }
+
+                if let parent = parentSession {
+                    HStack(spacing: 4) {
+                        Image(systemName: "arrow.triangle.branch")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Text("Forked from")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Button {
+                            onSelectSession?(parent.id)
+                        } label: {
+                            Text("\"\(parent.title)\"")
+                                .font(.caption)
+                                .foregroundStyle(theme.chrome.accent)
+                        }
+                        .buttonStyle(.plain)
                     }
                 }
 
@@ -144,6 +174,17 @@ public struct SessionHeaderView: View {
 
             Divider()
         }
+    }
+
+    // MARK: - Computed Properties
+
+    private var toolBadgeText: String {
+        var parts = [session.tool.displayName.lowercased()]
+        if session.useHappy {
+            parts.append("happy")
+        }
+        parts.append(session.permissionMode.badgeLabel)
+        return parts.joined(separator: " · ")
     }
 
     // MARK: - Status Dot

--- a/Sources/Views/SessionDetail/TerminalTabView.swift
+++ b/Sources/Views/SessionDetail/TerminalTabView.swift
@@ -246,7 +246,7 @@ public struct TerminalTabView: View {
     private func initializeTabs() {
         guard tabs.isEmpty else { return }
 
-        let mainTabID = "\(session.id)_main"
+        let mainTabID = "\(session.id)_main_\(terminalRestartTrigger)"
         let tmuxName = "runway-\(session.id)"
 
         // Build the command with permission flags for tools that support them

--- a/Sources/Views/SessionDetail/TerminalTabView.swift
+++ b/Sources/Views/SessionDetail/TerminalTabView.swift
@@ -132,15 +132,11 @@ public struct TerminalTabView: View {
             // must not initialize tabs until the tmux session actually exists.
             // Only .running, .idle, and .waiting indicate a live tmux session —
             // .error and .stopped mean creation failed or the session is gone.
-            if newStatus.tmuxSessionExpected {
-                if tabs.isEmpty {
-                    initializeTabs()
-                }
-            } else {
-                // Session went non-live (e.g., restarting) — clear tabs so they
-                // reinitialize when the session comes back.
-                tabs = []
-                selectedTabID = nil
+            // Note: tabs are NOT cleared on non-live status — restart uses .id()
+            // to force full view recreation, and stale hook events from a killed
+            // session could otherwise destroy the freshly created terminal.
+            if tabs.isEmpty, newStatus.tmuxSessionExpected {
+                initializeTabs()
             }
         }
     }

--- a/Sources/Views/SessionDetail/TerminalTabView.swift
+++ b/Sources/Views/SessionDetail/TerminalTabView.swift
@@ -27,6 +27,7 @@ public struct TerminalTabView: View {
     @Binding var showSearch: Bool
     @Binding var splitHorizontalTrigger: Int
     @Binding var splitVerticalTrigger: Int
+    @Binding var terminalRestartTrigger: Int
     @State private var tabs: [TerminalTab] = []
     @State private var selectedTabID: String?
     @State private var shellCounter: Int = 0
@@ -39,13 +40,15 @@ public struct TerminalTabView: View {
         tmuxManager: TmuxSessionManager,
         showSearch: Binding<Bool>,
         splitHorizontalTrigger: Binding<Int> = .constant(0),
-        splitVerticalTrigger: Binding<Int> = .constant(0)
+        splitVerticalTrigger: Binding<Int> = .constant(0),
+        terminalRestartTrigger: Binding<Int> = .constant(0)
     ) {
         self.session = session
         self.tmuxManager = tmuxManager
         self._showSearch = showSearch
         self._splitHorizontalTrigger = splitHorizontalTrigger
         self._splitVerticalTrigger = splitVerticalTrigger
+        self._terminalRestartTrigger = terminalRestartTrigger
     }
 
     public var body: some View {
@@ -116,6 +119,13 @@ public struct TerminalTabView: View {
         }
         .onChange(of: splitHorizontalTrigger) { _, _ in splitDown() }
         .onChange(of: splitVerticalTrigger) { _, _ in splitRight() }
+        .onChange(of: terminalRestartTrigger) { _, _ in
+            // Force reinitialize tabs after restart — the status onChange may not
+            // fire if SwiftUI coalesces .running → .starting → .running into no-op.
+            tabs = []
+            selectedTabID = nil
+            initializeTabsIfReady()
+        }
         .onChange(of: session.status) { _, newStatus in
             // Wait for the tmux session to be created before attaching.
             // TerminalPane calls `tmux attach-session` immediately, so we

--- a/Sources/Views/SessionDetail/TerminalTabView.swift
+++ b/Sources/Views/SessionDetail/TerminalTabView.swift
@@ -122,8 +122,15 @@ public struct TerminalTabView: View {
             // must not initialize tabs until the tmux session actually exists.
             // Only .running, .idle, and .waiting indicate a live tmux session —
             // .error and .stopped mean creation failed or the session is gone.
-            if tabs.isEmpty, newStatus.tmuxSessionExpected {
-                initializeTabs()
+            if newStatus.tmuxSessionExpected {
+                if tabs.isEmpty {
+                    initializeTabs()
+                }
+            } else {
+                // Session went non-live (e.g., restarting) — clear tabs so they
+                // reinitialize when the session comes back.
+                tabs = []
+                selectedTabID = nil
             }
         }
     }

--- a/Sources/Views/Shared/NewSessionDialog.swift
+++ b/Sources/Views/Shared/NewSessionDialog.swift
@@ -46,6 +46,7 @@ public struct NewSessionDialog: View {
     let onCreateReview: ((ReviewSessionRequest) async throws -> Void)?
 
     @State private var selectedTemplateID: String?
+    let forkSource: Session?
 
     public init(
         projects: [Project],
@@ -53,6 +54,7 @@ public struct NewSessionDialog: View {
         initialProjectID: String? = nil,
         parentID: String? = nil,
         templates: [SessionTemplate] = [],
+        forkSource: Session? = nil,
         onCreate: @escaping (NewSessionRequest) -> Void,
         onCreateReview: ((ReviewSessionRequest) async throws -> Void)? = nil
     ) {
@@ -61,6 +63,7 @@ public struct NewSessionDialog: View {
         self.initialProjectID = initialProjectID
         self.parentID = parentID
         self.templates = templates
+        self.forkSource = forkSource
         self.onCreate = onCreate
         self.onCreateReview = onCreateReview
         self._selectedProjectID = State(initialValue: initialProjectID)
@@ -158,6 +161,23 @@ public struct NewSessionDialog: View {
         .fixedSize(horizontal: false, vertical: true)
         .onAppear {
             permissionMode = defaultPermissionMode
+            if let source = forkSource {
+                title = "Fork of \(source.title)"
+                switch source.tool {
+                case .claude: selectedProfileID = "claude"
+                case .gemini: selectedProfileID = "gemini"
+                case .codex: selectedProfileID = "codex"
+                case .shell: selectedProfileID = "shell"
+                case .custom(let name): selectedProfileID = name
+                }
+                permissionMode = source.permissionMode
+                useHappy = source.useHappy
+                useWorktree = true
+                if let sourceBranch = source.worktreeBranch {
+                    branchName = "\(sourceBranch)-fork"
+                    branchManuallyEdited = true
+                }
+            }
             titleFocused = true
         }
     }
@@ -452,7 +472,8 @@ public struct NewSessionDialog: View {
             branchName: useWorktree ? branchName : nil,
             permissionMode: selectedTool.supportsPermissionModes ? permissionMode : .default,
             useHappy: selectedTool.supportsHappy ? useHappy : false,
-            initialPrompt: (selectedTool.supportsInitialPrompt && !initialPrompt.isEmpty) ? initialPrompt : nil
+            initialPrompt: (selectedTool.supportsInitialPrompt && !initialPrompt.isEmpty) ? initialPrompt : nil,
+            baseBranch: forkSource?.worktreeBranch
         )
 
         onCreate(request)

--- a/Sources/Views/Sidebar/ProjectTreeView.swift
+++ b/Sources/Views/Sidebar/ProjectTreeView.swift
@@ -503,12 +503,6 @@ struct SessionRowView: View {
                 Label("Rename Session", systemImage: "pencil")
             }
 
-            Button {
-                actions.newSession(projectID: session.projectID, parentID: session.id)
-            } label: {
-                Label("Spawn Sub-session", systemImage: "arrow.triangle.branch")
-            }
-
             if session.worktreeBranch != nil {
                 Button {
                     actions.forkSession(id: session.id)

--- a/Sources/Views/Sidebar/ProjectTreeView.swift
+++ b/Sources/Views/Sidebar/ProjectTreeView.swift
@@ -375,9 +375,16 @@ struct SessionRowView: View {
                         .font(.system(.body, design: .default))
                         .onAppear { editTitle = session.title }
                 } else {
-                    Text(session.title)
-                        .font(.system(.body, design: .default))
-                        .foregroundStyle(.primary)
+                    HStack(spacing: 4) {
+                        Text(session.title)
+                            .font(.system(.body, design: .default))
+                            .foregroundStyle(.primary)
+                        if session.parentID != nil {
+                            Image(systemName: "arrow.triangle.branch")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
                 }
                 if isProvisioningWorktree {
                     HStack(spacing: 4) {
@@ -467,13 +474,22 @@ struct SessionRowView: View {
             .opacity(isHovered ? 1 : 0)
             .allowsHitTesting(isHovered)
 
-            if !isHovered && session.tool != .claude {
-                Text(session.tool.displayName)
-                    .font(.caption2)
-                    .padding(.horizontal, 4)
-                    .padding(.vertical, 1)
-                    .background(theme.chrome.surface)
-                    .clipShape(RoundedRectangle(cornerRadius: 4))
+            if !isHovered {
+                HStack(spacing: 4) {
+                    if session.useHappy {
+                        Image(systemName: "iphone")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                    if session.tool != .claude {
+                        Text(session.tool.displayName)
+                            .font(.caption2)
+                            .padding(.horizontal, 4)
+                            .padding(.vertical, 1)
+                            .background(theme.chrome.surface)
+                            .clipShape(RoundedRectangle(cornerRadius: 4))
+                    }
+                }
             }
         }
         .padding(.vertical, 4)

--- a/Sources/Views/Sidebar/ProjectTreeView.swift
+++ b/Sources/Views/Sidebar/ProjectTreeView.swift
@@ -10,6 +10,7 @@ import Theme
 @MainActor
 public protocol SidebarActions {
     func restartSession(id: String) async
+    func forkSession(id: String)
     func deleteSession(id: String, deleteWorktree: Bool)
     func newSession(projectID: String?, parentID: String?)
     func newProject()

--- a/Sources/Views/Sidebar/ProjectTreeView.swift
+++ b/Sources/Views/Sidebar/ProjectTreeView.swift
@@ -493,6 +493,14 @@ struct SessionRowView: View {
                 Label("Spawn Sub-session", systemImage: "arrow.triangle.branch")
             }
 
+            if session.worktreeBranch != nil {
+                Button {
+                    actions.forkSession(id: session.id)
+                } label: {
+                    Label("Fork Session", systemImage: "arrow.triangle.branch")
+                }
+            }
+
             Divider()
 
             Button {

--- a/Tests/GitOperationsTests/WorktreeManagerTests.swift
+++ b/Tests/GitOperationsTests/WorktreeManagerTests.swift
@@ -111,7 +111,7 @@ private func withTempGitRepo(_ body: (String) async throws -> Void) async throws
             withIntermediateDirectories: true
         )
 
-        let worktreePath = try await manager.createWorktree(
+        let (worktreePath, _) = try await manager.createWorktree(
             repoPath: repoPath,
             branchName: "test-feature",
             baseBranch: currentBranch
@@ -139,7 +139,7 @@ private func withTempGitRepo(_ body: (String) async throws -> Void) async throws
             withIntermediateDirectories: true
         )
 
-        let worktreePath = try await manager.createWorktree(
+        let (worktreePath, _) = try await manager.createWorktree(
             repoPath: repoPath,
             branchName: "to-remove",
             baseBranch: currentBranch
@@ -222,7 +222,7 @@ private func withTempGitRepo(_ body: (String) async throws -> Void) async throws
             withIntermediateDirectories: true
         )
 
-        let worktreePath = try await manager.createWorktree(
+        let (worktreePath, _) = try await manager.createWorktree(
             repoPath: repoPath,
             branchName: "stale-wt",
             baseBranch: currentBranch

--- a/Tests/ModelsTests/AgentProfileTests.swift
+++ b/Tests/ModelsTests/AgentProfileTests.swift
@@ -110,3 +110,67 @@ import Testing
     #expect(profile.runningPatterns == ["Applying edit"])
     #expect(!profile.hookEnabled)
 }
+
+@Test func claudeProfileHasResumeArguments() {
+    #expect(AgentProfile.claude.resumeArguments == ["--continue"])
+}
+
+@Test func geminiProfileHasResumeArguments() {
+    #expect(AgentProfile.gemini.resumeArguments == ["--resume"])
+}
+
+@Test func codexProfileHasResumeArguments() {
+    #expect(AgentProfile.codex.resumeArguments == ["--continue"])
+}
+
+@Test func shellProfileHasEmptyResumeArguments() {
+    #expect(AgentProfile.shell.resumeArguments.isEmpty)
+}
+
+@Test func customProfileHasEmptyResumeArguments() {
+    let profile = AgentProfile.defaultProfile(for: .custom("aider"))
+    #expect(profile.resumeArguments.isEmpty)
+}
+
+@Test func agentProfileJSONDecodingWithResumeArguments() throws {
+    let json = """
+        {
+            "id": "cursor",
+            "name": "Cursor",
+            "command": "cursor",
+            "arguments": [],
+            "resumeArguments": ["--resume-last"],
+            "runningPatterns": [],
+            "waitingPatterns": [],
+            "idlePatterns": ["$"],
+            "lineStartIdlePatterns": [],
+            "spinnerChars": [],
+            "hookEnabled": false,
+            "icon": "terminal.fill"
+        }
+        """
+    let data = try #require(json.data(using: .utf8))
+    let profile = try JSONDecoder().decode(AgentProfile.self, from: data)
+    #expect(profile.resumeArguments == ["--resume-last"])
+}
+
+@Test func agentProfileJSONDecodingWithoutResumeArguments() throws {
+    let json = """
+        {
+            "id": "aider",
+            "name": "Aider",
+            "command": "aider",
+            "arguments": ["--watch"],
+            "runningPatterns": ["Applying edit"],
+            "waitingPatterns": ["Add these files?"],
+            "idlePatterns": ["aider>"],
+            "lineStartIdlePatterns": [],
+            "spinnerChars": [],
+            "hookEnabled": false,
+            "icon": "terminal.fill"
+        }
+        """
+    let data = try #require(json.data(using: .utf8))
+    let profile = try JSONDecoder().decode(AgentProfile.self, from: data)
+    #expect(profile.resumeArguments.isEmpty)
+}

--- a/docs/superpowers/plans/2026-04-09-restart-resume-fork.md
+++ b/docs/superpowers/plans/2026-04-09-restart-resume-fork.md
@@ -1,0 +1,911 @@
+# Restart Resume, Fork Session, and Happy Indicator — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make restart resume previous agent conversations, add session forking via worktree branching, and show Happy/fork indicators in sidebar and header.
+
+**Architecture:** Add `resumeArguments` to `AgentProfile`, extract a shared `buildAgentCommand` helper in `RunwayStore`, add fork pre-population state to drive `NewSessionDialog`, and extend sidebar row + header views with indicator badges. The `NewSessionRequest` gains a `baseBranch` field for fork worktree creation.
+
+**Tech Stack:** Swift, SwiftUI, Swift Testing, GRDB
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `Sources/Models/AgentProfile.swift` | Modify | Add `resumeArguments` field to struct + init + built-ins |
+| `Sources/Models/NewSessionRequest.swift` | Modify | Add `baseBranch: String?` field |
+| `Sources/App/RunwayStore.swift` | Modify | Extract `buildAgentCommand`, update `restartSession` + `startTmuxSession`, add fork state + `forkSession` method, pass `baseBranch` in `handleNewSessionRequest` |
+| `Sources/Views/Sidebar/ProjectTreeView.swift` | Modify | Add `forkSession` to protocol, fork context menu, fork + Happy indicators in row |
+| `Sources/Views/SessionDetail/SessionHeaderView.swift` | Modify | Add Happy to tool badge, add "Forked from" line |
+| `Sources/Views/Shared/NewSessionDialog.swift` | Modify | Accept fork pre-population via new init parameters |
+| `Sources/App/RunwayApp.swift` | Modify | Pass fork state to `NewSessionDialog` |
+| `Tests/ModelsTests/AgentProfileTests.swift` | Modify | Test `resumeArguments` on built-ins + JSON decoding |
+
+---
+
+### Task 1: Add `resumeArguments` to AgentProfile
+
+**Files:**
+- Modify: `Sources/Models/AgentProfile.swift:5-50` (struct + init)
+- Modify: `Sources/Models/AgentProfile.swift:56-157` (built-in profiles)
+- Modify: `Sources/Models/AgentProfile.swift:163-176` (defaultProfile)
+- Test: `Tests/ModelsTests/AgentProfileTests.swift`
+
+- [ ] **Step 1: Write failing tests for resumeArguments**
+
+Add to `Tests/ModelsTests/AgentProfileTests.swift`:
+
+```swift
+@Test func claudeProfileHasResumeArguments() {
+    #expect(AgentProfile.claude.resumeArguments == ["--continue"])
+}
+
+@Test func geminiProfileHasResumeArguments() {
+    #expect(AgentProfile.gemini.resumeArguments == ["--resume"])
+}
+
+@Test func codexProfileHasResumeArguments() {
+    #expect(AgentProfile.codex.resumeArguments == ["--continue"])
+}
+
+@Test func shellProfileHasEmptyResumeArguments() {
+    #expect(AgentProfile.shell.resumeArguments.isEmpty)
+}
+
+@Test func customProfileHasEmptyResumeArguments() {
+    let profile = AgentProfile.defaultProfile(for: .custom("aider"))
+    #expect(profile.resumeArguments.isEmpty)
+}
+
+@Test func agentProfileJSONDecodingWithResumeArguments() throws {
+    let json = """
+        {
+            "id": "cursor",
+            "name": "Cursor",
+            "command": "cursor",
+            "arguments": [],
+            "resumeArguments": ["--resume-last"],
+            "runningPatterns": [],
+            "waitingPatterns": [],
+            "idlePatterns": ["$"],
+            "lineStartIdlePatterns": [],
+            "spinnerChars": [],
+            "hookEnabled": false,
+            "icon": "terminal.fill"
+        }
+        """
+    let data = try #require(json.data(using: .utf8))
+    let profile = try JSONDecoder().decode(AgentProfile.self, from: data)
+    #expect(profile.resumeArguments == ["--resume-last"])
+}
+
+@Test func agentProfileJSONDecodingWithoutResumeArguments() throws {
+    let json = """
+        {
+            "id": "aider",
+            "name": "Aider",
+            "command": "aider",
+            "arguments": ["--watch"],
+            "runningPatterns": ["Applying edit"],
+            "waitingPatterns": ["Add these files?"],
+            "idlePatterns": ["aider>"],
+            "lineStartIdlePatterns": [],
+            "spinnerChars": [],
+            "hookEnabled": false,
+            "icon": "terminal.fill"
+        }
+        """
+    let data = try #require(json.data(using: .utf8))
+    let profile = try JSONDecoder().decode(AgentProfile.self, from: data)
+    #expect(profile.resumeArguments.isEmpty)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `swift test --filter AgentProfileTests 2>&1 | tail -20`
+Expected: Multiple failures — `resumeArguments` does not exist on `AgentProfile`.
+
+- [ ] **Step 3: Add `resumeArguments` field to AgentProfile**
+
+In `Sources/Models/AgentProfile.swift`, add the field to the struct (after `spinnerChars`):
+
+```swift
+/// CLI arguments to resume a previous conversation (e.g., ["--continue"]).
+public let resumeArguments: [String]
+```
+
+Update the `init` — add parameter with default `[]` (after `spinnerChars`):
+
+```swift
+public init(
+    id: String,
+    name: String,
+    command: String,
+    arguments: [String] = [],
+    runningPatterns: [String] = [],
+    waitingPatterns: [String] = [],
+    idlePatterns: [String] = [],
+    lineStartIdlePatterns: [String] = [],
+    spinnerChars: [String] = [],
+    resumeArguments: [String] = [],
+    hookEnabled: Bool = false,
+    icon: String = "terminal.fill"
+) {
+    self.id = id
+    self.name = name
+    self.command = command
+    self.arguments = arguments
+    self.runningPatterns = runningPatterns
+    self.waitingPatterns = waitingPatterns
+    self.idlePatterns = idlePatterns
+    self.lineStartIdlePatterns = lineStartIdlePatterns
+    self.spinnerChars = spinnerChars
+    self.resumeArguments = resumeArguments
+    self.hookEnabled = hookEnabled
+    self.icon = icon
+}
+```
+
+Update built-in profiles — add `resumeArguments` to each:
+
+**Claude** (after `lineStartIdlePatterns`):
+```swift
+resumeArguments: ["--continue"],
+```
+
+**Shell** — no change needed (default `[]` is correct).
+
+**Gemini** (after `lineStartIdlePatterns`):
+```swift
+resumeArguments: ["--resume"],
+```
+
+**Codex** (after `idlePatterns`):
+```swift
+resumeArguments: ["--continue"],
+```
+
+**`defaultProfile(for:)`** — the custom case already uses the default `[]`, so no change needed.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --filter AgentProfileTests 2>&1 | tail -20`
+Expected: All tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/Models/AgentProfile.swift Tests/ModelsTests/AgentProfileTests.swift
+git commit -m "feat: add resumeArguments to AgentProfile for session resume support"
+```
+
+---
+
+### Task 2: Add `baseBranch` to NewSessionRequest
+
+**Files:**
+- Modify: `Sources/Models/NewSessionRequest.swift:4-42`
+
+- [ ] **Step 1: Add `baseBranch` field to NewSessionRequest**
+
+In `Sources/Models/NewSessionRequest.swift`, add the field after `issueNumber`:
+
+```swift
+public let baseBranch: String?
+```
+
+Add the parameter to `init` with default `nil` (after `issueNumber`):
+
+```swift
+public init(
+    title: String,
+    projectID: String?,
+    parentID: String? = nil,
+    path: String,
+    tool: Tool,
+    useWorktree: Bool,
+    branchName: String?,
+    permissionMode: PermissionMode = .default,
+    useHappy: Bool = false,
+    initialPrompt: String? = nil,
+    issueNumber: Int? = nil,
+    baseBranch: String? = nil
+) {
+    self.title = title
+    self.projectID = projectID
+    self.parentID = parentID
+    self.path = path
+    self.tool = tool
+    self.useWorktree = useWorktree
+    self.branchName = branchName
+    self.permissionMode = permissionMode
+    self.useHappy = useHappy
+    self.initialPrompt = initialPrompt
+    self.issueNumber = issueNumber
+    self.baseBranch = baseBranch
+}
+```
+
+- [ ] **Step 2: Build to verify compilation**
+
+Run: `swift build 2>&1 | tail -10`
+Expected: Build succeeds. The default `nil` means all existing call sites remain compatible.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/Models/NewSessionRequest.swift
+git commit -m "feat: add baseBranch to NewSessionRequest for fork worktree creation"
+```
+
+---
+
+### Task 3: Extract `buildAgentCommand` and fix restart
+
+**Files:**
+- Modify: `Sources/App/RunwayStore.swift:427-475` (startTmuxSession)
+- Modify: `Sources/App/RunwayStore.swift:498-548` (restartSession)
+
+- [ ] **Step 1: Add `buildAgentCommand` helper to RunwayStore**
+
+Add this private method in `RunwayStore`, before `startTmuxSession` (around line 426):
+
+```swift
+/// Builds the CLI command string for an agent session.
+/// Returns nil for shell sessions (tmux uses its default shell).
+private func buildAgentCommand(
+    session: Session,
+    profile: AgentProfile,
+    resume: Bool = false
+) -> String? {
+    guard profile.id != "shell" else { return nil }
+    var parts: [String] = []
+    if session.useHappy {
+        parts.append("happy")
+        parts.append(session.tool.command)
+    } else {
+        parts.append(profile.command)
+    }
+    parts.append(contentsOf: profile.arguments)
+    if resume {
+        parts.append(contentsOf: profile.resumeArguments)
+    }
+    if session.tool.supportsPermissionModes {
+        parts.append(contentsOf: session.permissionMode.cliFlags(for: session.tool))
+    }
+    return parts.joined(separator: " ")
+}
+```
+
+- [ ] **Step 2: Update `startTmuxSession` to use the helper**
+
+Replace the command construction block in `startTmuxSession` (lines 436-452) with:
+
+```swift
+let tmuxName = "runway-\(session.id)"
+let profile = profileForSession(session)
+let toolCommand = buildAgentCommand(session: session, profile: profile, resume: false)
+```
+
+Remove the old `let profile`, `let toolCommand`, `if profile.id == "shell"` block, and the `var parts` block that follows. Keep everything else (the `tmuxManager.createSession` call and below).
+
+- [ ] **Step 3: Update `restartSession` to use the helper with resume**
+
+Replace the command construction block in `restartSession` (lines 517-528) with:
+
+```swift
+let profile = profileForSession(session)
+let toolCommand = buildAgentCommand(session: session, profile: profile, resume: true)
+```
+
+Remove the old `if profile.id == "shell"` / `else` block.
+
+- [ ] **Step 4: Build to verify compilation**
+
+Run: `swift build 2>&1 | tail -10`
+Expected: Build succeeds.
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `swift test 2>&1 | tail -20`
+Expected: All tests pass. This is a refactor with no behavioral change to testable units — the command construction is verified via integration (tmux launch).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/App/RunwayStore.swift
+git commit -m "refactor: extract buildAgentCommand helper, fix restart dropping useHappy"
+```
+
+---
+
+### Task 4: Pass `baseBranch` through `handleNewSessionRequest`
+
+**Files:**
+- Modify: `Sources/App/RunwayStore.swift:352-424` (handleNewSessionRequest)
+
+- [ ] **Step 1: Update `handleNewSessionRequest` to use `baseBranch`**
+
+In `handleNewSessionRequest`, change the `baseBranch` resolution (line 390) from:
+
+```swift
+let baseBranch = project?.defaultBranch ?? "main"
+```
+
+to:
+
+```swift
+let baseBranch = request.baseBranch ?? project?.defaultBranch ?? "main"
+```
+
+This single-line change makes forks use the source session's branch as the base.
+
+- [ ] **Step 2: Build to verify**
+
+Run: `swift build 2>&1 | tail -10`
+Expected: Build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/App/RunwayStore.swift
+git commit -m "feat: support custom baseBranch in handleNewSessionRequest for forks"
+```
+
+---
+
+### Task 5: Add fork state and `forkSession` to RunwayStore
+
+**Files:**
+- Modify: `Sources/Views/Sidebar/ProjectTreeView.swift:11-25` (SidebarActions protocol)
+- Modify: `Sources/App/RunwayStore.swift:39-59` (state properties)
+- Modify: `Sources/App/RunwayStore.swift:1545-1552` (SidebarActions conformance)
+
+- [ ] **Step 1: Add `forkSession` to SidebarActions protocol**
+
+In `Sources/Views/Sidebar/ProjectTreeView.swift`, add to the protocol (after `restartSession`):
+
+```swift
+func forkSession(id: String)
+```
+
+- [ ] **Step 2: Add fork pre-population state to RunwayStore**
+
+In `Sources/App/RunwayStore.swift`, add after `newSessionParentID` (around line 42):
+
+```swift
+var forkSourceSession: Session?
+```
+
+- [ ] **Step 3: Implement `forkSession` in RunwayStore's SidebarActions conformance**
+
+In the `SidebarActions` conformance extension (after `newSession`), add:
+
+```swift
+public func forkSession(id: String) {
+    guard let session = sessions.first(where: { $0.id == id }),
+          session.worktreeBranch != nil
+    else { return }
+    forkSourceSession = session
+    newSessionProjectID = session.projectID
+    newSessionParentID = session.id
+    showNewSessionDialog = true
+}
+```
+
+- [ ] **Step 4: Build to verify**
+
+Run: `swift build 2>&1 | tail -10`
+Expected: Build succeeds.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/Views/Sidebar/ProjectTreeView.swift Sources/App/RunwayStore.swift
+git commit -m "feat: add forkSession to SidebarActions and RunwayStore"
+```
+
+---
+
+### Task 6: Pre-populate NewSessionDialog for forks
+
+**Files:**
+- Modify: `Sources/Views/Shared/NewSessionDialog.swift:50-67` (init)
+- Modify: `Sources/Views/Shared/NewSessionDialog.swift:159-162` (onAppear)
+- Modify: `Sources/Views/Shared/NewSessionDialog.swift:436-459` (createNormalSession)
+- Modify: `Sources/App/RunwayApp.swift:147-161` (sheet presentation)
+
+- [ ] **Step 1: Add fork parameters to NewSessionDialog init**
+
+In `Sources/Views/Shared/NewSessionDialog.swift`, add a new stored property and init parameter:
+
+Add property after `selectedTemplateID`:
+```swift
+let forkSource: Session?
+```
+
+Update `init` — add parameter with default `nil` (after `templates`):
+```swift
+public init(
+    projects: [Project],
+    profiles: [AgentProfile] = AgentProfile.builtIn,
+    initialProjectID: String? = nil,
+    parentID: String? = nil,
+    templates: [SessionTemplate] = [],
+    forkSource: Session? = nil,
+    onCreate: @escaping (NewSessionRequest) -> Void,
+    onCreateReview: ((ReviewSessionRequest) async throws -> Void)? = nil
+) {
+    self.projects = projects
+    self.profiles = profiles
+    self.initialProjectID = initialProjectID
+    self.parentID = parentID
+    self.templates = templates
+    self.forkSource = forkSource
+    self.onCreate = onCreate
+    self.onCreateReview = onCreateReview
+    self._selectedProjectID = State(initialValue: initialProjectID)
+}
+```
+
+- [ ] **Step 2: Pre-populate state from fork source on appear**
+
+Update the `.onAppear` block (line 159-162) to set fields from `forkSource`:
+
+```swift
+.onAppear {
+    permissionMode = defaultPermissionMode
+    if let source = forkSource {
+        title = "Fork of \(source.title)"
+        switch source.tool {
+        case .claude: selectedProfileID = "claude"
+        case .gemini: selectedProfileID = "gemini"
+        case .codex: selectedProfileID = "codex"
+        case .shell: selectedProfileID = "shell"
+        case .custom(let name): selectedProfileID = name
+        }
+        permissionMode = source.permissionMode
+        useHappy = source.useHappy
+        useWorktree = true
+        if let sourceBranch = source.worktreeBranch {
+            branchName = "\(sourceBranch)-fork"
+            branchManuallyEdited = true
+        }
+    }
+    titleFocused = true
+}
+```
+
+- [ ] **Step 3: Pass `baseBranch` from fork source in `createNormalSession`**
+
+Update the `NewSessionRequest` construction in `createNormalSession` (line 445-456) to include `baseBranch`:
+
+```swift
+let request = NewSessionRequest(
+    title: title,
+    projectID: selectedProjectID,
+    parentID: parentID,
+    path: path,
+    tool: selectedTool,
+    useWorktree: useWorktree,
+    branchName: useWorktree ? branchName : nil,
+    permissionMode: selectedTool.supportsPermissionModes ? permissionMode : .default,
+    useHappy: selectedTool.supportsHappy ? useHappy : false,
+    initialPrompt: (selectedTool.supportsInitialPrompt && !initialPrompt.isEmpty) ? initialPrompt : nil,
+    baseBranch: forkSource?.worktreeBranch
+)
+```
+
+- [ ] **Step 4: Pass fork state from RunwayApp to NewSessionDialog**
+
+In `Sources/App/RunwayApp.swift`, update the `NewSessionDialog` instantiation (line 147) to pass `forkSource`:
+
+```swift
+NewSessionDialog(
+    projects: store.projects,
+    profiles: store.agentProfiles.isEmpty ? AgentProfile.builtIn : store.agentProfiles,
+    initialProjectID: store.newSessionProjectID,
+    parentID: store.newSessionParentID,
+    templates: store.availableTemplates(forProjectID: store.newSessionProjectID),
+    forkSource: store.forkSourceSession,
+    onCreate: { request in
+        Task { await store.handleNewSessionRequest(request) }
+        store.newSessionProjectID = nil
+        store.newSessionParentID = nil
+        store.forkSourceSession = nil
+    },
+    onCreateReview: { request in
+        try await store.handleReviewSessionRequest(request)
+    }
+)
+```
+
+- [ ] **Step 5: Build to verify**
+
+Run: `swift build 2>&1 | tail -10`
+Expected: Build succeeds.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/Views/Shared/NewSessionDialog.swift Sources/App/RunwayApp.swift
+git commit -m "feat: pre-populate NewSessionDialog for fork sessions"
+```
+
+---
+
+### Task 7: Add fork context menu item to sidebar
+
+**Files:**
+- Modify: `Sources/Views/Sidebar/ProjectTreeView.swift:482-553` (contextMenu)
+
+- [ ] **Step 1: Add "Fork Session" context menu item**
+
+In `Sources/Views/Sidebar/ProjectTreeView.swift`, inside the `.contextMenu` block of `SessionRowView`, add after the "Spawn Sub-session" button (after line 493):
+
+```swift
+if session.worktreeBranch != nil {
+    Button {
+        actions.forkSession(id: session.id)
+    } label: {
+        Label("Fork Session", systemImage: "arrow.triangle.branch")
+    }
+}
+```
+
+- [ ] **Step 2: Build to verify**
+
+Run: `swift build 2>&1 | tail -10`
+Expected: Build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/Views/Sidebar/ProjectTreeView.swift
+git commit -m "feat: add Fork Session context menu item for worktree sessions"
+```
+
+---
+
+### Task 8: Add Happy and fork indicators to sidebar row
+
+**Files:**
+- Modify: `Sources/Views/Sidebar/ProjectTreeView.swift:362-476` (SessionRowView body)
+
+- [ ] **Step 1: Add fork icon next to session title**
+
+In `SessionRowView`, after the title `Text` (line 379), add a fork indicator:
+
+```swift
+if session.parentID != nil {
+    Image(systemName: "arrow.triangle.branch")
+        .font(.caption)
+        .foregroundStyle(.secondary)
+}
+```
+
+This goes inside the else branch of the `isRenaming` check, right after the `Text(session.title)` view, within the same `VStack`.
+
+Actually, looking at the layout, the title and fork icon should be in a horizontal grouping. Wrap the title text + fork icon in an `HStack`:
+
+Replace the `Text(session.title)` block (lines 377-379) with:
+
+```swift
+HStack(spacing: 4) {
+    Text(session.title)
+        .font(.system(.body, design: .default))
+        .foregroundStyle(.primary)
+    if session.parentID != nil {
+        Image(systemName: "arrow.triangle.branch")
+            .font(.caption2)
+            .foregroundStyle(.secondary)
+    }
+}
+```
+
+- [ ] **Step 2: Add Happy icon next to tool badge**
+
+In the non-hover tool badge area (lines 469-476), add a Happy indicator before the tool badge:
+
+Replace the existing tool badge block:
+
+```swift
+if !isHovered && session.tool != .claude {
+    Text(session.tool.displayName)
+        .font(.caption2)
+        .padding(.horizontal, 4)
+        .padding(.vertical, 1)
+        .background(theme.chrome.surface)
+        .clipShape(RoundedRectangle(cornerRadius: 4))
+}
+```
+
+with:
+
+```swift
+if !isHovered {
+    HStack(spacing: 4) {
+        if session.useHappy {
+            Image(systemName: "iphone")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+        }
+        if session.tool != .claude {
+            Text(session.tool.displayName)
+                .font(.caption2)
+                .padding(.horizontal, 4)
+                .padding(.vertical, 1)
+                .background(theme.chrome.surface)
+                .clipShape(RoundedRectangle(cornerRadius: 4))
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Build to verify**
+
+Run: `swift build 2>&1 | tail -10`
+Expected: Build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/Views/Sidebar/ProjectTreeView.swift
+git commit -m "feat: add fork and Happy indicators to sidebar session row"
+```
+
+---
+
+### Task 9: Add Happy and fork indicators to session header
+
+**Files:**
+- Modify: `Sources/Views/SessionDetail/SessionHeaderView.swift:31-147` (body)
+- Modify: `Sources/Views/SessionDetail/SessionHeaderView.swift:158-165` (badgeLabel)
+
+- [ ] **Step 1: Add `sessions` and `onSelectSession` parameters to SessionHeaderView**
+
+The header needs access to all sessions to resolve the parent session name for the "Forked from" label. Add parameters:
+
+```swift
+public struct SessionHeaderView: View {
+    let session: Session
+    var linkedPR: PullRequest?
+    var prDetail: PRDetail? = nil
+    var parentSession: Session? = nil
+    var onSelectPR: ((PullRequest) -> Void)?
+    var onSelectSession: ((String) -> Void)? = nil
+    var changesVisible: Bool = false
+    var onToggleChanges: (() -> Void)? = nil
+    @Environment(\.theme) private var theme
+
+    public init(
+        session: Session,
+        linkedPR: PullRequest? = nil,
+        prDetail: PRDetail? = nil,
+        parentSession: Session? = nil,
+        onSelectPR: ((PullRequest) -> Void)? = nil,
+        onSelectSession: ((String) -> Void)? = nil,
+        changesVisible: Bool = false,
+        onToggleChanges: (() -> Void)? = nil
+    ) {
+        self.session = session
+        self.linkedPR = linkedPR
+        self.prDetail = prDetail
+        self.parentSession = parentSession
+        self.onSelectPR = onSelectPR
+        self.onSelectSession = onSelectSession
+        self.changesVisible = changesVisible
+        self.onToggleChanges = onToggleChanges
+    }
+```
+
+- [ ] **Step 2: Extend the tool badge to include Happy**
+
+Update the `badgeLabel` computed property in the `PermissionMode` extension (line 159):
+
+```swift
+fileprivate var badgeLabel: String {
+    switch self {
+    case .default: "default"
+    case .acceptEdits: "accept-edits"
+    case .bypassAll: "bypass-all"
+    }
+}
+```
+
+No change needed here — instead, update the badge `Text` in the body (line 51) to insert "happy" when applicable:
+
+Replace:
+```swift
+Text("\(session.tool.displayName.lowercased()) · \(session.permissionMode.badgeLabel)")
+```
+
+with:
+```swift
+Text(toolBadgeText)
+```
+
+And add a computed property:
+
+```swift
+private var toolBadgeText: String {
+    var parts = [session.tool.displayName.lowercased()]
+    if session.useHappy {
+        parts.append("happy")
+    }
+    parts.append(session.permissionMode.badgeLabel)
+    return parts.joined(separator: " · ")
+}
+```
+
+Update the badge foreground/background to use cyan when Happy is active. Replace the badge colors (lines 53-56):
+
+```swift
+.foregroundColor(session.useHappy ? theme.chrome.cyan : session.permissionMode.badgeForeground(chrome: theme.chrome))
+.padding(.horizontal, 7)
+.padding(.vertical, 3)
+.background(session.useHappy ? theme.chrome.cyan.opacity(0.15) : session.permissionMode.badgeBackground(chrome: theme.chrome))
+```
+
+- [ ] **Step 3: Add "Forked from" line between title row and git row**
+
+In the body, after the Row 1 `HStack` closing brace and before the `if let branch = session.worktreeBranch` block, add:
+
+```swift
+// Fork origin label
+if let parent = parentSession {
+    HStack(spacing: 4) {
+        Image(systemName: "arrow.triangle.branch")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        Text("Forked from")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        Button {
+            onSelectSession?(parent.id)
+        } label: {
+            Text("\"\(parent.title)\"")
+                .font(.caption)
+                .foregroundStyle(theme.chrome.accent)
+        }
+        .buttonStyle(.plain)
+    }
+}
+```
+
+- [ ] **Step 4: Thread parentSession through SessionDetailView**
+
+`SessionDetailView` (`Sources/Views/SessionDetail/SessionDetailView.swift:7-64`) creates `SessionHeaderView` at line 68. Add `parentSession` and `onSelectSession` parameters to `SessionDetailView`:
+
+In the stored properties (after `onSelectPR`):
+```swift
+var parentSession: Session? = nil
+var onSelectSession: ((String) -> Void)? = nil
+```
+
+In `init` (after `onSelectPR`):
+```swift
+parentSession: Session? = nil,
+onSelectSession: ((String) -> Void)? = nil,
+```
+
+With assignments:
+```swift
+self.parentSession = parentSession
+self.onSelectSession = onSelectSession
+```
+
+Update the `SessionHeaderView` call inside `body` (line 68-75):
+```swift
+SessionHeaderView(
+    session: session,
+    linkedPR: linkedPR,
+    prDetail: prDetail,
+    parentSession: parentSession,
+    onSelectPR: onSelectPR,
+    onSelectSession: onSelectSession,
+    changesVisible: changesVisible,
+    onToggleChanges: onToggleChanges
+)
+```
+
+- [ ] **Step 5: Pass parentSession from RunwayApp**
+
+In `Sources/App/RunwayApp.swift:411`, update the `SessionDetailView` instantiation to pass the parent session. Add after the `prDetail` line (line 415):
+
+```swift
+parentSession: {
+    guard let parentID = session.parentID else { return nil }
+    return store.sessions.first(where: { $0.id == parentID })
+}(),
+onSelectSession: { id in store.selectSession(id) },
+```
+
+- [ ] **Step 6: Build to verify**
+
+Run: `swift build 2>&1 | tail -10`
+Expected: Build succeeds.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Sources/Views/SessionDetail/SessionHeaderView.swift Sources/Views/SessionDetail/SessionDetailView.swift Sources/App/RunwayApp.swift
+git commit -m "feat: add Happy badge and fork origin label to session header"
+```
+
+---
+
+### Task 10: Update existing test for JSON decoding without resumeArguments
+
+**Files:**
+- Modify: `Tests/ModelsTests/AgentProfileTests.swift:89-112`
+
+- [ ] **Step 1: Verify existing JSON decoding test still works**
+
+The existing `agentProfileJSONDecoding` test (line 89) uses JSON without `resumeArguments`. Since the init default is `[]`, this should still pass. Verify:
+
+Run: `swift test --filter agentProfileJSONDecoding 2>&1 | tail -10`
+Expected: Test passes (the `Codable` synthesis uses the init default for missing keys).
+
+- [ ] **Step 2: Check if Codable handles missing keys**
+
+Swift's `Codable` auto-synthesis does NOT skip missing keys — it requires all keys to be present in JSON. Since `AgentProfile` uses auto-synthesized `Codable`, we need a custom `init(from:)` that defaults missing `resumeArguments` to `[]`.
+
+Add a custom `Decodable` conformance. In `Sources/Models/AgentProfile.swift`, add after the existing `init`:
+
+```swift
+enum CodingKeys: String, CodingKey {
+    case id, name, command, arguments, runningPatterns, waitingPatterns
+    case idlePatterns, lineStartIdlePatterns, spinnerChars, resumeArguments
+    case hookEnabled, icon
+}
+
+public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    id = try container.decode(String.self, forKey: .id)
+    name = try container.decode(String.self, forKey: .name)
+    command = try container.decode(String.self, forKey: .command)
+    arguments = try container.decodeIfPresent([String].self, forKey: .arguments) ?? []
+    runningPatterns = try container.decodeIfPresent([String].self, forKey: .runningPatterns) ?? []
+    waitingPatterns = try container.decodeIfPresent([String].self, forKey: .waitingPatterns) ?? []
+    idlePatterns = try container.decodeIfPresent([String].self, forKey: .idlePatterns) ?? []
+    lineStartIdlePatterns = try container.decodeIfPresent([String].self, forKey: .lineStartIdlePatterns) ?? []
+    spinnerChars = try container.decodeIfPresent([String].self, forKey: .spinnerChars) ?? []
+    resumeArguments = try container.decodeIfPresent([String].self, forKey: .resumeArguments) ?? []
+    hookEnabled = try container.decodeIfPresent(Bool.self, forKey: .hookEnabled) ?? false
+    icon = try container.decodeIfPresent(String.self, forKey: .icon) ?? "terminal.fill"
+}
+```
+
+- [ ] **Step 3: Run all AgentProfile tests**
+
+Run: `swift test --filter AgentProfileTests 2>&1 | tail -20`
+Expected: All tests pass, including both JSON tests (with and without `resumeArguments`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/Models/AgentProfile.swift Tests/ModelsTests/AgentProfileTests.swift
+git commit -m "fix: add custom Decodable for AgentProfile to handle missing resumeArguments"
+```
+
+---
+
+### Task 11: Final integration test
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `swift test 2>&1 | tail -30`
+Expected: All 266+ tests pass.
+
+- [ ] **Step 2: Run full build**
+
+Run: `swift build 2>&1 | tail -10`
+Expected: Build succeeds with no warnings related to our changes.
+
+- [ ] **Step 3: Commit any remaining fixes if needed**
+
+If any tests fail, fix and commit. Otherwise, this task is a verification-only step.

--- a/docs/superpowers/specs/2026-04-09-restart-resume-fork-design.md
+++ b/docs/superpowers/specs/2026-04-09-restart-resume-fork-design.md
@@ -1,0 +1,194 @@
+# Restart Resume, Fork Session, and Happy Indicator
+
+**Date**: 2026-04-09
+**Status**: Approved
+**Branch**: `feature-restart-resume`
+
+## Overview
+
+Three related enhancements to Runway's session management:
+
+1. **Restart as Resume**: The restart button resumes the previous agent conversation (via `--continue`/`--resume` flags) instead of starting a fresh session.
+2. **Fork Session**: Create a new worktree from an existing session's branch, launching a fresh agent conversation with all code changes carried over.
+3. **Happy Indicator**: Visual indicator in sidebar and header when a session uses the Happy mobile wrapper, honored when forking and resuming.
+
+## Data Model Changes
+
+### AgentProfile — New Field
+
+Add `resumeArguments: [String]` to `AgentProfile`:
+
+| Profile | `resumeArguments` |
+|---------|-------------------|
+| Claude  | `["--continue"]`  |
+| Gemini  | `["--resume"]`    |
+| Codex   | `["--continue"]`  |
+| Shell   | `[]`              |
+
+This field is decoded from custom profile JSON files in `~/.runway/agents/`, so user-defined agents can specify their own resume flags. Defaults to `[]` if omitted.
+
+### NewSessionRequest — New Field
+
+Add `baseBranch: String?` to `NewSessionRequest`. When non-nil, the worktree is created from this branch instead of the project's default base branch. Used by the fork flow to branch from the source session's worktree branch.
+
+### Session Model — No Changes
+
+`parentID` already exists for fork relationships. `useHappy` already exists for the Happy toggle. No database migration needed.
+
+## Restart as Resume
+
+### Current Behavior
+
+`restartSession(id:)` in `RunwayStore`:
+1. Kills tmux session + shell tabs
+2. Clears terminal cache
+3. Recreates tmux session with `profile.command + profile.arguments + permissionFlags`
+4. Bug: ignores `session.useHappy` — restart drops the Happy wrapper
+
+### New Behavior
+
+1. Kill tmux session + shell tabs (unchanged)
+2. Clear terminal cache (unchanged)
+3. Recreate tmux session with resume arguments included
+
+Command construction:
+
+```
+[happy?] + profile.command + profile.arguments + profile.resumeArguments + permissionFlags
+```
+
+Examples:
+- Claude + Happy: `happy claude --continue --accept-edits`
+- Gemini: `gemini --resume`
+- Codex: `codex --no-alt-screen --continue`
+- Shell: `(default shell, no resume)`
+
+### Shared Command Builder
+
+Extract a `buildAgentCommand(session:profile:resume:)` helper used by both `startTmuxSession` and `restartSession`. This prevents the two paths from drifting apart (the `useHappy` bug is an example of such drift).
+
+```swift
+private func buildAgentCommand(
+    session: Session,
+    profile: AgentProfile,
+    resume: Bool = false
+) -> String? {
+    guard profile.id != "shell" else { return nil }
+    var parts: [String] = []
+    if session.useHappy {
+        parts.append("happy")
+        parts.append(session.tool.command)
+    } else {
+        parts.append(profile.command)
+    }
+    parts.append(contentsOf: profile.arguments)
+    if resume {
+        parts.append(contentsOf: profile.resumeArguments)
+    }
+    if session.tool.supportsPermissionModes {
+        parts.append(contentsOf: session.permissionMode.cliFlags(for: session.tool))
+    }
+    return parts.joined(separator: " ")
+}
+```
+
+`startTmuxSession` calls with `resume: false`, `restartSession` calls with `resume: true`.
+
+### Edge Cases
+
+- **Shell sessions**: `resumeArguments` is `[]`, no behavioral change.
+- **Custom agents with no resume support**: `resumeArguments` defaults to `[]`, behaves as fresh start.
+- **First launch with resume flag**: Claude's `--continue` starts a new session if nothing exists in that directory. Gemini and Codex behave similarly. Safe.
+
+## Fork Session
+
+### Trigger
+
+Context menu on any session with a worktree: "Fork Session" (`arrow.triangle.branch` icon). Disabled when `session.worktreeBranch == nil` — can't fork a non-worktree session.
+
+### Flow
+
+1. User right-clicks session -> "Fork Session"
+2. `forkSession(id:)` opens `NewSessionDialog` pre-populated with:
+   - **Title**: `"Fork of {original title}"`
+   - **Project**: same as source
+   - **Tool**: same as source
+   - **Permission mode**: same as source
+   - **Happy toggle**: same as source (`useHappy` inherited)
+   - **Worktree**: enabled, branch name auto-generated as `{source-branch}-fork` (editable). If that branch already exists, append a numeric suffix (`-fork-2`, `-fork-3`, etc.)
+   - **`parentID`**: set to source session's ID
+   - **`baseBranch`**: set to source session's `worktreeBranch`
+3. User can adjust any field, then clicks Create
+4. Normal `handleNewSessionRequest` runs — creates worktree branching from source session's branch (not the default base branch)
+5. Fresh agent conversation starts in the new worktree directory
+
+### Key Difference from Normal New Session
+
+The worktree's `baseBranch` is the source session's worktree branch, not `main`/`master`. The forked worktree starts with all code changes from the source session.
+
+### Changes
+
+- **`NewSessionRequest`**: Add `baseBranch: String?` field
+- **`handleNewSessionRequest`**: Pass `baseBranch` to `worktreeManager.createWorktree()` when non-nil
+- **`SidebarActions`**: Add `forkSession(id: String)` method
+- **`RunwayStore`**: Implement `forkSession` — opens dialog with pre-populated values
+- **`ProjectTreeView`**: Add context menu item, gated on `worktreeBranch != nil`
+
+### Non-Worktree Sessions
+
+Fork is disabled for non-worktree sessions. There's no isolated branch to fork from. Users can create a new worktree session from the project instead.
+
+## UI Indicators
+
+### Sidebar Row
+
+**Happy indicator**: When `session.useHappy == true`, show a small `iphone` SF Symbol icon next to the tool badge. Same area as existing tool badge (non-hover zone). `caption2` styling, secondary color.
+
+**Fork indicator**: When `session.parentID != nil`, show `arrow.triangle.branch` SF Symbol icon next to the title. Secondary color, matching branch name styling.
+
+Sidebar row layout for a forked Happy session:
+```
+[status] Session Title  [fork-icon]
+         feature/my-fork
+         Last activity text...
+                                    [phone-icon] [Gemini CLI]
+```
+
+### Header
+
+**Tool badge**: Extend the existing `"tool . mode"` badge to include Happy:
+- Normal: `"claude . accept edits"`
+- With Happy: `"claude . happy . accept edits"`
+- The "happy" segment uses accent/teal color to stand out
+
+**Fork label**: When `session.parentID != nil`, add a line below the title row:
+```
+[fork-icon] Forked from "Parent Session Name"
+```
+Caption font, secondary color. Parent name is clickable (calls `selectSession(parentID)`). If the parent has been deleted (cascade sets `parentID` to nil), this line does not appear.
+
+Full header layout for a forked Happy session:
+```
+[status] My Forked Session   Running   [claude . happy . accept edits]
+         [fork-icon] Forked from "Original Session"
+         [branch] feature/my-fork  <-  main
+```
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `Sources/Models/AgentProfile.swift` | Add `resumeArguments` field, populate for built-ins |
+| `Sources/Models/NewSessionRequest.swift` | Add `baseBranch: String?` field |
+| `Sources/App/RunwayStore.swift` | Extract `buildAgentCommand`, update `restartSession` to use resume args + fix Happy bug, implement `forkSession`, update `handleNewSessionRequest` to pass `baseBranch` |
+| `Sources/Views/Sidebar/ProjectTreeView.swift` | Add fork context menu item, fork icon on `parentID != nil` rows, Happy icon on `useHappy` rows, add `forkSession` to `SidebarActions` protocol |
+| `Sources/Views/SessionDetail/SessionHeaderView.swift` | Add "Forked from" label, extend tool badge with Happy segment |
+| `Sources/Views/Shared/NewSessionDialog.swift` | Accept pre-populated fork values, expose `baseBranch` |
+| `Tests/` | Update AgentProfile tests for new field, add fork flow tests |
+
+## Out of Scope
+
+- Interactive session picker (Claude's `--resume` with picker) — Runway manages sessions itself
+- Forking non-worktree sessions
+- Forking conversation context into the new worktree (agent sessions are directory-scoped)
+- Changes to the `Session` model or database schema


### PR DESCRIPTION
## Summary

- **Restart = Resume**: Restart button now resumes the previous agent conversation using `--continue` (Claude/Codex) or `--resume` (Gemini) instead of starting fresh. Also fixes a bug where restart dropped the Happy wrapper.
- **Fork Session**: Right-click context menu on worktree sessions to fork — creates a new worktree from the source branch with all code changes, inheriting tool, permissions, and Happy toggle. Pre-populates the new session dialog.
- **Happy Indicator**: `iphone` icon in sidebar row and cyan "happy" segment in header tool badge when a session uses the Happy mobile wrapper.
- **Fork Indicator**: `arrow.triangle.branch` icon in sidebar, clickable "Forked from" label in header linking back to parent session.

### Technical changes
- Added `resumeArguments` to `AgentProfile` (extensible for custom agents via JSON)
- Extracted shared `buildAgentCommand` helper to prevent restart/launch drift
- Added `baseBranch` to `NewSessionRequest` for fork worktree creation
- Added `forkSession` to `SidebarActions` protocol
- 8 new tests, 273 total passing

## Test plan
- [ ] Restart a Claude session — verify it resumes the previous conversation (--continue)
- [ ] Restart a Gemini session — verify --resume flag is used
- [ ] Restart a session with Happy — verify happy claude --continue command
- [ ] Fork a worktree session — verify new worktree branches from source branch
- [ ] Fork dialog pre-populates tool, permissions, Happy, branch name
- [ ] Cancel fork dialog, then open normal New Session — verify no stale fork state
- [ ] Happy indicator visible in sidebar and header for Happy sessions
- [ ] Fork indicator visible in sidebar and header for forked sessions
- [ ] Click Forked from label in header — navigates to parent session
- [ ] Shell sessions restart normally (no resume flag)
- [ ] swift test — all 273 tests pass