### PR TITLE
fix: crash in packaged app when syntax highlighting code blocks

### DIFF
--- a/Sources/MarkdownRendering/CodeBlockView.swift
+++ b/Sources/MarkdownRendering/CodeBlockView.swift
@@ -8,6 +8,8 @@ struct CodeBlockView: View {
     let language: String?
     let theme: AppTheme
 
+    private let highlighter = SyntaxHighlighter.shared
+
     @State private var highlighted: AttributedString?
     @State private var isHovering = false
     @State private var copied = false
@@ -82,16 +84,16 @@ struct CodeBlockView: View {
 
     private func highlightCode() async {
         let themeBridge = MarkdownThemeBridge(theme: theme)
-        let highlight = Highlight()
+        let css = themeBridge.highlightColors.css
         do {
+            let result: HighlightJSResult
             if let language, !language.isEmpty {
-                highlighted = try await highlight.attributedText(
-                    code, language: language, colors: themeBridge.highlightColors
-                )
+                result = try await highlighter.highlight(code, language: language)
             } else {
-                highlighted = try await highlight.attributedText(
-                    code, colors: themeBridge.highlightColors
-                )
+                result = try await highlighter.highlightAuto(code)
+            }
+            if result.value != "undefined" {
+                highlighted = try await highlighter.attributedText(html: result.value, css: css)
             }
         } catch {
             // Keep plain text on failure — no crash, no spinner

--- a/Sources/MarkdownRendering/SyntaxHighlighter.swift
+++ b/Sources/MarkdownRendering/SyntaxHighlighter.swift
@@ -1,0 +1,118 @@
+import Foundation
+import JavaScriptCore
+
+/// Loads highlight.js and runs syntax highlighting via JSContext,
+/// avoiding HighlightSwift's Bundle.module which fatalErrors in packaged .app bundles.
+///
+/// SPM's generated resource accessor uses Bundle.main.bundleURL (the .app root)
+/// where code signing prevents placing files. This actor loads highlight.min.js
+/// from Bundle.main.resourceURL (Contents/Resources/) for packaged apps,
+/// falling back to the SPM build location for development.
+final actor SyntaxHighlighter {
+    static let shared = SyntaxHighlighter()
+
+    private var hljs: JSValue?
+
+    private func load() throws -> JSValue {
+        if let hljs { return hljs }
+
+        guard let jsPath = findHighlightJS() else {
+            throw SyntaxHighlighterError.jsFileNotFound
+        }
+        guard let context = JSContext() else {
+            throw SyntaxHighlighterError.jsContextFailed
+        }
+        let script = try String(contentsOfFile: jsPath)
+        context.evaluateScript(script)
+        guard let hljs = context.objectForKeyedSubscript("hljs") else {
+            throw SyntaxHighlighterError.hljsNotFound
+        }
+        self.hljs = hljs
+        return hljs
+    }
+
+    /// Highlight code with a specific language.
+    func highlight(_ text: String, language: String) throws -> HighlightJSResult {
+        let hljs = try load()
+        let options: [String: Any] = ["language": language]
+        let result = hljs.invokeMethod("highlight", withArguments: [text, options])
+        return try parseResult(result)
+    }
+
+    /// Highlight code with automatic language detection.
+    func highlightAuto(_ text: String) throws -> HighlightJSResult {
+        let hljs = try load()
+        let result = hljs.invokeMethod("highlightAuto", withArguments: [text])
+        return try parseResult(result)
+    }
+
+    /// Convert highlight.js HTML output to an AttributedString.
+    func attributedText(html: String, css: String) throws -> AttributedString {
+        let fullHTML =
+            "<style>\n\(css)\n</style>\n<pre><code class=\"hljs\">\(html.trimmingCharacters(in: .whitespacesAndNewlines))</code></pre>"
+        guard let data = fullHTML.data(using: .utf8) else {
+            throw SyntaxHighlighterError.htmlConversionFailed
+        }
+        let mutable = try NSMutableAttributedString(
+            data: data,
+            options: [
+                .documentType: NSAttributedString.DocumentType.html,
+                .characterEncoding: String.Encoding.utf8.rawValue,
+            ],
+            documentAttributes: nil
+        )
+        // Remove the font so SwiftUI applies its own monospace font
+        mutable.removeAttribute(.font, range: NSRange(location: 0, length: mutable.length))
+        let range = NSRange(location: 0, length: max(mutable.length - 1, 0))
+        let trimmed = mutable.attributedSubstring(from: range)
+        return try AttributedString(trimmed, including: \.appKit)
+    }
+
+    // MARK: - Private
+
+    private func parseResult(_ result: JSValue?) throws -> HighlightJSResult {
+        guard let result else { throw SyntaxHighlighterError.hljsNotFound }
+        guard let value = result.objectForKeyedSubscript("value").toString(),
+            let language = result.objectForKeyedSubscript("language").toString()
+        else {
+            throw SyntaxHighlighterError.hljsNotFound
+        }
+        return HighlightJSResult(
+            value: value,
+            language: language,
+            relevance: result.objectForKeyedSubscript("relevance").toInt32()
+        )
+    }
+
+    /// Search for highlight.min.js in multiple locations:
+    /// 1. Bundle.main.resourceURL — packaged .app (Contents/Resources/)
+    /// 2. SPM resource bundle alongside executable — development (swift run)
+    private func findHighlightJS() -> String? {
+        // Packaged .app: Contents/Resources/highlight.min.js
+        if let resourceURL = Bundle.main.resourceURL {
+            let path = resourceURL.appendingPathComponent("highlight.min.js").path
+            if FileManager.default.fileExists(atPath: path) { return path }
+        }
+
+        // Development: SPM resource bundle alongside executable
+        let spmBundlePath = Bundle.main.bundleURL
+            .appendingPathComponent("HighlightSwift_HighlightSwift.bundle")
+            .appendingPathComponent("highlight.min.js").path
+        if FileManager.default.fileExists(atPath: spmBundlePath) { return spmBundlePath }
+
+        return nil
+    }
+}
+
+struct HighlightJSResult: Sendable {
+    let value: String
+    let language: String
+    let relevance: Int32
+}
+
+enum SyntaxHighlighterError: Error {
+    case jsFileNotFound
+    case jsContextFailed
+    case hljsNotFound
+    case htmlConversionFailed
+}

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -125,6 +125,18 @@ sed -e "s/__VERSION__/$VERSION/g" \
 cp "$PROJECT_DIR/images/Runway.icns" "$RESOURCES/Runway.icns"
 cp "$PROJECT_DIR/images/App-icon-1024.png" "$RESOURCES/App-icon-1024.png"
 
+# Copy highlight.min.js for syntax highlighting.
+# SPM's Bundle.module accessor uses Bundle.main.bundleURL (the .app root) which
+# conflicts with hardened-runtime code signing. Our SyntaxHighlighter loads the
+# JS from Bundle.main.resourceURL (Contents/Resources/) instead.
+HLJS_SOURCE="$PROJECT_DIR/.build/checkouts/highlightswift/Sources/HighlightSwift/HighlightJS/highlight.min.js"
+if [[ -f "$HLJS_SOURCE" ]]; then
+    echo "    Copying highlight.min.js for syntax highlighting"
+    cp "$HLJS_SOURCE" "$RESOURCES/highlight.min.js"
+else
+    echo "Warning: highlight.min.js not found — syntax highlighting will be unavailable" >&2
+fi
+
 # Embed Sparkle.framework (SPM builds it as a dynamic framework)
 FRAMEWORKS="$CONTENTS/Frameworks"
 mkdir -p "$FRAMEWORKS"


### PR DESCRIPTION
## Summary
- Fixes crash (`EXC_BREAKPOINT` / `fatalError`) when `CodeBlockView` attempts syntax highlighting in the packaged `.app`
- SPM's auto-generated `Bundle.module` accessor looks for resource bundles at `Bundle.main.bundleURL` (the `.app` root), but hardened-runtime code signing forbids files there — causing HighlightSwift's `HLJS.load()` to `fatalError`
- Replaces direct HighlightSwift `Highlight()` usage with a custom `SyntaxHighlighter` actor that loads `highlight.min.js` from `Bundle.main.resourceURL` (`Contents/Resources/`) for packaged apps, falling back to the SPM build directory for development

## What Changed
- **`Sources/MarkdownRendering/SyntaxHighlighter.swift`** (new) — Actor-based JS loader using `JSContext` directly, with dual-path resource resolution
- **`Sources/MarkdownRendering/CodeBlockView.swift`** — Uses `SyntaxHighlighter.shared` instead of `Highlight()`
- **`scripts/package.sh`** — Copies `highlight.min.js` to `Contents/Resources/` during app bundling

## Test plan
- [x] `swift build` compiles cleanly
- [x] `swift test` — all 273 tests pass
- [x] `./scripts/package.sh` — packaging succeeds with valid code signing
- [x] `highlight.min.js` present in `build/Runway.app/Contents/Resources/`
- [ ] Launch packaged app → open a session with code blocks → verify syntax highlighting renders without crash