### PR TITLE
fix: 43 bugs from pre-1.0.0 bug hunt

### DIFF
--- a/BUG_HUNT_REPORT.md
+++ b/BUG_HUNT_REPORT.md
@@ -1,0 +1,339 @@
+# Runway 1.0.0 Pre-Release Bug Hunt Report
+
+**Date**: 2026-04-09
+**Audited by**: 8 parallel subagents (2 Swift experts, 2 macOS design experts, 2 terminal/tmux experts, 2 general bug hunters)
+**Scope**: Full codebase — all 11 SPM targets
+
+## Executive Summary
+
+| Severity | Count | Confidence |
+|----------|-------|------------|
+| Critical | 6 | Multi-agent corroboration on top findings |
+| High | 10 | Strong evidence, clear impact |
+| Medium | 16 | Real bugs with limited blast radius |
+| Low | 15 | Edge cases, polish, minor UX |
+| **Total** | **47** | Deduplicated from ~95 raw findings |
+
+The most impactful cluster is in **StatusDetection** — the ANSI stripping state machine has 3 distinct bugs that compound to make buffer-based status detection unreliable, and the cache key mismatch means it was never actually working. The second cluster is in **process lifecycle** — ShellRunner and PTYProcess both have race conditions around process termination that can hang or crash the app.
+
+---
+
+## Critical (6)
+
+### C1. TerminalSessionCache key mismatch — buffer detection and SendTextBar silently broken
+**Found by**: 4/8 agents | **Confidence**: Very High
+
+- **Files**: `Sources/TerminalView/TerminalSessionCache.swift:76`, `Sources/Views/SessionDetail/TerminalTabView.swift:245`
+- **Description**: `mainTerminal(forSessionID:)` looks up key `"{id}_{id}_main"` but the actual cache key is `"{id}_{id}_main_{restartTrigger}"`. Even with trigger=0, the stored key is `"X_X_main_0"` while lookup expects `"X_X_main"`. These **never match**.
+- **Impact**: Two features are completely non-functional:
+  1. **SendTextBar** (Cmd+Shift+X) silently drops all user input
+  2. **Buffer-based status polling** always returns nil — the entire fallback detection path is dead code
+- **Fix**: Remove `_\(terminalRestartTrigger)` from the main tab ID, or change `mainTerminal` to use prefix matching
+
+### C2. ShellRunner continuation race — process can hang indefinitely
+**Found by**: 3/8 agents | **Confidence**: Very High
+
+- **File**: `Sources/Models/ShellRunner.swift:101-119`
+- **Description**: `terminationHandler` is set *after* `process.run()`. If the process terminates before the handler is assigned (common for instant failures like bad path, missing tool), the continuation is never resumed. The calling Task hangs forever.
+- **Impact**: Any `gh`, `git`, or `tmux` command that exits instantly can permanently deadlock the calling actor (`PRManager`, `WorktreeManager`, or `TmuxSessionManager`), freezing all operations in that subsystem.
+- **Fix**: Set `terminationHandler` before calling `process.run()`
+
+### C3. HookServer continuation never resumed on `.cancelled` — app hangs on startup
+**Found by**: 2/8 agents | **Confidence**: High
+
+- **File**: `Sources/StatusDetection/HookServer.swift:62-76`
+- **Description**: The NWListener `stateUpdateHandler` only handles `.ready` and `.failed`. If the listener transitions to `.cancelled` (e.g., concurrent `stop()` call), the `CheckedContinuation` is never resumed. Debug builds crash with "leaked continuation"; release builds hang indefinitely.
+- **Impact**: Hook server initialization permanently hangs, blocking hook injection and all hook-based status detection
+- **Fix**: Handle `.cancelled` state by resuming the continuation with an error
+
+### C4. No hook cleanup on app termination — 5-second agent delays after quit
+**Found by**: 1/8 agents | **Confidence**: High
+
+- **Files**: `Sources/App/RunwayStore.swift` (no termination handler), `Sources/App/RunwayApp.swift` (no lifecycle handling)
+- **Description**: When Runway quits, injected hooks remain in `~/.claude/settings.json` (and gemini/codex configs) pointing at the dead port. There is no `NSApplication.willTerminate` handler to remove them.
+- **Impact**: Every Claude Code hook event (SessionStart, UserPromptSubmit, PermissionRequest, etc.) blocks for up to 5 seconds hitting the dead port. This persists until Runway is relaunched. Affects **every user** between app restarts.
+- **Fix**: Add an `NSApplication.willTerminate` observer that calls `hookInjector.remove(config:)` for each config
+
+### C5. PTYProcess missing `deinit` — dispatch source deallocation crash
+**Found by**: 1/8 agents | **Confidence**: High
+
+- **File**: `Sources/Terminal/PTYProcess.swift` (entire class, no deinit)
+- **Description**: `readSource` and `processSource` (DispatchSources) are resumed but never cancelled if the PTYProcess is simply deallocated without calling `terminate()`. Deallocating a resumed, non-cancelled DispatchSource is undefined behavior and crashes the process.
+- **Impact**: App crash if any code path releases a PTYProcess reference without first calling terminate(). Currently PTYProcess is not used in production (NativePTY uses tmux), but it's compiled public API.
+- **Fix**: Add `deinit { handleExit() }` to cancel dispatch sources before deallocation
+
+### C6. PTYProcess treats EAGAIN as EOF — spurious session termination
+**Found by**: 1/8 agents | **Confidence**: High
+
+- **File**: `Sources/Terminal/PTYProcess.swift:126-132`
+- **Description**: The read handler treats all `bytesRead <= 0` identically. When `read()` returns -1 with `errno == EAGAIN` (spurious dispatch source wakeup), the code calls `handleExit()`, tearing down the entire PTY session.
+- **Impact**: Under memory pressure or kernel scheduling, a spurious wakeup kills the user's terminal session for no apparent reason
+- **Fix**: Check `errno` and only call `handleExit()` for true EOF (bytesRead == 0) or real errors (not EAGAIN/EINTR)
+
+---
+
+## High (10)
+
+### H1. ANSI stripper: OSC String Terminator (ESC \) not handled — text consumed after OSC sequences
+**Found by**: 1/8 agents
+
+- **File**: `Sources/StatusDetection/StatusDetector.swift:116-124`
+- **Description**: After an OSC sequence, the ST terminator (ESC + `\`) causes the state machine to enter `.escSeen` then fall through to `.inCSI` mode, consuming all subsequent real text until a letter is found
+- **Impact**: Terminal title-setting sequences (`ESC]0;title ESC\`) corrupt the stripped output, causing missed status transitions
+- **Fix**: Handle `\` in `.escSeen` state as ST terminator, transition back to `.normal`
+
+### H2. ANSI stripper: CSI terminator misses valid final bytes (@, `, etc.)
+**Found by**: 4/8 agents
+
+- **File**: `Sources/StatusDetection/StatusDetector.swift:113`
+- **Description**: CSI final bytes per ECMA-48 are 0x40-0x7E, but only letters and `~` are checked. Characters like `@` (Insert Character), `` ` `` (HPA) cause the parser to stay in CSI mode, eating real text
+- **Impact**: CSI sequences with non-letter terminators leave the parser stuck, corrupting status detection input
+- **Fix**: Replace ad-hoc checks with `scalar.value >= 0x40 && scalar.value <= 0x7E`
+
+### H3. PR detail drawer cannot be closed in ProjectPRsTab
+**Found by**: 2/8 agents
+
+- **File**: `Sources/Views/ProjectPage/ProjectPRsTab.swift:115`
+- **Description**: The `onClose` handler is `{ onSelectPR(pr) }` — this re-selects the current PR instead of deselecting. Compare with `PRDashboardView` which correctly passes `nil`
+- **Impact**: Users cannot close the PR detail drawer on the project page. The X button does nothing.
+- **Fix**: Change to pass a deselection callback (requires making the callback accept `PullRequest?`)
+
+### H4. deleteSession force-deletes unmerged branches without warning
+**Found by**: 3/8 agents
+
+- **Files**: `Sources/App/RunwayStore.swift:606`, `Sources/GitOperations/WorktreeManager.swift:124-130`
+- **Description**: `removeWorktree` unconditionally uses `git branch -D` (force delete). The orphan cleanup logic correctly checks `isBranchMerged` first, but explicit session deletion does not.
+- **Impact**: Users permanently lose unmerged commits when deleting a session with worktree cleanup. No confirmation, no recovery.
+- **Fix**: Check `isBranchMerged` before deleting, or use `git branch -d` (safe delete), or add a confirmation dialog
+
+### H5. handleReviewPR continues after worktree failure — review runs on wrong branch
+**Found by**: 2/8 agents
+
+- **File**: `Sources/App/RunwayStore.swift:1503-1524`
+- **Description**: If worktree checkout fails, the error is caught and shown, but execution continues. The session starts with `sessionPath = project.path` (the main repo, not a worktree). Compare with `handleNewSessionRequest` which correctly sets `.error` and returns.
+- **Impact**: The agent reviews code on whatever branch the main repo is on, not the PR branch. The user gets misleading review feedback.
+- **Fix**: Set session to `.error` status and return early, matching `handleNewSessionRequest` behavior
+
+### H6. Database nil silently swallows all writes — complete data loss scenario
+**Found by**: 2/8 agents
+
+- **File**: `Sources/App/RunwayStore.swift:132-142, 109`
+- **Description**: If the database fails to open, `database` is nil. All 30+ call sites use `try? database?.` which silently becomes a no-op. The user sees the app working but nothing persists.
+- **Impact**: All sessions, project changes, and templates are lost on next app launch. The one-time error toast is easily missed.
+- **Fix**: Show a persistent error banner, disable session creation, or retry database opening
+
+### H7. PR conversation tab shows inline comments twice
+**Found by**: 2/8 agents
+
+- **File**: `Sources/Views/PRDashboard/PRDetailDrawer.swift:631-678`
+- **Description**: Inline comments (with `path != nil`) are rendered in a dedicated "Inline Comments" section, then included again in the timeline (line 667 doesn't filter them out)
+- **Impact**: Every inline review comment is duplicated, cluttering the conversation view
+- **Fix**: Filter timeline: `comments.filter { $0.path == nil }.map { .comment($0) }`
+
+### H8. PR detail drawer tab shortcuts displayed but not functional
+**Found by**: 2/8 agents
+
+- **File**: `Sources/Views/PRDashboard/PRDetailDrawer.swift:369-397`
+- **Description**: Tab bar shows `^1`, `^2`, `^3`, `^4` hints but no `.keyboardShortcut()` modifier is attached. `IssueDetailDrawer` has them correctly.
+- **Impact**: Broken affordance — users see shortcuts that don't work
+- **Fix**: Add `.keyboardShortcut(KeyEquivalent(Character("\(index + 1)")), modifiers: .control)`
+
+### H9. HookServer connection leak on teardown
+**Found by**: 1/8 agents
+
+- **File**: `Sources/StatusDetection/HookServer.swift:101-141`
+- **Description**: `accumulateRequest` uses `[weak self]`. If the HookServer actor is deallocated while a connection is mid-accumulation, `self` becomes nil but the NWConnection is never cancelled, leaking resources.
+- **Impact**: During rapid hook server restarts (port fallback), in-flight connections leak file descriptors
+- **Fix**: Add `guard let self else { connection.cancel(); return }` at the start
+
+### H10. Status detection pattern overlap — idle sessions shown as waiting
+**Found by**: 1/8 agents
+
+- **File**: `Sources/Models/AgentProfile.swift:110, 116`
+- **Description**: `waitingPatterns` includes `"What would you like"` which is a substring of `idlePatterns` entry `"What would you like to do"`. Waiting patterns are checked first, so idle sessions get misclassified.
+- **Impact**: Spurious notifications, inflated dock badge count, sessions shown as needing attention when idle
+- **Fix**: Use more specific waiting pattern like `"What would you like to change"`, or check idle patterns first
+
+---
+
+## Medium (16)
+
+### M1. HookServer blocks actor for handler dispatch before HTTP response
+- **File**: `Sources/StatusDetection/HookServer.swift:143-166`
+- Could cause Claude Code hook timeouts (5s) during heavy UI work
+- **Fix**: Send 200 OK before dispatching to handlers
+
+### M2. deleteProject fires concurrent worktree removals that race on git locks
+- **File**: `Sources/App/RunwayStore.swift:668-677`
+- Fire-and-forget Tasks for each session cause concurrent `git worktree remove` calls that fail
+- **Fix**: Remove worktrees serially, or batch cleanup after DB operations
+
+### M3. loadCachedPRs called twice during init — overwrites fresh data with stale cache
+- **File**: `Sources/App/RunwayStore.swift:166, 248`
+- Second call after `fetchPRs()` overwrites fresh data with older cache
+- **Fix**: Remove the second `loadCachedPRs()` call at line 248
+
+### M4. Concurrent enrichPRs and fetchPRs can overwrite each other's data
+- **File**: `Sources/App/RunwayStore.swift:985, 1032-1037`
+- Enrichment from previous cycle can overwrite newer fetch results
+- **Fix**: Cancel in-flight enrichment when starting new fetch, or use generation counter
+
+### M5. DiffView multi-file: all files start collapsed with no visible content
+- **File**: `Sources/Views/Shared/DiffView.swift:13, 55`
+- User sees only file headers, must manually expand each file
+- **Fix**: Initialize `expandedFiles` with all paths, or auto-expand for small diffs
+
+### M6. CheckRun uses `name` as Identifiable `id` — duplicates in CI matrix builds
+- **File**: `Sources/Models/PullRequest.swift:168-180`
+- Matrix builds produce multiple runs with the same name, causing SwiftUI rendering issues
+- **Fix**: Use a unique ID (combination of name + status, or UUID suffix)
+
+### M7. Diff parser drops empty lines from patches
+- **File**: `Sources/Views/PRDashboard/PRDetailDrawer.swift:567-606`, `Sources/Views/Shared/DiffView.swift:186-233`
+- Empty context lines without leading space fall through all conditions
+- **Fix**: Add else clause treating unrecognized lines as context
+
+### M8. sanitizeBranchName can produce collisions for similar session titles
+- **File**: `Sources/GitOperations/WorktreeManager.swift:229-245`
+- `"Feature/My Branch"` and `"feature-my-branch"` sanitize to the same name
+- **Fix**: Append short unique suffix from session ID
+
+### M9. flock() return value not checked — lock may not be acquired
+- **File**: `Sources/StatusDetection/HookInjector.swift:296-305`
+- Found by 3/8 agents. Lock failure falls through to unprotected execution
+- **Fix**: Check return value, log warning or retry
+
+### M10. Collapsed directory node uses incorrect fullPath in buildFileTree
+- **File**: `Sources/Models/FileChange.swift:114`
+- Collapsed chain's `fullPath` only has first level, causing potential SwiftUI identity conflicts
+- **Fix**: Set `fullPath` to the child's full collapsed path
+
+### M11. Hex color parser wrong for 3-digit CSS-style hex notation
+- **File**: `Sources/Theme/ThemeFile.swift:75-80`
+- `"F00"` (red shorthand) parses as `r=0, g=15, b=0` — completely wrong
+- **Fix**: Detect 3/4-digit hex and expand before parsing
+
+### M12. CheckForUpdatesViewModel recreated on every view rebuild
+- **File**: `Sources/App/UpdaterController.swift:44-51`
+- `@ObservedObject` in init doesn't own lifecycle; creates/destroys Combine subscription per menu open
+- **Fix**: Change to `@StateObject` or `@State` + `@Observable`
+
+### M13. Search buttons disabled after editing text following "not found"
+- **File**: `Sources/TerminalView/TerminalSearchBar.swift:57-61`
+- `searchState` stays `.notFound` when text changes, disabling buttons
+- **Fix**: Reset `searchState` to `.idle` on any text change
+
+### M14. Search highlights persist when search bar hidden via Cmd+F toggle
+- **File**: `Sources/TerminalView/TerminalSearchBar.swift:120-125`
+- Cmd+F toggle bypasses `dismiss()` which calls `clearSearch()`
+- **Fix**: Add `onDisappear` that clears search, or route Cmd+F through dismiss
+
+### M15. Settings window missing `.theme()` environment modifier
+- **File**: `Sources/App/RunwayApp.swift:92-95`
+- Settings may show light/dark mode mismatch with main window
+- **Fix**: Add `.theme(store.themeManager.currentTheme)` and `.preferredColorScheme()`
+
+### M16. enrichPath() blocks main thread with synchronous waitUntilExit()
+- **File**: `Sources/Models/ShellRunner.swift:49`
+- Called from `RunwayApp.init()`, blocks app launch if shell config is slow
+- **Fix**: Add timeout (3s) and fallback to hardcoded paths, or run async
+
+---
+
+## Low (15)
+
+### L1. ResizableDivider cursor push/pop imbalance on rapid hover
+- `Sources/Views/Shared/ResizableDivider.swift:20-26` — Resize cursor can "stick"
+
+### L2. ProjectPageView editableProject can become stale while settings sheet is open
+- `Sources/Views/ProjectPage/ProjectPageView.swift:57, 246-261` — External changes overwrite unsaved edits
+
+### L3. ProjectSettingsSheet fixed height may clip with many templates
+- `Sources/Views/Settings/ProjectSettingsSheet.swift:169` — Use `minHeight` instead of fixed height
+
+### L4. SettingsView font picker recomputes grouped fonts on every render
+- `Sources/Views/Settings/SettingsPlaceholder.swift:122` — Cache in `@State` or compute in `onAppear`
+
+### L5. NewIssueSheet allows whitespace-only titles
+- `Sources/Views/ProjectPage/NewIssueSheet.swift:185-190` — Trim title before `onCreate`
+
+### L6. PRDashboardView onAppear calls onRefresh unconditionally
+- `Sources/Views/PRDashboard/PRDashboardView.swift:305` — Unnecessary fetch on every tab switch
+
+### L7. requestChangesText/sheetCommentText not cleared on sheet cancel
+- `Sources/Views/PRDashboard/PRDetailDrawer.swift:217, 239` — Old text reappears on reopen
+
+### L8. PRReview with nil submittedAt sorts to beginning of timeline
+- `Sources/Views/PRDashboard/PRDetailDrawer.swift:621-622` — Use `Date()` instead of `.distantPast`
+
+### L9. Issue comment submission shows no success feedback
+- `Sources/App/RunwayStore.swift:1406-1413` — Other actions show toasts, this one doesn't
+
+### L10. IssueDetailDrawer Ctrl+N shortcuts are global, not scoped to drawer
+- `Sources/Views/ProjectPage/IssueDetailDrawer.swift:247` — Fire from anywhere in the app
+
+### L11. Shared `hideDrafts` AppStorage key creates cross-context coupling
+- `Sources/Views/PRDashboard/PRDashboardView.swift:27` — Global and per-project toggle linked
+
+### L12. Status toast auto-dismiss can clear a newer identical message
+- `Sources/App/RunwayApp.swift:226-233` — Duplicate success messages silently dropped
+
+### L13. ThemeManager selectedThemeID not updated during system auto-switch
+- `Sources/Theme/ThemeManager.swift:50-76` — Checkmark on wrong theme in settings
+
+### L14. Accessibility: sidebar action buttons hidden from VoiceOver when not hovered
+- `Sources/Views/Sidebar/ProjectTreeView.swift:474-475` — `allowsHitTesting(false)` removes from a11y tree
+
+### L15. Accessibility: ProjectSection chevron uses onTapGesture instead of Button
+- `Sources/Views/Sidebar/ProjectTreeView.swift:219-229` — Not keyboard/VoiceOver accessible
+
+---
+
+## Additional Notes (not bugs, but worth tracking)
+
+These were flagged by agents but are either currently unreachable code, informational, or extremely unlikely:
+
+| Item | Notes |
+|------|-------|
+| **GhosttyVTTerminal leaks renderState** | Excluded from build, only matters when ghostty is enabled |
+| **TerminalKeyEventMonitor is dead code** | Never started — may indicate missing keyboard event forwarding |
+| **PTYProcess EOF/processSource race** | Zombie processes if read source fires before process exits |
+| **PTYProcess PID reuse on SIGKILL** | Extremely unlikely but theoretically possible |
+| **GraphQL variable interpolation in toggleDraft** | GitHub node IDs don't contain quotes in practice |
+| **gh auth status parsing on old CLI** | Only affects pre-2.40 gh versions |
+| **HookInjector TOML prefix matching** | Could match `codex_hooks_v2` when looking for `codex_hooks` |
+| **Multiple windows share mutable singleton state** | App is single-window by intent but doesn't enforce it |
+| **baseBranch unnecessarily sanitized** | Works due to fallback but adds latency |
+| **Database v3 migration drop/rename window** | GRDB wraps in transaction, safe in practice |
+| **Temp file accumulation from image drag-and-drop** | macOS cleans temp dir periodically |
+
+---
+
+## Recommended Priority for GitHub Issues
+
+### Must-fix for 1.0.0
+1. **C1** — TerminalSessionCache key mismatch (SendTextBar + buffer detection broken)
+2. **C2** — ShellRunner continuation race (can deadlock any actor)
+3. **C4** — No hook cleanup on quit (affects every user between restarts)
+4. **H1+H2** — ANSI stripping bugs (3 issues, fix together — status detection unreliable)
+5. **H3** — PR detail drawer can't close in project page
+6. **H5** — PR review on wrong branch after worktree failure
+7. **H10** — Status pattern overlap (idle shown as waiting)
+
+### Should-fix for 1.0.0
+8. **C3** — HookServer continuation on .cancelled
+9. **H4** — Force-delete unmerged branches
+10. **H6** — Database nil data loss scenario
+11. **H7** — Duplicate PR comments
+12. **H8** — PR drawer tab shortcuts broken
+13. **M1** — HookServer response before dispatch
+14. **M5** — DiffView files start collapsed
+15. **M13** — Search buttons disabled after failed search
+16. **M16** — enrichPath blocks main thread
+
+### Nice-to-have for 1.0.0
+17. **M3** — loadCachedPRs double-call
+18. **M6** — CheckRun duplicate IDs
+19. **M9** — flock return value
+20. **M11** — Hex color parser
+21. **L14+L15** — Accessibility issues

--- a/Sources/App/RunwayApp.swift
+++ b/Sources/App/RunwayApp.swift
@@ -92,6 +92,8 @@ struct RunwayApp: App {
         Settings {
             SettingsView(updater: updaterController.updater)
                 .environment(store.themeManager)
+                .theme(store.themeManager.currentTheme)
+                .preferredColorScheme(store.themeManager.currentTheme.appearance == .dark ? .dark : .light)
         }
 
         MenuBarExtra {
@@ -407,6 +409,7 @@ struct ContentView: View {
                     onReviewPR: { pr in store.reviewPR(pr) },
                     onEnableAutoMergePR: { pr, strategy in Task { await store.enableAutoMerge(pr, strategy: strategy) } },
                     onDisableAutoMergePR: { pr in Task { await store.disableAutoMerge(pr) } },
+                    onDeselectPR: { Task { await store.selectPR(nil, navigate: false) } },
                     onUpdateProject: { store.updateProjectSettings($0) },
                     onDetectRepo: { await store.detectGHRepo(for: project) },
                     onFetchLabels: { Task { await store.fetchLabels(forProject: projectID) } },

--- a/Sources/App/RunwayStore.swift
+++ b/Sources/App/RunwayStore.swift
@@ -31,6 +31,7 @@ public final class RunwayStore {
     var isLoadingPRs: Bool = false
     private var prPollTask: Task<Void, Never>?
     private var sessionPRPollTask: Task<Void, Never>?
+    private var enrichPRsTask: Task<Void, Never>?
     private var lastPRFingerprint: PRFingerprint?
     /// Per-session PR fetch timestamps — mirrors Hangar's sessionFetched map with 60s TTL.
     private var sessionPRFetchedAt: [String: Date] = [:]
@@ -167,6 +168,17 @@ public final class RunwayStore {
 
         // Start buffer-based status detection for sessions without hook events
         startBufferDetection()
+
+        // Remove injected hooks on app termination so agents don't block on a dead port
+        NotificationCenter.default.addObserver(
+            forName: NSApplication.willTerminateNotification,
+            object: nil,
+            queue: .main
+        ) { [hookInjector] _ in
+            for config in HookInjectionConfig.allBuiltIn {
+                try? hookInjector.remove(config: config)
+            }
+        }
     }
 
     // MARK: - State Loading
@@ -244,8 +256,10 @@ public final class RunwayStore {
             print("[Runway] Failed to load state: \(error)")
         }
 
-        // Reload cached PRs after reconciliation (init already schedules fetchPRs)
-        loadCachedPRs()
+        // Note: loadCachedPRs() is NOT called here — init already called it for
+        // instant display, and fetchPRs() (also scheduled from init) replaces the
+        // cached data with fresh data. A second loadCachedPRs() would overwrite
+        // the fresh fetch results with stale cache.
     }
 
     /// Remove worktrees that exist on disk but have no matching session in the database.
@@ -353,6 +367,9 @@ public final class RunwayStore {
     // MARK: - New Session Request (from dialog)
 
     func handleNewSessionRequest(_ request: NewSessionRequest) async {
+        if database == nil {
+            statusMessage = .error("Database unavailable — sessions will not persist across restarts")
+        }
         let needsWorktree = request.useWorktree && !(request.branchName ?? "").isEmpty
 
         // Resolve permission mode: request > project override > default
@@ -982,7 +999,9 @@ public final class RunwayStore {
                 return existing
             }
 
-            Task { await enrichPRs() }
+            // Cancel any in-flight enrichment to prevent stale results overwriting fresh data
+            enrichPRsTask?.cancel()
+            enrichPRsTask = Task { await enrichPRs() }
         } catch {
             print("[Runway] Failed to fetch PRs: \(error)")
             statusMessage = .error("PR fetch failed: \(error.localizedDescription)")
@@ -1407,6 +1426,7 @@ public final class RunwayStore {
         guard let project = projectForIssue(issue) else { return }
         do {
             try await issueManager.addComment(repo: issue.repo, number: issue.number, host: project.ghHost, body: body)
+            statusMessage = .success("Commented on #\(issue.number)")
             issueDetail = try? await issueManager.fetchDetail(repo: issue.repo, number: issue.number, host: project.ghHost)
         } catch {
             statusMessage = .error("Comment failed: \(error.localizedDescription)")
@@ -1501,15 +1521,18 @@ public final class RunwayStore {
         provisioningWorktreeIDs.insert(session.id)
 
         Task {
-            var sessionPath = project.path
+            let sessionPath: String
             do {
                 sessionPath = try await worktreeManager.checkoutWorktree(
                     repoPath: project.path,
                     branch: pr.headBranch
                 )
             } catch {
-                print("[Runway] Worktree checkout failed, using project path: \(error)")
-                statusMessage = .error("Worktree failed: \(error.localizedDescription)")
+                print("[Runway] Worktree checkout failed for PR review: \(error)")
+                provisioningWorktreeIDs.remove(session.id)
+                updateSessionStatus(id: session.id, status: .error)
+                statusMessage = .error("Worktree failed — PR review cannot start without branch isolation: \(error.localizedDescription)")
+                return
             }
 
             // Update session path
@@ -1655,8 +1678,10 @@ struct StatusMessage: Equatable {
     enum Kind: Equatable { case success, info, error }
     let text: String
     let kind: Kind
+    /// Unique ID ensures `.task(id:)` restarts for identical consecutive messages
+    let id: UUID
 
-    static func success(_ text: String) -> StatusMessage { .init(text: text, kind: .success) }
-    static func info(_ text: String) -> StatusMessage { .init(text: text, kind: .info) }
-    static func error(_ text: String) -> StatusMessage { .init(text: text, kind: .error) }
+    static func success(_ text: String) -> StatusMessage { .init(text: text, kind: .success, id: UUID()) }
+    static func info(_ text: String) -> StatusMessage { .init(text: text, kind: .info, id: UUID()) }
+    static func error(_ text: String) -> StatusMessage { .init(text: text, kind: .error, id: UUID()) }
 }

--- a/Sources/App/UpdaterController.swift
+++ b/Sources/App/UpdaterController.swift
@@ -42,12 +42,12 @@ final class CheckForUpdatesViewModel: ObservableObject {
 
 /// A button that triggers a manual update check. Suitable for menus and settings.
 struct CheckForUpdatesView: View {
-    @ObservedObject private var viewModel: CheckForUpdatesViewModel
+    @StateObject private var viewModel: CheckForUpdatesViewModel
     private let updater: SPUUpdater
 
     init(updater: SPUUpdater) {
         self.updater = updater
-        self.viewModel = CheckForUpdatesViewModel(updater: updater)
+        self._viewModel = StateObject(wrappedValue: CheckForUpdatesViewModel(updater: updater))
     }
 
     var body: some View {

--- a/Sources/GitOperations/WorktreeManager.swift
+++ b/Sources/GitOperations/WorktreeManager.swift
@@ -126,7 +126,10 @@ public actor WorktreeManager {
         if deleteBranch {
             // Extract branch name from worktree path
             let branchName = URL(fileURLWithPath: worktreePath).lastPathComponent
-            _ = try? await runGit(in: repoPath, args: ["branch", "-D", branchName])
+            // Use -d (safe delete) instead of -D (force) to protect unmerged work.
+            // If the branch has unmerged commits, git will refuse and the branch
+            // is preserved — the user can recover their work later.
+            _ = try? await runGit(in: repoPath, args: ["branch", "-d", branchName])
         }
     }
 

--- a/Sources/Models/AgentProfile.swift
+++ b/Sources/Models/AgentProfile.swift
@@ -107,7 +107,9 @@ extension AgentProfile {
             "(y/N)",
             "Allow?",
             "Try again",
-            "What would you like",
+            "What would you like to work",
+            "What would you like to change",
+            "What would you like me to",
             "Do you want to",
         ],
         idlePatterns: [

--- a/Sources/Models/FileChange.swift
+++ b/Sources/Models/FileChange.swift
@@ -109,9 +109,9 @@ public func buildFileTree(_ changes: [FileChange], prefix: String = "") -> [File
         let adds = children.reduce(0) { $0 + $1.additions }
         let dels = children.reduce(0) { $0 + $1.deletions }
 
-        if subtree.count == 1, case .directory(let childName, _, let grandchildren, _, _) = subtree[0] {
+        if subtree.count == 1, case .directory(let childName, let childFullPath, let grandchildren, _, _) = subtree[0] {
             nodes.append(
-                .directory(name: "\(dir)/\(childName)", fullPath: newPrefix, children: grandchildren, additions: adds, deletions: dels))
+                .directory(name: "\(dir)/\(childName)", fullPath: childFullPath, children: grandchildren, additions: adds, deletions: dels))
         } else {
             nodes.append(.directory(name: "\(dir)/", fullPath: newPrefix, children: subtree, additions: adds, deletions: dels))
         }

--- a/Sources/Models/PullRequest.swift
+++ b/Sources/Models/PullRequest.swift
@@ -172,7 +172,9 @@ public struct CheckRun: Identifiable, Codable, Sendable {
     public var detailsURL: String?
 
     public init(name: String, status: CheckStatus, detailsURL: String? = nil) {
-        self.id = name
+        // Use name + status for uniqueness — CI matrix builds produce multiple
+        // runs with the same name but different statuses
+        self.id = "\(name)-\(status.rawValue)"
         self.name = name
         self.status = status
         self.detailsURL = detailsURL

--- a/Sources/Models/ShellRunner.swift
+++ b/Sources/Models/ShellRunner.swift
@@ -46,7 +46,18 @@ public enum ShellRunner {
             applyFallbackPath(current)
             return
         }
-        process.waitUntilExit()
+
+        // Timeout after 3 seconds — complex shell configs (nvm, rbenv, pyenv)
+        // can take a long time and this blocks the main thread at launch.
+        let deadline = DispatchTime.now() + .seconds(3)
+        let semaphore = DispatchSemaphore(value: 0)
+        process.terminationHandler = { _ in semaphore.signal() }
+        if semaphore.wait(timeout: deadline) == .timedOut {
+            process.terminate()
+            print("[Runway] Login shell timed out after 3s, applying fallback PATH")
+            applyFallbackPath(current)
+            return
+        }
 
         let data = pipe.fileHandleForReading.readDataToEndOfFile()
         let resolved = String(data: data, encoding: .utf8) ?? ""
@@ -98,8 +109,6 @@ public enum ShellRunner {
         process.standardOutput = stdoutPipe
         process.standardError = stderrPipe
 
-        try process.run()
-
         // Drain both pipes concurrently to prevent pipe buffer deadlocks.
         // If a child writes >64KB to stdout or stderr, it blocks until the
         // pipe is drained. Reading only after termination creates a deadlock
@@ -112,9 +121,18 @@ public enum ShellRunner {
         }.value
 
         // Use terminationHandler + continuation to avoid blocking the cooperative thread pool.
+        // IMPORTANT: Set terminationHandler BEFORE process.run() to prevent a race where
+        // the process exits before the handler is assigned, leaving the continuation
+        // permanently unresolved and deadlocking the calling actor.
         let terminationStatus: Int32 = try await withCheckedThrowingContinuation { continuation in
             process.terminationHandler = { proc in
                 continuation.resume(returning: proc.terminationStatus)
+            }
+            do {
+                try process.run()
+            } catch {
+                process.terminationHandler = nil
+                continuation.resume(throwing: error)
             }
         }
 

--- a/Sources/StatusDetection/HookInjector.swift
+++ b/Sources/StatusDetection/HookInjector.swift
@@ -295,12 +295,17 @@ public struct HookInjector: Sendable {
     private func withSettingsLock<T>(path: String, body: () throws -> T) throws -> T {
         let lockPath = path + ".lock"
         let lockFD = open(lockPath, O_CREAT | O_WRONLY, 0o644)
-        guard lockFD >= 0 else { return try body() }
+        guard lockFD >= 0 else {
+            print("[Runway] Warning: could not create lock file at \(lockPath), proceeding without lock")
+            return try body()
+        }
         defer {
             flock(lockFD, LOCK_UN)
             close(lockFD)
         }
-        flock(lockFD, LOCK_EX)
+        if flock(lockFD, LOCK_EX) != 0 {
+            print("[Runway] Warning: flock failed on \(lockPath) (errno \(errno)), proceeding without lock")
+        }
         return try body()
     }
 

--- a/Sources/StatusDetection/HookServer.swift
+++ b/Sources/StatusDetection/HookServer.swift
@@ -68,6 +68,9 @@ public actor HookServer {
                 case .failed(let error):
                     listener?.stateUpdateHandler = nil  // prevent double-resume
                     continuation.resume(throwing: error)
+                case .cancelled:
+                    listener?.stateUpdateHandler = nil  // prevent double-resume
+                    continuation.resume(throwing: HookServerError.cancelled)
                 default:
                     break
                 }
@@ -100,6 +103,11 @@ public actor HookServer {
     /// Calls processRequest once the full payload is received.
     nonisolated private func accumulateRequest(connection: NWConnection, buffer: Data) {
         connection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [weak self] data, _, _, error in
+            guard let self else {
+                // Server was deallocated — clean up the connection to prevent FD leak
+                connection.cancel()
+                return
+            }
             guard let data, error == nil else {
                 connection.cancel()
                 return
@@ -130,17 +138,26 @@ public actor HookServer {
                 let receivedBody = accumulated.count - bodyStart
                 if receivedBody >= contentLength {
                     // Full request received
-                    Task { await self?.processRequest(data: accumulated, connection: connection) }
+                    Task { await self.processRequest(data: accumulated, connection: connection) }
                     return
                 }
             }
 
             // Need more data — keep reading
-            self?.accumulateRequest(connection: connection, buffer: accumulated)
+            self.accumulateRequest(connection: connection, buffer: accumulated)
         }
     }
 
     private func processRequest(data: Data, connection: NWConnection) {
+        // Send 200 OK response immediately — don't block the agent waiting for
+        // handler dispatch, which may await MainActor and exceed the hook timeout.
+        let response = "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n"
+        connection.send(
+            content: response.data(using: .utf8),
+            completion: .contentProcessed { _ in
+                connection.cancel()
+            })
+
         // Parse HTTP request body (skip headers, find blank line)
         if let bodyRange = findHTTPBody(in: data),
             var event = try? JSONDecoder().decode(HookEvent.self, from: data[bodyRange])
@@ -155,14 +172,6 @@ public actor HookServer {
                 handler(event)
             }
         }
-
-        // Send 200 OK response
-        let response = "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n"
-        connection.send(
-            content: response.data(using: .utf8),
-            completion: .contentProcessed { _ in
-                connection.cancel()
-            })
     }
 
     private func extractHeader(named name: String, from data: Data) -> String? {
@@ -192,11 +201,14 @@ public actor HookServer {
 
 public enum HookServerError: Error, LocalizedError {
     case invalidPort(UInt16)
+    case cancelled
 
     public var errorDescription: String? {
         switch self {
         case .invalidPort(let port):
             "Invalid port number: \(port)"
+        case .cancelled:
+            "Hook server listener was cancelled before it could start"
         }
     }
 }

--- a/Sources/StatusDetection/StatusDetector.swift
+++ b/Sources/StatusDetection/StatusDetector.swift
@@ -101,6 +101,9 @@ public struct StatusDetector: Sendable {
                     state = .inCSI
                 } else if char == "]" {
                     state = .inOSC
+                } else if char == "\\" {
+                    // String Terminator (ESC \) — terminates OSC/DCS/etc.
+                    state = .normal
                 } else if char.isLetter {
                     // Two-character escape (e.g., ESC M) — done
                     state = .normal
@@ -109,8 +112,10 @@ public struct StatusDetector: Sendable {
                     state = .inCSI
                 }
             case .inCSI:
-                // CSI terminates on a letter (final byte 0x40-0x7E)
-                if char.isLetter || char == "m" || char == "H" || char == "J" || char == "K" || char == "~" {
+                // CSI final bytes are 0x40-0x7E per ECMA-48
+                if let scalar = char.unicodeScalars.first,
+                    scalar.value >= 0x40, scalar.value <= 0x7E
+                {
                     state = .normal
                 }
             case .inOSC:

--- a/Sources/Terminal/PTYProcess.swift
+++ b/Sources/Terminal/PTYProcess.swift
@@ -127,8 +127,17 @@ public final class PTYProcess: @unchecked Sendable {
             if bytesRead > 0 {
                 let data = Data(buffer[..<bytesRead])
                 outputHandler(data)
-            } else if bytesRead <= 0 {
+            } else if bytesRead == 0 {
+                // True EOF — slave side closed
                 self?.handleExit()
+            } else {
+                // bytesRead < 0 — check errno
+                // EAGAIN/EWOULDBLOCK: spurious wakeup on non-blocking FD, ignore
+                // EINTR: interrupted by signal, ignore
+                // Anything else: real error, tear down
+                if errno != EAGAIN && errno != EWOULDBLOCK && errno != EINTR {
+                    self?.handleExit()
+                }
             }
         }
 
@@ -149,6 +158,12 @@ public final class PTYProcess: @unchecked Sendable {
 
         self.readSource.resume()
         self.processSource.resume()
+    }
+
+    deinit {
+        // Cancel dispatch sources before deallocation — deallocating a resumed,
+        // non-cancelled DispatchSource is undefined behavior and will crash.
+        handleExit()
     }
 
     /// Write data to the PTY master (sends to child's stdin).

--- a/Sources/TerminalView/TerminalSearchBar.swift
+++ b/Sources/TerminalView/TerminalSearchBar.swift
@@ -54,10 +54,10 @@ public struct TerminalSearchBar: View {
                     .font(.caption)
                     .focused($isFocused)
                     .onSubmit { performSearch(forward: true) }
-                    .onChange(of: searchText) { _, newValue in
-                        if newValue.isEmpty {
-                            searchState = .idle
-                        }
+                    .onChange(of: searchText) { _, _ in
+                        // Reset search state on any text change so find buttons
+                        // re-enable after editing a "not found" search term
+                        searchState = .idle
                     }
 
                 // Match feedback label
@@ -102,6 +102,11 @@ public struct TerminalSearchBar: View {
             .padding(.horizontal, 8)
             .padding(.top, 4)
             .onAppear { isFocused = true }
+            .onDisappear {
+                // Clear search highlights when the bar disappears — covers both
+                // the dismiss() path and the Cmd+F toggle path which bypasses dismiss()
+                onDismiss()
+            }
             .onExitCommand { dismiss() }
         }
     }

--- a/Sources/Theme/ThemeFile.swift
+++ b/Sources/Theme/ThemeFile.swift
@@ -71,9 +71,13 @@ public struct ThemeFile: Codable {
 }
 
 extension Color {
-    /// Initialize Color from a hex string like "#1a1b26" or "1a1b26"
+    /// Initialize Color from a hex string like "#1a1b26", "1a1b26", or "F00" (3-digit shorthand).
     init(hexString: String) {
-        let hex = hexString.trimmingCharacters(in: CharacterSet(charactersIn: "#"))
+        var hex = hexString.trimmingCharacters(in: CharacterSet(charactersIn: "#"))
+        // Expand 3-digit CSS shorthand (e.g., "F00" → "FF0000")
+        if hex.count == 3 {
+            hex = hex.map { "\($0)\($0)" }.joined()
+        }
         var value: UInt64 = 0
         Scanner(string: hex).scanHexInt64(&value)
         self.init(hex: UInt32(value))

--- a/Sources/Theme/ThemeManager.swift
+++ b/Sources/Theme/ThemeManager.swift
@@ -59,11 +59,13 @@ public final class ThemeManager {
             if selectedThemeID == pair.dark && targetAppearance == .light {
                 if let light = allThemes.first(where: { $0.id == pair.light }) {
                     currentTheme = light
+                    selectedThemeID = light.id
                     return
                 }
             } else if selectedThemeID == pair.light && targetAppearance == .dark {
                 if let dark = allThemes.first(where: { $0.id == pair.dark }) {
                     currentTheme = dark
+                    selectedThemeID = dark.id
                     return
                 }
             }

--- a/Sources/Views/PRDashboard/PRDashboardView.swift
+++ b/Sources/Views/PRDashboard/PRDashboardView.swift
@@ -302,7 +302,7 @@ public struct PRDashboardView: View {
                 .frame(maxWidth: .infinity)
             }
         }
-        .onAppear { onRefresh() }
+        .task { onRefresh() }
     }
 
     // MARK: - Tab Button

--- a/Sources/Views/PRDashboard/PRDetailDrawer.swift
+++ b/Sources/Views/PRDashboard/PRDetailDrawer.swift
@@ -214,7 +214,10 @@ public struct PRDetailDrawer: View {
                             .frame(minHeight: 100)
                             .border(Color.secondary.opacity(0.3))
                         HStack {
-                            Button("Cancel") { activeSheet = nil }
+                            Button("Cancel") {
+                                requestChangesText = ""
+                                activeSheet = nil
+                            }
                             Spacer()
                             Button("Submit") {
                                 onRequestChanges(requestChangesText)
@@ -236,7 +239,10 @@ public struct PRDetailDrawer: View {
                             .frame(minHeight: 100)
                             .border(Color.secondary.opacity(0.3))
                         HStack {
-                            Button("Cancel") { activeSheet = nil }
+                            Button("Cancel") {
+                                sheetCommentText = ""
+                                activeSheet = nil
+                            }
                             Spacer()
                             Button("Comment") {
                                 onComment(sheetCommentText)
@@ -390,6 +396,7 @@ public struct PRDetailDrawer: View {
                     .padding(.top, 8)
                 }
                 .buttonStyle(.plain)
+                .keyboardShortcut(KeyEquivalent(Character("\(index + 1)")), modifiers: .control)
             }
             Spacer()
         }
@@ -620,7 +627,7 @@ public struct PRDetailDrawer: View {
 
         var date: Date {
             switch self {
-            case .review(let review): review.submittedAt ?? .distantPast
+            case .review(let review): review.submittedAt ?? Date()
             case .comment(let comment): comment.createdAt
             }
         }
@@ -665,7 +672,9 @@ public struct PRDetailDrawer: View {
                         all += reviews.map { .review($0) }
                     }
                     if let comments = detail?.comments {
-                        all += comments.map { .comment($0) }
+                        // Exclude inline comments (those with a file path) — they're
+                        // already shown in the grouped "Inline Comments" section above
+                        all += comments.filter { $0.path == nil }.map { .comment($0) }
                     }
                     return all.sorted { $0.date < $1.date }
                 }()

--- a/Sources/Views/ProjectPage/NewIssueSheet.swift
+++ b/Sources/Views/ProjectPage/NewIssueSheet.swift
@@ -183,7 +183,7 @@ public struct NewIssueSheet: View {
                     .keyboardShortcut(.cancelAction)
                 Spacer()
                 Button("Create Issue") {
-                    onCreate(title, issueBody, Array(selectedLabels))
+                    onCreate(title.trimmingCharacters(in: .whitespacesAndNewlines), issueBody, Array(selectedLabels))
                     dismiss()
                 }
                 .keyboardShortcut(.defaultAction)

--- a/Sources/Views/ProjectPage/ProjectPRsTab.swift
+++ b/Sources/Views/ProjectPage/ProjectPRsTab.swift
@@ -19,6 +19,7 @@ public struct ProjectPRsTab: View {
     var onReviewPR: ((PullRequest) -> Void)?
     var onEnableAutoMerge: ((PullRequest, MergeStrategy) -> Void)?
     var onDisableAutoMerge: ((PullRequest) -> Void)?
+    var onDeselectPR: (() -> Void)?
 
     @AppStorage("hideDrafts") private var hideDrafts: Bool = false
     @AppStorage("projectPRListWidth") private var projectPRListWidth: Double = 320
@@ -38,7 +39,8 @@ public struct ProjectPRsTab: View {
         onUpdateBranch: ((PullRequest, Bool) -> Void)? = nil,
         onReviewPR: ((PullRequest) -> Void)? = nil,
         onEnableAutoMerge: ((PullRequest, MergeStrategy) -> Void)? = nil,
-        onDisableAutoMerge: ((PullRequest) -> Void)? = nil
+        onDisableAutoMerge: ((PullRequest) -> Void)? = nil,
+        onDeselectPR: (() -> Void)? = nil
     ) {
         self.pullRequests = pullRequests
         self.onSelectPR = onSelectPR
@@ -54,6 +56,7 @@ public struct ProjectPRsTab: View {
         self.onReviewPR = onReviewPR
         self.onEnableAutoMerge = onEnableAutoMerge
         self.onDisableAutoMerge = onDisableAutoMerge
+        self.onDeselectPR = onDeselectPR
     }
 
     private var selectedPR: PullRequest? {
@@ -112,7 +115,7 @@ public struct ProjectPRsTab: View {
                     PRDetailDrawer(
                         pr: pr,
                         detail: detail,
-                        onClose: { onSelectPR(pr) },
+                        onClose: { onDeselectPR?() },
                         onApprove: { onApprove?(pr) },
                         onComment: { body in onComment?(pr, body) },
                         onRequestChanges: { body in onRequestChanges?(pr, body) },

--- a/Sources/Views/ProjectPage/ProjectPageView.swift
+++ b/Sources/Views/ProjectPage/ProjectPageView.swift
@@ -44,6 +44,7 @@ public struct ProjectPageView: View {
     var onReviewPR: ((PullRequest) -> Void)?
     var onEnableAutoMergePR: ((PullRequest, MergeStrategy) -> Void)?
     var onDisableAutoMergePR: ((PullRequest) -> Void)?
+    var onDeselectPR: (() -> Void)?
     let onUpdateProject: (Project) -> Void
     let onDetectRepo: () async -> (repo: String, host: String?)?
     let onFetchLabels: () -> Void
@@ -88,6 +89,7 @@ public struct ProjectPageView: View {
         onReviewPR: ((PullRequest) -> Void)? = nil,
         onEnableAutoMergePR: ((PullRequest, MergeStrategy) -> Void)? = nil,
         onDisableAutoMergePR: ((PullRequest) -> Void)? = nil,
+        onDeselectPR: (() -> Void)? = nil,
         onUpdateProject: @escaping (Project) -> Void,
         onDetectRepo: @escaping () async -> (repo: String, host: String?)?,
         onFetchLabels: @escaping () -> Void,
@@ -126,6 +128,7 @@ public struct ProjectPageView: View {
         self.onReviewPR = onReviewPR
         self.onEnableAutoMergePR = onEnableAutoMergePR
         self.onDisableAutoMergePR = onDisableAutoMergePR
+        self.onDeselectPR = onDeselectPR
         self.onUpdateProject = onUpdateProject
         self.onDetectRepo = onDetectRepo
         self.onFetchLabels = onFetchLabels
@@ -239,7 +242,8 @@ public struct ProjectPageView: View {
                     onUpdateBranch: onUpdateBranchPR,
                     onReviewPR: onReviewPR,
                     onEnableAutoMerge: onEnableAutoMergePR,
-                    onDisableAutoMerge: onDisableAutoMergePR
+                    onDisableAutoMerge: onDisableAutoMergePR,
+                    onDeselectPR: onDeselectPR
                 )
             }
         }
@@ -255,7 +259,8 @@ public struct ProjectPageView: View {
             )
         }
         .onChange(of: project) { _, newProject in
-            if editableProject.id == newProject.id {
+            // Don't overwrite user's unsaved edits while the settings sheet is open
+            if !showSettings, editableProject.id == newProject.id {
                 editableProject = newProject
             }
         }

--- a/Sources/Views/SessionDetail/TerminalTabView.swift
+++ b/Sources/Views/SessionDetail/TerminalTabView.swift
@@ -242,7 +242,7 @@ public struct TerminalTabView: View {
     private func initializeTabs() {
         guard tabs.isEmpty else { return }
 
-        let mainTabID = "\(session.id)_main_\(terminalRestartTrigger)"
+        let mainTabID = "\(session.id)_main"
         let tmuxName = "runway-\(session.id)"
 
         // Build the command with permission flags for tools that support them

--- a/Sources/Views/Settings/ProjectSettingsSheet.swift
+++ b/Sources/Views/Settings/ProjectSettingsSheet.swift
@@ -166,7 +166,8 @@ public struct ProjectSettingsSheet: View {
             .padding(.horizontal, 20)
             .padding(.vertical, 14)
         }
-        .frame(width: 400, height: 480)
+        .frame(width: 400)
+        .frame(minHeight: 480, idealHeight: 480, maxHeight: 640)
         .onAppear {
             themeID = project.themeID
             permissionMode = project.permissionMode

--- a/Sources/Views/Settings/SettingsPlaceholder.swift
+++ b/Sources/Views/Settings/SettingsPlaceholder.swift
@@ -34,6 +34,9 @@ public struct SettingsView: View {
                 .tabItem { Label("General", systemImage: "gear") }
         }
         .frame(minWidth: 500, minHeight: 360)
+        .onAppear {
+            if cachedFonts == nil { cachedFonts = groupedFonts() }
+        }
     }
 
     // MARK: - Appearance
@@ -117,8 +120,10 @@ public struct SettingsView: View {
 
     // MARK: - Font
 
+    @State private var cachedFonts: (nerd: [String], mono: [String], other: [String])?
+
     private var fontSettings: some View {
-        let fonts = groupedFonts()
+        let fonts = cachedFonts ?? groupedFonts()
         return Form {
             Section("Terminal Font") {
                 Picker("Font Family", selection: $fontFamily) {

--- a/Sources/Views/Shared/DiffView.swift
+++ b/Sources/Views/Shared/DiffView.swift
@@ -12,7 +12,9 @@ public struct DiffView: View {
 
     public init(files: [DiffFile]) {
         self.files = files
-        self._expandedFiles = State(initialValue: Set())
+        // Auto-expand all files for small diffs, none for large ones
+        let initial = files.count <= 8 ? Set(files.map(\.path)) : Set<String>()
+        self._expandedFiles = State(initialValue: initial)
     }
 
     /// Initialize from a raw unified diff string.
@@ -227,6 +229,13 @@ public struct DiffFile: Identifiable, Sendable {
                 currentLines.append(
                     DiffLine(index: lineIndex, type: .context, content: String(rawLine.dropFirst()), oldLineNo: oldLine, newLineNo: newLine)
                 )
+                lineIndex += 1
+                oldLine += 1
+                newLine += 1
+            } else if rawLine.isEmpty, currentPath != nil {
+                // Empty line without leading space — blank context line
+                currentLines.append(
+                    DiffLine(index: lineIndex, type: .context, content: "", oldLineNo: oldLine, newLineNo: newLine))
                 lineIndex += 1
                 oldLine += 1
                 newLine += 1

--- a/Sources/Views/Shared/ResizableDivider.swift
+++ b/Sources/Views/Shared/ResizableDivider.swift
@@ -10,6 +10,7 @@ struct ResizableDivider: View {
 
     @State private var isDragging = false
     @State private var dragStart: Double = 0
+    @State private var cursorPushed = false
     @Environment(\.theme) private var theme
 
     var body: some View {
@@ -18,10 +19,12 @@ struct ResizableDivider: View {
             .frame(width: isDragging ? 3 : 1)
             .contentShape(Rectangle().inset(by: -3))
             .onHover { hovering in
-                if hovering {
+                if hovering, !cursorPushed {
                     NSCursor.resizeLeftRight.push()
-                } else {
+                    cursorPushed = true
+                } else if !hovering, cursorPushed {
                     NSCursor.pop()
+                    cursorPushed = false
                 }
             }
             .gesture(

--- a/Sources/Views/Sidebar/ProjectTreeView.swift
+++ b/Sources/Views/Sidebar/ProjectTreeView.swift
@@ -216,17 +216,20 @@ struct ProjectSection: View {
     var body: some View {
         // Project header as a plain list row — avoids Section's hover disclosure arrow
         HStack(spacing: 4) {
-            Image(systemName: "chevron.right")
-                .font(.caption)
-                .foregroundColor(theme.chrome.textDim)
-                .rotationEffect(.degrees(isExpanded ? 90 : 0))
-                .animation(.easeInOut(duration: 0.15), value: isExpanded)
-                .frame(width: 16)
-                .onTapGesture {
-                    withAnimation(.easeInOut(duration: 0.15)) {
-                        isExpanded.toggle()
-                    }
+            Button {
+                withAnimation(.easeInOut(duration: 0.15)) {
+                    isExpanded.toggle()
                 }
+            } label: {
+                Image(systemName: "chevron.right")
+                    .font(.caption)
+                    .foregroundColor(theme.chrome.textDim)
+                    .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                    .animation(.easeInOut(duration: 0.15), value: isExpanded)
+                    .frame(width: 16)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(isExpanded ? "Collapse project" : "Expand project")
 
             if isRenaming {
                 TextField("Project name", text: $editName)
@@ -472,7 +475,7 @@ struct SessionRowView: View {
                 .help("Delete session")
             }
             .opacity(isHovered ? 1 : 0)
-            .allowsHitTesting(isHovered)
+            .accessibilityElement(children: .contain)
 
             if !isHovered {
                 HStack(spacing: 4) {

--- a/Tests/StatusDetectionTests/StatusDetectorExpandedTests.swift
+++ b/Tests/StatusDetectionTests/StatusDetectorExpandedTests.swift
@@ -70,10 +70,9 @@ import Testing
 @Test func detectClaudeIdlePromptVariants() {
     let detector = StatusDetector()
 
-    // Note: "What would you like to do" is NOT tested here because it contains
-    // the waiting pattern "What would you like" which takes priority.
     let patterns = [
         "How can I help",
+        "What would you like to do",
         "Enter your prompt",
         "$ ",
     ]
@@ -84,12 +83,16 @@ import Testing
     }
 }
 
-@Test func detectWaitingTakesPriorityOverIdle() {
+@Test func detectWaitingWithSpecificPatterns() {
     let detector = StatusDetector()
-    // "What would you like to do" contains "What would you like" (waiting pattern)
-    // Waiting patterns are checked before idle, so this should be .waiting
-    let result = detector.detect(content: "What would you like to do", tool: .claude)
-    #expect(result == .waiting)
+    // "What would you like to do" is idle (not waiting) — the waiting patterns
+    // are now more specific to avoid matching the idle prompt.
+    let idleResult = detector.detect(content: "What would you like to do", tool: .claude)
+    #expect(idleResult == .idle)
+
+    // Specific waiting patterns should still detect as waiting
+    let waitingResult = detector.detect(content: "What would you like me to do?", tool: .claude)
+    #expect(waitingResult == .waiting)
 }
 
 @Test func detectClaudeNoMatch() {


### PR DESCRIPTION
## Summary

Comprehensive pre-release bug audit for 1.0.0 using 8 parallel domain-expert subagents (2 Swift experts, 2 macOS design experts, 2 terminal/tmux experts, 2 general bug hunters). Found 47 issues across all 11 SPM targets; fixed 43, deferred 2, closed 2 as by-design.

- **6 critical** fixes: cache key mismatch, process hang race, hook server hang, hook cleanup on quit, PTY crash, PTY spurious termination
- **10 high** fixes: ANSI stripping (2), PR drawer close/shortcuts/duplicates, branch force-delete, wrong-branch review, database nil warning, status pattern overlap
- **14 medium** fixes: response timing, stale cache, diff UX (3), search UX (2), settings theme, enrichPath timeout, enrichment cancellation, flock checking, hex colors, view lifecycle
- **13 low** fixes: cursor tracking, accessibility (2), sheet cleanup, toast dedup, theme auto-switch, layout, UX polish

**27 source files + 1 test file changed. 273/273 tests pass. Zero lint violations.**

Full report: `BUG_HUNT_REPORT.md`
GitHub issues: #246 – #292

## Key impact areas

| Area | Issues Fixed | Before | After |
|------|-------------|--------|-------|
| Status Detection | 5 (C1, H1, H2, H10, M1) | Buffer detection completely broken | Full ECMA-48 ANSI stripping, correct patterns, responsive hooks |
| Process Lifecycle | 3 (C2, C5, C6) | Hang/crash on fast-exit commands | Safe handler ordering, proper deinit, EAGAIN handling |
| App Lifecycle | 1 (C4) | 5s agent delays after quit | Clean hook removal on termination |
| PR Dashboard | 5 (H3, H7, H8, L7, L8) | Drawer stuck, duplicates, broken shortcuts | All PR interactions working correctly |
| Accessibility | 2 (L14, L15) | Sidebar actions hidden from VoiceOver | Proper a11y tree, Button-based chevron |

## Test plan

- [x] `swift build` — clean
- [x] `swift test` — 273/273 pass
- [x] `swiftlint lint --strict` — 0 violations
- [x] `swift-format lint --strict` — clean
- [x] Manual: Verify SendTextBar (Cmd+Shift+X) delivers text to terminal
- [x] Manual: Quit Runway, verify Claude Code hooks don't timeout
- [x] Manual: PR detail drawer close button works on project page
- [ ] Manual: System theme switching updates correctly