### PR TITLE
feat: PR dashboard with sortable columns, filter bar, and native Table view

### DIFF
--- a/Sources/Views/PRDashboard/PRColumnHeader.swift
+++ b/Sources/Views/PRDashboard/PRColumnHeader.swift
@@ -3,7 +3,6 @@ import SwiftUI
 import Theme
 
 /// Clickable column header row for the PR list. Tapping a column toggles sort.
-/// Drag the edges between columns to resize.
 struct PRColumnHeader: View {
     @Binding var sortField: PRSortField
     @Binding var sortOrder: PRSortOrder
@@ -14,22 +13,16 @@ struct PRColumnHeader: View {
         HStack(spacing: 0) {
             columnButton(.title)
                 .frame(maxWidth: .infinity, alignment: .leading)
-            columnDivider(for: .repo)
             columnButton(.repo)
                 .frame(width: columnWidths.repo, alignment: .leading)
-            columnDivider(for: .author)
             columnButton(.author)
                 .frame(width: columnWidths.author, alignment: .leading)
-            columnDivider(for: .age)
             columnButton(.age)
                 .frame(width: columnWidths.age, alignment: .leading)
-            columnDivider(for: .checks)
             columnButton(.checks)
                 .frame(width: columnWidths.checks, alignment: .leading)
-            columnDivider(for: .review)
             columnButton(.review)
                 .frame(width: columnWidths.review, alignment: .leading)
-            columnDivider(for: .mergeStatus)
             columnButton(.mergeStatus)
                 .frame(width: columnWidths.merge, alignment: .leading)
         }
@@ -61,69 +54,5 @@ struct PRColumnHeader: View {
             }
         }
         .buttonStyle(.plain)
-    }
-
-    /// A thin draggable divider between column headers for resizing.
-    private func columnDivider(for field: PRSortField) -> some View {
-        ColumnResizeHandle(
-            width: Binding(
-                get: { columnWidths.width(for: field) },
-                set: { newWidth in
-                    let clamped = Swift.min(
-                        Swift.max(newWidth, PRColumnWidths.min(for: field)),
-                        PRColumnWidths.max(for: field)
-                    )
-                    switch field {
-                    case .repo: columnWidths.repo = clamped
-                    case .author: columnWidths.author = clamped
-                    case .age: columnWidths.age = clamped
-                    case .checks: columnWidths.checks = clamped
-                    case .review: columnWidths.review = clamped
-                    case .mergeStatus: columnWidths.merge = clamped
-                    case .title: break
-                    }
-                }
-            )
-        )
-    }
-}
-
-// MARK: - Column Resize Handle
-
-/// A thin vertical handle that can be dragged left/right to resize a column.
-private struct ColumnResizeHandle: View {
-    @Binding var width: CGFloat
-    @State private var isDragging = false
-    @State private var dragStartWidth: CGFloat = 0
-    @State private var cursorPushed = false
-    @Environment(\.theme) private var theme
-
-    var body: some View {
-        Rectangle()
-            .fill(isDragging ? Color.accentColor.opacity(0.5) : Color.clear)
-            .frame(width: isDragging ? 3 : 1)
-            .contentShape(Rectangle().inset(by: -3))
-            .onHover { hovering in
-                if hovering, !cursorPushed {
-                    NSCursor.resizeLeftRight.push()
-                    cursorPushed = true
-                } else if !hovering, cursorPushed {
-                    NSCursor.pop()
-                    cursorPushed = false
-                }
-            }
-            .gesture(
-                DragGesture(minimumDistance: 1)
-                    .onChanged { value in
-                        if !isDragging {
-                            isDragging = true
-                            dragStartWidth = width
-                        }
-                        width = dragStartWidth + value.translation.width
-                    }
-                    .onEnded { _ in
-                        isDragging = false
-                    }
-            )
     }
 }

--- a/Sources/Views/PRDashboard/PRColumnHeader.swift
+++ b/Sources/Views/PRDashboard/PRColumnHeader.swift
@@ -1,0 +1,57 @@
+import Models
+import SwiftUI
+import Theme
+
+/// Clickable column header row for the PR list. Tapping a column toggles sort.
+struct PRColumnHeader: View {
+    @Binding var sortField: PRSortField
+    @Binding var sortOrder: PRSortOrder
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        HStack(spacing: 0) {
+            columnButton(.title)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            columnButton(.repo)
+                .frame(width: 100, alignment: .leading)
+            columnButton(.author)
+                .frame(width: 70, alignment: .leading)
+            columnButton(.age)
+                .frame(width: 50, alignment: .leading)
+            columnButton(.checks)
+                .frame(width: 55, alignment: .leading)
+            columnButton(.review)
+                .frame(width: 55, alignment: .leading)
+            columnButton(.mergeStatus)
+                .frame(width: 65, alignment: .leading)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 4)
+        .background(theme.chrome.surface)
+    }
+
+    private func columnButton(_ field: PRSortField) -> some View {
+        Button {
+            if sortField == field {
+                sortOrder = sortOrder == .ascending ? .descending : .ascending
+            } else {
+                sortField = field
+                sortOrder = field == .age ? .descending : .ascending
+            }
+        } label: {
+            HStack(spacing: 2) {
+                Text(field.label)
+                    .font(.caption)
+                    .foregroundColor(
+                        sortField == field ? theme.chrome.accent : theme.chrome.textDim
+                    )
+                if sortField == field {
+                    Image(systemName: sortOrder == .ascending ? "chevron.up" : "chevron.down")
+                        .font(.system(size: 8))
+                        .foregroundColor(theme.chrome.accent)
+                }
+            }
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/Sources/Views/PRDashboard/PRColumnHeader.swift
+++ b/Sources/Views/PRDashboard/PRColumnHeader.swift
@@ -3,27 +3,35 @@ import SwiftUI
 import Theme
 
 /// Clickable column header row for the PR list. Tapping a column toggles sort.
+/// Drag the edges between columns to resize.
 struct PRColumnHeader: View {
     @Binding var sortField: PRSortField
     @Binding var sortOrder: PRSortOrder
+    @Binding var columnWidths: PRColumnWidths
     @Environment(\.theme) private var theme
 
     var body: some View {
         HStack(spacing: 0) {
             columnButton(.title)
                 .frame(maxWidth: .infinity, alignment: .leading)
+            columnDivider(for: .repo)
             columnButton(.repo)
-                .frame(width: 100, alignment: .leading)
+                .frame(width: columnWidths.repo, alignment: .leading)
+            columnDivider(for: .author)
             columnButton(.author)
-                .frame(width: 70, alignment: .leading)
+                .frame(width: columnWidths.author, alignment: .leading)
+            columnDivider(for: .age)
             columnButton(.age)
-                .frame(width: 50, alignment: .leading)
+                .frame(width: columnWidths.age, alignment: .leading)
+            columnDivider(for: .checks)
             columnButton(.checks)
-                .frame(width: 55, alignment: .leading)
+                .frame(width: columnWidths.checks, alignment: .leading)
+            columnDivider(for: .review)
             columnButton(.review)
-                .frame(width: 55, alignment: .leading)
+                .frame(width: columnWidths.review, alignment: .leading)
+            columnDivider(for: .mergeStatus)
             columnButton(.mergeStatus)
-                .frame(width: 65, alignment: .leading)
+                .frame(width: columnWidths.merge, alignment: .leading)
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 4)
@@ -53,5 +61,69 @@ struct PRColumnHeader: View {
             }
         }
         .buttonStyle(.plain)
+    }
+
+    /// A thin draggable divider between column headers for resizing.
+    private func columnDivider(for field: PRSortField) -> some View {
+        ColumnResizeHandle(
+            width: Binding(
+                get: { columnWidths.width(for: field) },
+                set: { newWidth in
+                    let clamped = Swift.min(
+                        Swift.max(newWidth, PRColumnWidths.min(for: field)),
+                        PRColumnWidths.max(for: field)
+                    )
+                    switch field {
+                    case .repo: columnWidths.repo = clamped
+                    case .author: columnWidths.author = clamped
+                    case .age: columnWidths.age = clamped
+                    case .checks: columnWidths.checks = clamped
+                    case .review: columnWidths.review = clamped
+                    case .mergeStatus: columnWidths.merge = clamped
+                    case .title: break
+                    }
+                }
+            )
+        )
+    }
+}
+
+// MARK: - Column Resize Handle
+
+/// A thin vertical handle that can be dragged left/right to resize a column.
+private struct ColumnResizeHandle: View {
+    @Binding var width: CGFloat
+    @State private var isDragging = false
+    @State private var dragStartWidth: CGFloat = 0
+    @State private var cursorPushed = false
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        Rectangle()
+            .fill(isDragging ? Color.accentColor.opacity(0.5) : Color.clear)
+            .frame(width: isDragging ? 3 : 1)
+            .contentShape(Rectangle().inset(by: -3))
+            .onHover { hovering in
+                if hovering, !cursorPushed {
+                    NSCursor.resizeLeftRight.push()
+                    cursorPushed = true
+                } else if !hovering, cursorPushed {
+                    NSCursor.pop()
+                    cursorPushed = false
+                }
+            }
+            .gesture(
+                DragGesture(minimumDistance: 1)
+                    .onChanged { value in
+                        if !isDragging {
+                            isDragging = true
+                            dragStartWidth = width
+                        }
+                        width = dragStartWidth + value.translation.width
+                    }
+                    .onEnded { _ in
+                        isDragging = false
+                    }
+            )
     }
 }

--- a/Sources/Views/PRDashboard/PRDashboardView.swift
+++ b/Sources/Views/PRDashboard/PRDashboardView.swift
@@ -259,45 +259,47 @@ public struct PRDashboardView: View {
                 )
                 Divider()
 
-                List(
-                    selection: Binding(
-                        get: { selectedPRID },
-                        set: { id in
-                            let pr = sortedPRs.first(where: { $0.id == id })
-                            onSelectPR(pr)
-                        }
-                    )
-                ) {
-                    ForEach(sortedPRs) { pr in
-                        PRRowView(
-                            pr: pr,
-                            columnWidths: columnWidths,
-                            onReview: onReviewPR.map { callback in { callback(pr) } }
+                GeometryReader { _ in
+                    List(
+                        selection: Binding(
+                            get: { selectedPRID },
+                            set: { id in
+                                let pr = sortedPRs.first(where: { $0.id == id })
+                                onSelectPR(pr)
+                            }
                         )
-                        .tag(pr.id)
-                        .listRowInsets(EdgeInsets())
+                    ) {
+                        ForEach(sortedPRs) { pr in
+                            PRRowView(
+                                pr: pr,
+                                columnWidths: columnWidths,
+                                onReview: onReviewPR.map { callback in { callback(pr) } }
+                            )
+                            .tag(pr.id)
+                            .listRowInsets(EdgeInsets())
+                        }
                     }
-                }
-                .listStyle(.plain)
-                .scrollContentBackground(.hidden)
-                .overlay {
-                    if sortedPRs.isEmpty && !isLoading {
-                        VStack(spacing: 8) {
-                            Image(systemName: "pull.request")
-                                .font(.largeTitle)
-                                .foregroundStyle(.secondary)
-                            if filterState.isActive {
-                                Text("No PRs match current filters")
+                    .listStyle(.plain)
+                    .scrollContentBackground(.hidden)
+                    .overlay {
+                        if sortedPRs.isEmpty && !isLoading {
+                            VStack(spacing: 8) {
+                                Image(systemName: "pull.request")
+                                    .font(.largeTitle)
                                     .foregroundStyle(.secondary)
-                                Button("Clear Filters") {
-                                    filterState = PRFilterState()
-                                }
-                                .controlSize(.small)
-                            } else {
-                                Text("No pull requests")
-                                    .foregroundStyle(.secondary)
-                                Button("Refresh") { onRefresh() }
+                                if filterState.isActive {
+                                    Text("No PRs match current filters")
+                                        .foregroundStyle(.secondary)
+                                    Button("Clear Filters") {
+                                        filterState = PRFilterState()
+                                    }
                                     .controlSize(.small)
+                                } else {
+                                    Text("No pull requests")
+                                        .foregroundStyle(.secondary)
+                                    Button("Refresh") { onRefresh() }
+                                        .controlSize(.small)
+                                }
                             }
                         }
                     }
@@ -334,7 +336,6 @@ public struct PRDashboardView: View {
                 .frame(maxWidth: .infinity)
             }
         }
-        .toolbarTitleDisplayMode(.inline)
         .task { onRefresh() }
     }
 

--- a/Sources/Views/PRDashboard/PRDashboardView.swift
+++ b/Sources/Views/PRDashboard/PRDashboardView.swift
@@ -334,6 +334,7 @@ public struct PRDashboardView: View {
                 .frame(maxWidth: .infinity)
             }
         }
+        .toolbarTitleDisplayMode(.inline)
         .task { onRefresh() }
     }
 

--- a/Sources/Views/PRDashboard/PRDashboardView.swift
+++ b/Sources/Views/PRDashboard/PRDashboardView.swift
@@ -372,13 +372,17 @@ public struct PRDashboardView: View {
                                                 onReview: onReviewPR.map { callback in { callback(pr) } }
                                             )
                                             .tag(pr.id)
+                                            .listRowInsets(EdgeInsets())
                                         }
                                     }
                                 } header: {
                                     groupHeader(entry.group, count: entry.prs.count)
+                                        .listRowInsets(EdgeInsets())
                                 }
                             }
                         }
+                        .listStyle(.plain)
+                        .scrollContentBackground(.hidden)
                     }
                 }
             }
@@ -454,6 +458,7 @@ public struct PRDashboardView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
+            .padding(.horizontal, 12)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)

--- a/Sources/Views/PRDashboard/PRDashboardView.swift
+++ b/Sources/Views/PRDashboard/PRDashboardView.swift
@@ -240,6 +240,7 @@ public struct PRDashboardView: View {
                 }
                 .listRowInsets(EdgeInsets())
                 .listRowSeparator(.hidden)
+                .tag("__toolbar__")
 
                 // Filter bar
                 PRFilterBar(
@@ -251,6 +252,7 @@ public struct PRDashboardView: View {
                 )
                 .listRowInsets(EdgeInsets())
                 .listRowSeparator(.hidden)
+                .tag("__filter__")
 
                 // Column headers
                 PRColumnHeader(
@@ -268,6 +270,7 @@ public struct PRDashboardView: View {
                     )
                 )
                 .listRowInsets(EdgeInsets())
+                .tag("__columns__")
 
                 // PR rows
                 ForEach(sortedPRs) { pr in

--- a/Sources/Views/PRDashboard/PRDashboardView.swift
+++ b/Sources/Views/PRDashboard/PRDashboardView.swift
@@ -329,11 +329,37 @@ public struct PRDashboardView: View {
     // MARK: - PR List Content
 
     /// The filter bar, column headers, and scrollable PR list as one cohesive unit.
-    /// Filter bar and column headers are pinned above the scroll content via safeAreaInset.
     @ViewBuilder
     private var prListContent: some View {
+        // Filter bar — always visible, fixed above scroll
+        PRFilterBar(
+            filter: Binding(
+                get: { filterState },
+                set: { filterState = $0 }
+            ),
+            pullRequests: filteredPRs
+        )
+        Divider()
+
+        // Column headers — fixed above scroll
+        PRColumnHeader(
+            sortField: Binding(
+                get: { sortField },
+                set: { sortField = $0 }
+            ),
+            sortOrder: Binding(
+                get: { sortOrder },
+                set: { sortOrder = $0 }
+            ),
+            columnWidths: Binding(
+                get: { columnWidths },
+                set: { columnWidths = $0 }
+            )
+        )
+        Divider()
+
+        // Scrollable PR content
         if filteredPRs.isEmpty && !isLoading {
-            Spacer()
             VStack(spacing: 8) {
                 Image(systemName: "pull.request")
                     .font(.largeTitle)
@@ -350,11 +376,10 @@ public struct PRDashboardView: View {
                         .controlSize(.small)
                 }
             }
-            Spacer()
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else {
             let visibleGroups = groupedPRs().filter { !($0.group == .drafts && hideDrafts) }
             if visibleGroups.isEmpty {
-                Spacer()
                 VStack(spacing: 8) {
                     Image(systemName: "pull.request")
                         .font(.largeTitle)
@@ -364,7 +389,7 @@ public struct PRDashboardView: View {
                     Button("Refresh") { onRefresh() }
                         .controlSize(.small)
                 }
-                Spacer()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
                 ScrollView {
                     LazyVStack(spacing: 0) {
@@ -392,34 +417,6 @@ public struct PRDashboardView: View {
                             }
                         }
                     }
-                }
-                .safeAreaInset(edge: .top, spacing: 0) {
-                    VStack(spacing: 0) {
-                        PRFilterBar(
-                            filter: Binding(
-                                get: { filterState },
-                                set: { filterState = $0 }
-                            ),
-                            pullRequests: filteredPRs
-                        )
-                        Divider()
-                        PRColumnHeader(
-                            sortField: Binding(
-                                get: { sortField },
-                                set: { sortField = $0 }
-                            ),
-                            sortOrder: Binding(
-                                get: { sortOrder },
-                                set: { sortOrder = $0 }
-                            ),
-                            columnWidths: Binding(
-                                get: { columnWidths },
-                                set: { columnWidths = $0 }
-                            )
-                        )
-                        Divider()
-                    }
-                    .background(theme.chrome.background)
                 }
             }
         }

--- a/Sources/Views/PRDashboard/PRDashboardView.swift
+++ b/Sources/Views/PRDashboard/PRDashboardView.swift
@@ -31,7 +31,46 @@ public struct PRDashboardView: View {
     @AppStorage("prGroupReadyExpanded") private var readyExpanded: Bool = true
     @AppStorage("prGroupWaitingForReviewExpanded") private var waitingForReviewExpanded: Bool = true
     @AppStorage("prGroupDraftsExpanded") private var draftsExpanded: Bool = false
+    @AppStorage("prSortField") private var sortFieldRaw: String = PRSortField.age.rawValue
+    @AppStorage("prSortOrder") private var sortOrderRaw: String = PRSortOrder.descending.rawValue
+    @AppStorage("prFilterRepo") private var filterRepo: String = ""
+    @AppStorage("prFilterAuthor") private var filterAuthor: String = ""
+    @AppStorage("prFilterAge") private var filterAgeRaw: String = PRAgeBucket.any.rawValue
+    @AppStorage("prFilterChecks") private var filterChecksRaw: String = ""
+    @AppStorage("prFilterReview") private var filterReviewRaw: String = ""
+    @AppStorage("prFilterMerge") private var filterMergeRaw: String = ""
     @Environment(\.theme) private var theme
+
+    private var sortField: PRSortField {
+        get { PRSortField(rawValue: sortFieldRaw) ?? .age }
+        nonmutating set { sortFieldRaw = newValue.rawValue }
+    }
+
+    private var sortOrder: PRSortOrder {
+        get { PRSortOrder(rawValue: sortOrderRaw) ?? .descending }
+        nonmutating set { sortOrderRaw = newValue.rawValue }
+    }
+
+    private var filterState: PRFilterState {
+        get {
+            var state = PRFilterState()
+            state.repo = filterRepo.isEmpty ? nil : filterRepo
+            state.author = filterAuthor.isEmpty ? nil : filterAuthor
+            state.ageBucket = PRAgeBucket(rawValue: filterAgeRaw) ?? .any
+            state.checks = CheckStatus(rawValue: filterChecksRaw)
+            state.review = filterReviewRaw.isEmpty ? nil : ReviewDecision(rawValue: filterReviewRaw)
+            state.mergeFilter = filterMergeRaw.isEmpty ? nil : PRMergeFilter(rawValue: filterMergeRaw)
+            return state
+        }
+        nonmutating set {
+            filterRepo = newValue.repo ?? ""
+            filterAuthor = newValue.author ?? ""
+            filterAgeRaw = newValue.ageBucket.rawValue
+            filterChecksRaw = newValue.checks?.rawValue ?? ""
+            filterReviewRaw = newValue.review?.rawValue ?? ""
+            filterMergeRaw = newValue.mergeFilter?.rawValue ?? ""
+        }
+    }
 
     public init(
         pullRequests: [PullRequest] = [],
@@ -99,12 +138,21 @@ public struct PRDashboardView: View {
     }
 
     private var filteredPRs: [PullRequest] {
-        applyFilters(to: pullRequests, tab: selectedTab)
+        var result = applyFilters(to: pullRequests, tab: selectedTab)
+        let currentFilter = filterState
+        if currentFilter.isActive {
+            result = result.filter { currentFilter.matches($0) }
+        }
+        return result
     }
 
     private func tabCount(_ tab: PRTab) -> Int {
         var prs = applyFilters(to: pullRequests, tab: tab)
         if hideDrafts { prs = prs.filter { !$0.isDraft } }
+        let currentFilter = filterState
+        if currentFilter.isActive {
+            prs = prs.filter { currentFilter.matches($0) }
+        }
         return prs.count
     }
 
@@ -116,8 +164,11 @@ public struct PRDashboardView: View {
             let g = prGroup(for: pr)
             byGroup[g, default: []].append(pr)
         }
+        let currentSortField = sortField
+        let currentSortOrder = sortOrder
         return PRGroup.allCases.compactMap { g in
-            guard let prs = byGroup[g], !prs.isEmpty else { return nil }
+            guard var prs = byGroup[g], !prs.isEmpty else { return nil }
+            prs = sortPRs(prs, by: currentSortField, order: currentSortOrder)
             return (g, prs)
         }
     }
@@ -215,6 +266,31 @@ public struct PRDashboardView: View {
 
                 Divider()
 
+                // Filter bar
+                PRFilterBar(
+                    filter: Binding(
+                        get: { filterState },
+                        set: { filterState = $0 }
+                    ),
+                    pullRequests: filteredPRs
+                )
+
+                Divider()
+
+                // Column headers
+                PRColumnHeader(
+                    sortField: Binding(
+                        get: { sortField },
+                        set: { sortField = $0 }
+                    ),
+                    sortOrder: Binding(
+                        get: { sortOrder },
+                        set: { sortOrder = $0 }
+                    )
+                )
+
+                Divider()
+
                 // PR list
                 if filteredPRs.isEmpty && !isLoading {
                     Spacer()
@@ -222,10 +298,17 @@ public struct PRDashboardView: View {
                         Image(systemName: "pull.request")
                             .font(.largeTitle)
                             .foregroundStyle(.secondary)
-                        Text("No pull requests")
-                            .foregroundStyle(.secondary)
-                        Button("Refresh") { onRefresh() }
-                            .controlSize(.small)
+                        if filterState.isActive {
+                            Text("No PRs match current filters")
+                                .foregroundStyle(.secondary)
+                            Button("Clear Filters") { filterState = PRFilterState() }
+                                .controlSize(.small)
+                        } else {
+                            Text("No pull requests")
+                                .foregroundStyle(.secondary)
+                            Button("Refresh") { onRefresh() }
+                                .controlSize(.small)
+                        }
                     }
                     Spacer()
                 } else {

--- a/Sources/Views/PRDashboard/PRDashboardView.swift
+++ b/Sources/Views/PRDashboard/PRDashboardView.swift
@@ -392,7 +392,7 @@ public struct PRDashboardView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
                 ScrollView {
-                    LazyVStack(spacing: 0) {
+                    LazyVStack(alignment: .leading, spacing: 0) {
                         ForEach(visibleGroups, id: \.group) { entry in
                             groupHeader(entry.group, count: entry.prs.count)
                                 .background(theme.chrome.background)
@@ -417,7 +417,9 @@ public struct PRDashboardView: View {
                             }
                         }
                     }
+                    .frame(maxWidth: .infinity)
                 }
+                .frame(maxHeight: .infinity, alignment: .top)
             }
         }
     }

--- a/Sources/Views/PRDashboard/PRDashboardView.swift
+++ b/Sources/Views/PRDashboard/PRDashboardView.swift
@@ -289,104 +289,8 @@ public struct PRDashboardView: View {
 
                 Divider()
 
-                // Filter bar
-                PRFilterBar(
-                    filter: Binding(
-                        get: { filterState },
-                        set: { filterState = $0 }
-                    ),
-                    pullRequests: filteredPRs
-                )
-
-                Divider()
-
-                // Column headers
-                PRColumnHeader(
-                    sortField: Binding(
-                        get: { sortField },
-                        set: { sortField = $0 }
-                    ),
-                    sortOrder: Binding(
-                        get: { sortOrder },
-                        set: { sortOrder = $0 }
-                    ),
-                    columnWidths: Binding(
-                        get: { columnWidths },
-                        set: { columnWidths = $0 }
-                    )
-                )
-
-                Divider()
-
-                // PR list
-                if filteredPRs.isEmpty && !isLoading {
-                    Spacer()
-                    VStack(spacing: 8) {
-                        Image(systemName: "pull.request")
-                            .font(.largeTitle)
-                            .foregroundStyle(.secondary)
-                        if filterState.isActive {
-                            Text("No PRs match current filters")
-                                .foregroundStyle(.secondary)
-                            Button("Clear Filters") { filterState = PRFilterState() }
-                                .controlSize(.small)
-                        } else {
-                            Text("No pull requests")
-                                .foregroundStyle(.secondary)
-                            Button("Refresh") { onRefresh() }
-                                .controlSize(.small)
-                        }
-                    }
-                    Spacer()
-                } else {
-                    let visibleGroups = groupedPRs().filter { !($0.group == .drafts && hideDrafts) }
-                    if visibleGroups.isEmpty {
-                        Spacer()
-                        VStack(spacing: 8) {
-                            Image(systemName: "pull.request")
-                                .font(.largeTitle)
-                                .foregroundStyle(.secondary)
-                            Text("No pull requests")
-                                .foregroundStyle(.secondary)
-                            Button("Refresh") { onRefresh() }
-                                .controlSize(.small)
-                        }
-                        Spacer()
-                    } else {
-                        ScrollView {
-                            LazyVStack(spacing: 0, pinnedViews: .sectionHeaders) {
-                                ForEach(visibleGroups, id: \.group) { entry in
-                                    Section {
-                                        if isGroupExpanded(entry.group) {
-                                            ForEach(entry.prs) { pr in
-                                                PRRowView(
-                                                    pr: pr,
-                                                    columnWidths: columnWidths,
-                                                    onReview: onReviewPR.map { callback in
-                                                        { callback(pr) }
-                                                    }
-                                                )
-                                                .background(
-                                                    selectedPRID == pr.id
-                                                        ? theme.chrome.accent.opacity(0.15)
-                                                        : Color.clear
-                                                )
-                                                .onTapGesture {
-                                                    onSelectPR(
-                                                        selectedPRID == pr.id ? nil : pr
-                                                    )
-                                                }
-                                            }
-                                        }
-                                    } header: {
-                                        groupHeader(entry.group, count: entry.prs.count)
-                                            .background(theme.chrome.background)
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
+                // PR list with pinned filter bar + column headers
+                prListContent
             }
             .frame(minWidth: 300)
             .frame(maxWidth: selectedPR == nil ? .infinity : CGFloat(prListWidth))
@@ -420,6 +324,105 @@ public struct PRDashboardView: View {
             }
         }
         .task { onRefresh() }
+    }
+
+    // MARK: - PR List Content
+
+    /// The filter bar, column headers, and scrollable PR list as one cohesive unit.
+    /// Filter bar and column headers are pinned above the scroll content via safeAreaInset.
+    @ViewBuilder
+    private var prListContent: some View {
+        if filteredPRs.isEmpty && !isLoading {
+            Spacer()
+            VStack(spacing: 8) {
+                Image(systemName: "pull.request")
+                    .font(.largeTitle)
+                    .foregroundStyle(.secondary)
+                if filterState.isActive {
+                    Text("No PRs match current filters")
+                        .foregroundStyle(.secondary)
+                    Button("Clear Filters") { filterState = PRFilterState() }
+                        .controlSize(.small)
+                } else {
+                    Text("No pull requests")
+                        .foregroundStyle(.secondary)
+                    Button("Refresh") { onRefresh() }
+                        .controlSize(.small)
+                }
+            }
+            Spacer()
+        } else {
+            let visibleGroups = groupedPRs().filter { !($0.group == .drafts && hideDrafts) }
+            if visibleGroups.isEmpty {
+                Spacer()
+                VStack(spacing: 8) {
+                    Image(systemName: "pull.request")
+                        .font(.largeTitle)
+                        .foregroundStyle(.secondary)
+                    Text("No pull requests")
+                        .foregroundStyle(.secondary)
+                    Button("Refresh") { onRefresh() }
+                        .controlSize(.small)
+                }
+                Spacer()
+            } else {
+                ScrollView {
+                    LazyVStack(spacing: 0) {
+                        ForEach(visibleGroups, id: \.group) { entry in
+                            groupHeader(entry.group, count: entry.prs.count)
+                                .background(theme.chrome.background)
+                            if isGroupExpanded(entry.group) {
+                                ForEach(entry.prs) { pr in
+                                    PRRowView(
+                                        pr: pr,
+                                        columnWidths: columnWidths,
+                                        onReview: onReviewPR.map { callback in
+                                            { callback(pr) }
+                                        }
+                                    )
+                                    .background(
+                                        selectedPRID == pr.id
+                                            ? theme.chrome.accent.opacity(0.15)
+                                            : Color.clear
+                                    )
+                                    .onTapGesture {
+                                        onSelectPR(selectedPRID == pr.id ? nil : pr)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                .safeAreaInset(edge: .top, spacing: 0) {
+                    VStack(spacing: 0) {
+                        PRFilterBar(
+                            filter: Binding(
+                                get: { filterState },
+                                set: { filterState = $0 }
+                            ),
+                            pullRequests: filteredPRs
+                        )
+                        Divider()
+                        PRColumnHeader(
+                            sortField: Binding(
+                                get: { sortField },
+                                set: { sortField = $0 }
+                            ),
+                            sortOrder: Binding(
+                                get: { sortOrder },
+                                set: { sortOrder = $0 }
+                            ),
+                            columnWidths: Binding(
+                                get: { columnWidths },
+                                set: { columnWidths = $0 }
+                            )
+                        )
+                        Divider()
+                    }
+                    .background(theme.chrome.background)
+                }
+            }
+        }
     }
 
     // MARK: - Tab Button
@@ -540,6 +543,7 @@ struct PRRowView: View {
                     .lineLimit(1)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
+            .clipped()
 
             // Repo column
             Text(repoShortName)
@@ -547,6 +551,7 @@ struct PRRowView: View {
                 .foregroundColor(theme.chrome.cyan)
                 .lineLimit(1)
                 .frame(width: columnWidths.repo, alignment: .leading)
+                .clipped()
 
             // Author column
             Text(pr.author)
@@ -554,24 +559,30 @@ struct PRRowView: View {
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
                 .frame(width: columnWidths.author, alignment: .leading)
+                .clipped()
 
             // Age column
             Text(pr.ageText)
                 .font(.caption)
                 .foregroundStyle(.secondary)
+                .lineLimit(1)
                 .frame(width: columnWidths.age, alignment: .leading)
+                .clipped()
 
             // Checks column
             CheckSummaryBadge(checks: pr.checks)
                 .frame(width: columnWidths.checks, alignment: .leading)
+                .clipped()
 
             // Review column
             ReviewDecisionBadge(decision: pr.reviewDecision)
                 .frame(width: columnWidths.review, alignment: .leading)
+                .clipped()
 
             // Merge column
             MergeStatusBadge(mergeable: pr.mergeable, mergeStateStatus: pr.mergeStateStatus)
                 .frame(width: columnWidths.merge, alignment: .leading)
+                .clipped()
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 4)

--- a/Sources/Views/PRDashboard/PRDashboardView.swift
+++ b/Sources/Views/PRDashboard/PRDashboardView.swift
@@ -235,8 +235,73 @@ public struct PRDashboardView: View {
 
                 Divider()
 
-                // PR list with pinned filter bar + column headers
-                prListContent
+                PRFilterBar(
+                    filter: Binding(
+                        get: { filterState },
+                        set: { filterState = $0 }
+                    ),
+                    pullRequests: filteredPRs
+                )
+                Divider()
+                PRColumnHeader(
+                    sortField: Binding(
+                        get: { sortField },
+                        set: { sortField = $0 }
+                    ),
+                    sortOrder: Binding(
+                        get: { sortOrder },
+                        set: { sortOrder = $0 }
+                    ),
+                    columnWidths: Binding(
+                        get: { columnWidths },
+                        set: { columnWidths = $0 }
+                    )
+                )
+                Divider()
+
+                List(
+                    selection: Binding(
+                        get: { selectedPRID },
+                        set: { id in
+                            let pr = sortedPRs.first(where: { $0.id == id })
+                            onSelectPR(pr)
+                        }
+                    )
+                ) {
+                    ForEach(sortedPRs) { pr in
+                        PRRowView(
+                            pr: pr,
+                            columnWidths: columnWidths,
+                            onReview: onReviewPR.map { callback in { callback(pr) } }
+                        )
+                        .tag(pr.id)
+                        .listRowInsets(EdgeInsets())
+                    }
+                }
+                .listStyle(.plain)
+                .scrollContentBackground(.hidden)
+                .overlay {
+                    if sortedPRs.isEmpty && !isLoading {
+                        VStack(spacing: 8) {
+                            Image(systemName: "pull.request")
+                                .font(.largeTitle)
+                                .foregroundStyle(.secondary)
+                            if filterState.isActive {
+                                Text("No PRs match current filters")
+                                    .foregroundStyle(.secondary)
+                                Button("Clear Filters") {
+                                    filterState = PRFilterState()
+                                }
+                                .controlSize(.small)
+                            } else {
+                                Text("No pull requests")
+                                    .foregroundStyle(.secondary)
+                                Button("Refresh") { onRefresh() }
+                                    .controlSize(.small)
+                            }
+                        }
+                    }
+                }
             }
             .frame(minWidth: 300)
             .frame(maxWidth: selectedPR == nil ? .infinity : CGFloat(prListWidth))
@@ -270,79 +335,6 @@ public struct PRDashboardView: View {
             }
         }
         .task { onRefresh() }
-    }
-
-    // MARK: - PR List Content
-
-    /// The filter bar, column headers, and scrollable PR list.
-    @ViewBuilder
-    private var prListContent: some View {
-        PRFilterBar(
-            filter: Binding(
-                get: { filterState },
-                set: { filterState = $0 }
-            ),
-            pullRequests: filteredPRs
-        )
-        Divider()
-        PRColumnHeader(
-            sortField: Binding(
-                get: { sortField },
-                set: { sortField = $0 }
-            ),
-            sortOrder: Binding(
-                get: { sortOrder },
-                set: { sortOrder = $0 }
-            ),
-            columnWidths: Binding(
-                get: { columnWidths },
-                set: { columnWidths = $0 }
-            )
-        )
-        Divider()
-
-        let prs = sortedPRs
-        if prs.isEmpty && !isLoading {
-            VStack(spacing: 8) {
-                Image(systemName: "pull.request")
-                    .font(.largeTitle)
-                    .foregroundStyle(.secondary)
-                if filterState.isActive {
-                    Text("No PRs match current filters")
-                        .foregroundStyle(.secondary)
-                    Button("Clear Filters") { filterState = PRFilterState() }
-                        .controlSize(.small)
-                } else {
-                    Text("No pull requests")
-                        .foregroundStyle(.secondary)
-                    Button("Refresh") { onRefresh() }
-                        .controlSize(.small)
-                }
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-        } else {
-            List(
-                selection: Binding(
-                    get: { selectedPRID },
-                    set: { id in
-                        let pr = prs.first(where: { $0.id == id })
-                        onSelectPR(pr)
-                    }
-                )
-            ) {
-                ForEach(prs) { pr in
-                    PRRowView(
-                        pr: pr,
-                        columnWidths: columnWidths,
-                        onReview: onReviewPR.map { callback in { callback(pr) } }
-                    )
-                    .tag(pr.id)
-                    .listRowInsets(EdgeInsets())
-                }
-            }
-            .listStyle(.plain)
-            .scrollContentBackground(.hidden)
-        }
     }
 
     // MARK: - Tab Button

--- a/Sources/Views/PRDashboard/PRDashboardView.swift
+++ b/Sources/Views/PRDashboard/PRDashboardView.swift
@@ -439,16 +439,19 @@ struct PRRowView: View {
 
             // Checks column
             CheckSummaryBadge(checks: pr.checks)
+                .lineLimit(1)
                 .frame(width: columnWidths.checks, alignment: .leading)
                 .clipped()
 
             // Review column
             ReviewDecisionBadge(decision: pr.reviewDecision)
+                .lineLimit(1)
                 .frame(width: columnWidths.review, alignment: .leading)
                 .clipped()
 
             // Merge column
             MergeStatusBadge(mergeable: pr.mergeable, mergeStateStatus: pr.mergeStateStatus)
+                .lineLimit(1)
                 .frame(width: columnWidths.merge, alignment: .leading)
                 .clipped()
         }

--- a/Sources/Views/PRDashboard/PRDashboardView.swift
+++ b/Sources/Views/PRDashboard/PRDashboardView.swift
@@ -26,31 +26,16 @@ public struct PRDashboardView: View {
     @AppStorage("prListWidth") private var prListWidth: Double = 380
     @AppStorage("hideDrafts") private var hideDrafts: Bool = false
     @AppStorage("showSessionPRsOnly") private var showSessionPRsOnly: Bool = false
-    @AppStorage("prSortField") private var sortFieldRaw: String = PRSortField.age.rawValue
-    @AppStorage("prSortOrder") private var sortOrderRaw: String = PRSortOrder.descending.rawValue
     @AppStorage("prFilterRepo") private var filterRepo: String = ""
     @AppStorage("prFilterAuthor") private var filterAuthor: String = ""
     @AppStorage("prFilterAge") private var filterAgeRaw: String = PRAgeBucket.any.rawValue
     @AppStorage("prFilterChecks") private var filterChecksRaw: String = ""
     @AppStorage("prFilterReview") private var filterReviewRaw: String = ""
     @AppStorage("prFilterMerge") private var filterMergeRaw: String = ""
-    @AppStorage("prColRepo") private var colRepo: Double = Double(PRColumnWidths.defaults.repo)
-    @AppStorage("prColAuthor") private var colAuthor: Double = Double(PRColumnWidths.defaults.author)
-    @AppStorage("prColAge") private var colAge: Double = Double(PRColumnWidths.defaults.age)
-    @AppStorage("prColChecks") private var colChecks: Double = Double(PRColumnWidths.defaults.checks)
-    @AppStorage("prColReview") private var colReview: Double = Double(PRColumnWidths.defaults.review)
-    @AppStorage("prColMerge") private var colMerge: Double = Double(PRColumnWidths.defaults.merge)
+    @State private var tableSortOrder: [KeyPathComparator<PullRequest>] = [
+        KeyPathComparator(\.createdAt, order: .reverse)
+    ]
     @Environment(\.theme) private var theme
-
-    private var sortField: PRSortField {
-        get { PRSortField(rawValue: sortFieldRaw) ?? .age }
-        nonmutating set { sortFieldRaw = newValue.rawValue }
-    }
-
-    private var sortOrder: PRSortOrder {
-        get { PRSortOrder(rawValue: sortOrderRaw) ?? .descending }
-        nonmutating set { sortOrderRaw = newValue.rawValue }
-    }
 
     private var filterState: PRFilterState {
         get {
@@ -70,23 +55,6 @@ public struct PRDashboardView: View {
             filterChecksRaw = newValue.checks?.rawValue ?? ""
             filterReviewRaw = newValue.review?.rawValue ?? ""
             filterMergeRaw = newValue.mergeFilter?.rawValue ?? ""
-        }
-    }
-
-    private var columnWidths: PRColumnWidths {
-        get {
-            PRColumnWidths(
-                repo: CGFloat(colRepo), author: CGFloat(colAuthor), age: CGFloat(colAge),
-                checks: CGFloat(colChecks), review: CGFloat(colReview), merge: CGFloat(colMerge)
-            )
-        }
-        nonmutating set {
-            colRepo = Double(newValue.repo)
-            colAuthor = Double(newValue.author)
-            colAge = Double(newValue.age)
-            colChecks = Double(newValue.checks)
-            colReview = Double(newValue.review)
-            colMerge = Double(newValue.merge)
         }
     }
 
@@ -179,7 +147,7 @@ public struct PRDashboardView: View {
     private var sortedPRs: [PullRequest] {
         var prs = filteredPRs
         if hideDrafts { prs = prs.filter { !$0.isDraft } }
-        return sortPRs(prs, by: sortField, order: sortOrder)
+        return prs.sorted(using: tableSortOrder)
     }
 
     // MARK: - Body
@@ -233,9 +201,10 @@ public struct PRDashboardView: View {
                     let pr = sortedPRs.first(where: { $0.id == id })
                     onSelectPR(pr)
                 }
-            )
+            ),
+            sortOrder: $tableSortOrder
         ) {
-            TableColumn("Title") { pr in
+            TableColumn("Title", value: \.title) { pr in
                 HStack(spacing: 4) {
                     prStateBadge(pr)
                     Text("#\(pr.number)")
@@ -248,7 +217,7 @@ public struct PRDashboardView: View {
             }
             .width(min: 150)
 
-            TableColumn("Repo") { pr in
+            TableColumn("Repo", value: \.repo) { pr in
                 Text(prRepoShortName(pr))
                     .font(.caption)
                     .foregroundColor(theme.chrome.cyan)
@@ -256,7 +225,7 @@ public struct PRDashboardView: View {
             }
             .width(min: 70, ideal: 130, max: 250)
 
-            TableColumn("Author") { pr in
+            TableColumn("Author", value: \.author) { pr in
                 Text(pr.author)
                     .font(.caption)
                     .foregroundStyle(.secondary)
@@ -264,14 +233,14 @@ public struct PRDashboardView: View {
             }
             .width(min: 60, ideal: 90, max: 200)
 
-            TableColumn("Age") { pr in
+            TableColumn("Age", value: \.createdAt) { pr in
                 Text(pr.ageText)
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
             .width(min: 40, ideal: 60, max: 80)
 
-            TableColumn("Checks") { pr in
+            TableColumn("Checks", value: \.checksPassRatio) { pr in
                 if pr.checks.total > 0 {
                     Text("\(pr.checks.passed)/\(pr.checks.total)")
                         .font(.caption)
@@ -284,14 +253,14 @@ public struct PRDashboardView: View {
             }
             .width(min: 40, ideal: 55, max: 80)
 
-            TableColumn("Review") { pr in
+            TableColumn("Review", value: \.reviewSortRank) { pr in
                 Text(reviewLabel(pr.reviewDecision))
                     .font(.caption)
                     .foregroundColor(reviewColor(pr.reviewDecision))
             }
             .width(min: 50, ideal: 70, max: 100)
 
-            TableColumn("Merge") { pr in
+            TableColumn("Merge", value: \.mergeSortRank) { pr in
                 Text(mergeLabel(pr))
                     .font(.caption)
                     .foregroundColor(mergeColor(pr))

--- a/Sources/Views/PRDashboard/PRDashboardView.swift
+++ b/Sources/Views/PRDashboard/PRDashboardView.swift
@@ -353,36 +353,38 @@ public struct PRDashboardView: View {
                         }
                         Spacer()
                     } else {
-                        List(
-                            selection: Binding(
-                                get: { selectedPRID },
-                                set: { id in
-                                    let pr = pullRequests.first(where: { $0.id == id })
-                                    onSelectPR(pr)
-                                }
-                            )
-                        ) {
-                            ForEach(visibleGroups, id: \.group) { entry in
-                                Section {
-                                    if isGroupExpanded(entry.group) {
-                                        ForEach(entry.prs) { pr in
-                                            PRRowView(
-                                                pr: pr,
-                                                columnWidths: columnWidths,
-                                                onReview: onReviewPR.map { callback in { callback(pr) } }
-                                            )
-                                            .tag(pr.id)
-                                            .listRowInsets(EdgeInsets())
+                        ScrollView {
+                            LazyVStack(spacing: 0, pinnedViews: .sectionHeaders) {
+                                ForEach(visibleGroups, id: \.group) { entry in
+                                    Section {
+                                        if isGroupExpanded(entry.group) {
+                                            ForEach(entry.prs) { pr in
+                                                PRRowView(
+                                                    pr: pr,
+                                                    columnWidths: columnWidths,
+                                                    onReview: onReviewPR.map { callback in
+                                                        { callback(pr) }
+                                                    }
+                                                )
+                                                .background(
+                                                    selectedPRID == pr.id
+                                                        ? theme.chrome.accent.opacity(0.15)
+                                                        : Color.clear
+                                                )
+                                                .onTapGesture {
+                                                    onSelectPR(
+                                                        selectedPRID == pr.id ? nil : pr
+                                                    )
+                                                }
+                                            }
                                         }
+                                    } header: {
+                                        groupHeader(entry.group, count: entry.prs.count)
+                                            .background(theme.chrome.background)
                                     }
-                                } header: {
-                                    groupHeader(entry.group, count: entry.prs.count)
-                                        .listRowInsets(EdgeInsets())
                                 }
                             }
                         }
-                        .listStyle(.plain)
-                        .scrollContentBackground(.hidden)
                     }
                 }
             }

--- a/Sources/Views/PRDashboard/PRDashboardView.swift
+++ b/Sources/Views/PRDashboard/PRDashboardView.swift
@@ -26,11 +26,6 @@ public struct PRDashboardView: View {
     @AppStorage("prListWidth") private var prListWidth: Double = 380
     @AppStorage("hideDrafts") private var hideDrafts: Bool = false
     @AppStorage("showSessionPRsOnly") private var showSessionPRsOnly: Bool = false
-    @AppStorage("prGroupNeedsAttentionExpanded") private var needsAttentionExpanded: Bool = true
-    @AppStorage("prGroupInProgressExpanded") private var inProgressExpanded: Bool = true
-    @AppStorage("prGroupReadyExpanded") private var readyExpanded: Bool = true
-    @AppStorage("prGroupWaitingForReviewExpanded") private var waitingForReviewExpanded: Bool = true
-    @AppStorage("prGroupDraftsExpanded") private var draftsExpanded: Bool = false
     @AppStorage("prSortField") private var sortFieldRaw: String = PRSortField.age.rawValue
     @AppStorage("prSortOrder") private var sortOrderRaw: String = PRSortOrder.descending.rawValue
     @AppStorage("prFilterRepo") private var filterRepo: String = ""
@@ -179,61 +174,12 @@ public struct PRDashboardView: View {
         return prs.count
     }
 
-    // MARK: - Grouping
+    // MARK: - Sorted PRs
 
-    private func groupedPRs() -> [(group: PRGroup, prs: [PullRequest])] {
-        var byGroup: [PRGroup: [PullRequest]] = [:]
-        for pr in filteredPRs {
-            let g = prGroup(for: pr)
-            byGroup[g, default: []].append(pr)
-        }
-        let currentSortField = sortField
-        let currentSortOrder = sortOrder
-        return PRGroup.allCases.compactMap { g in
-            guard var prs = byGroup[g], !prs.isEmpty else { return nil }
-            prs = sortPRs(prs, by: currentSortField, order: currentSortOrder)
-            return (g, prs)
-        }
-    }
-
-    private func isGroupExpanded(_ group: PRGroup) -> Bool {
-        switch group {
-        case .needsAttention: return needsAttentionExpanded
-        case .inProgress: return inProgressExpanded
-        case .ready: return readyExpanded
-        case .waitingForReview: return waitingForReviewExpanded
-        case .drafts: return draftsExpanded
-        }
-    }
-
-    private func toggleGroupExpanded(_ group: PRGroup) {
-        switch group {
-        case .needsAttention: needsAttentionExpanded.toggle()
-        case .inProgress: inProgressExpanded.toggle()
-        case .ready: readyExpanded.toggle()
-        case .waitingForReview: waitingForReviewExpanded.toggle()
-        case .drafts: draftsExpanded.toggle()
-        }
-    }
-
-    private func groupColor(_ group: PRGroup) -> Color {
-        switch group {
-        case .needsAttention: return theme.chrome.red
-        case .inProgress: return theme.chrome.yellow
-        case .ready: return theme.chrome.green
-        case .waitingForReview: return theme.chrome.accent
-        case .drafts: return theme.chrome.textDim
-        }
-    }
-
-    private func groupIcon(_ group: PRGroup) -> String {
-        switch group {
-        case .needsAttention: return "exclamationmark.circle"
-        case .inProgress: return "clock"
-        case .ready: return "checkmark.circle"
-        case .waitingForReview: return "eye"
-        case .drafts: return "circle.dashed"
-        }
+    private var sortedPRs: [PullRequest] {
+        var prs = filteredPRs
+        if hideDrafts { prs = prs.filter { !$0.isDraft } }
+        return sortPRs(prs, by: sortField, order: sortOrder)
     }
 
     // MARK: - Body
@@ -328,10 +274,9 @@ public struct PRDashboardView: View {
 
     // MARK: - PR List Content
 
-    /// The filter bar, column headers, and scrollable PR list as one cohesive unit.
+    /// The filter bar, column headers, and scrollable PR list.
     @ViewBuilder
     private var prListContent: some View {
-        // Filter bar — always visible, fixed above scroll
         PRFilterBar(
             filter: Binding(
                 get: { filterState },
@@ -340,8 +285,6 @@ public struct PRDashboardView: View {
             pullRequests: filteredPRs
         )
         Divider()
-
-        // Column headers — fixed above scroll
         PRColumnHeader(
             sortField: Binding(
                 get: { sortField },
@@ -358,8 +301,8 @@ public struct PRDashboardView: View {
         )
         Divider()
 
-        // Scrollable PR content
-        if filteredPRs.isEmpty && !isLoading {
+        let prs = sortedPRs
+        if prs.isEmpty && !isLoading {
             VStack(spacing: 8) {
                 Image(systemName: "pull.request")
                     .font(.largeTitle)
@@ -378,49 +321,27 @@ public struct PRDashboardView: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else {
-            let visibleGroups = groupedPRs().filter { !($0.group == .drafts && hideDrafts) }
-            if visibleGroups.isEmpty {
-                VStack(spacing: 8) {
-                    Image(systemName: "pull.request")
-                        .font(.largeTitle)
-                        .foregroundStyle(.secondary)
-                    Text("No pull requests")
-                        .foregroundStyle(.secondary)
-                    Button("Refresh") { onRefresh() }
-                        .controlSize(.small)
-                }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-            } else {
-                ScrollView {
-                    LazyVStack(alignment: .leading, spacing: 0) {
-                        ForEach(visibleGroups, id: \.group) { entry in
-                            groupHeader(entry.group, count: entry.prs.count)
-                                .background(theme.chrome.background)
-                            if isGroupExpanded(entry.group) {
-                                ForEach(entry.prs) { pr in
-                                    PRRowView(
-                                        pr: pr,
-                                        columnWidths: columnWidths,
-                                        onReview: onReviewPR.map { callback in
-                                            { callback(pr) }
-                                        }
-                                    )
-                                    .background(
-                                        selectedPRID == pr.id
-                                            ? theme.chrome.accent.opacity(0.15)
-                                            : Color.clear
-                                    )
-                                    .onTapGesture {
-                                        onSelectPR(selectedPRID == pr.id ? nil : pr)
-                                    }
-                                }
-                            }
-                        }
+            List(
+                selection: Binding(
+                    get: { selectedPRID },
+                    set: { id in
+                        let pr = prs.first(where: { $0.id == id })
+                        onSelectPR(pr)
                     }
-                    .frame(maxWidth: .infinity)
+                )
+            ) {
+                ForEach(prs) { pr in
+                    PRRowView(
+                        pr: pr,
+                        columnWidths: columnWidths,
+                        onReview: onReviewPR.map { callback in { callback(pr) } }
+                    )
+                    .tag(pr.id)
+                    .listRowInsets(EdgeInsets())
                 }
-                .frame(maxHeight: .infinity, alignment: .top)
             }
+            .listStyle(.plain)
+            .scrollContentBackground(.hidden)
         }
     }
 
@@ -442,31 +363,6 @@ public struct PRDashboardView: View {
         .accessibilityAddTraits(selectedTab == tab ? .isSelected : [])
     }
 
-    // MARK: - Group Header
-
-    private func groupHeader(_ group: PRGroup, count: Int) -> some View {
-        Button(action: { toggleGroupExpanded(group) }) {
-            HStack(spacing: 6) {
-                Image(systemName: groupIcon(group))
-                    .font(.callout)
-                    .foregroundColor(groupColor(group))
-                Text(group.rawValue)
-                    .font(.callout)
-                    .fontWeight(.semibold)
-                    .foregroundStyle(.secondary)
-                Text("(\(count))")
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
-                Spacer()
-                Image(systemName: isGroupExpanded(group) ? "chevron.down" : "chevron.right")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-            .padding(.horizontal, 12)
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-    }
 }
 
 // MARK: - Grouping

--- a/Sources/Views/PRDashboard/PRDashboardView.swift
+++ b/Sources/Views/PRDashboard/PRDashboardView.swift
@@ -197,79 +197,77 @@ public struct PRDashboardView: View {
                 )
             ) {
                 // Toolbar row
-                Section {
-                    HStack(spacing: 0) {
-                        ForEach(PRTab.allCases, id: \.self) { tab in
-                            tabButton(tab)
-                        }
-                        Spacer()
-
-                        if isLoading {
-                            ProgressView()
-                                .controlSize(.small)
-                                .padding(.trailing, 8)
-                        }
-
-                        Button {
-                            showSessionPRsOnly.toggle()
-                        } label: {
-                            Image(systemName: showSessionPRsOnly ? "terminal.fill" : "terminal")
-                                .font(.callout)
-                        }
-                        .buttonStyle(IconButtonStyle())
-                        .help(
-                            showSessionPRsOnly ? "Showing session PRs only" : "Show only session PRs"
-                        )
-                        .padding(.trailing, 4)
-
-                        Button {
-                            hideDrafts.toggle()
-                        } label: {
-                            Image(systemName: hideDrafts ? "eye.slash" : "eye")
-                                .font(.callout)
-                        }
-                        .buttonStyle(IconButtonStyle())
-                        .help(hideDrafts ? "Show drafts" : "Hide drafts")
-                        .padding(.trailing, 4)
-
-                        Button(action: onRefresh) {
-                            Image(systemName: "arrow.clockwise")
-                                .font(.callout)
-                        }
-                        .buttonStyle(IconButtonStyle())
-                        .padding(.trailing, 8)
+                HStack(spacing: 0) {
+                    ForEach(PRTab.allCases, id: \.self) { tab in
+                        tabButton(tab)
                     }
-                    .listRowInsets(EdgeInsets())
-                    .listRowSeparator(.hidden)
+                    Spacer()
 
-                    // Filter bar
-                    PRFilterBar(
-                        filter: Binding(
-                            get: { filterState },
-                            set: { filterState = $0 }
-                        ),
-                        pullRequests: filteredPRs
-                    )
-                    .listRowInsets(EdgeInsets())
-                    .listRowSeparator(.hidden)
+                    if isLoading {
+                        ProgressView()
+                            .controlSize(.small)
+                            .padding(.trailing, 8)
+                    }
 
-                    // Column headers
-                    PRColumnHeader(
-                        sortField: Binding(
-                            get: { sortField },
-                            set: { sortField = $0 }
-                        ),
-                        sortOrder: Binding(
-                            get: { sortOrder },
-                            set: { sortOrder = $0 }
-                        ),
-                        columnWidths: Binding(
-                            get: { columnWidths },
-                            set: { columnWidths = $0 }
-                        )
+                    Button {
+                        showSessionPRsOnly.toggle()
+                    } label: {
+                        Image(systemName: showSessionPRsOnly ? "terminal.fill" : "terminal")
+                            .font(.callout)
+                    }
+                    .buttonStyle(IconButtonStyle())
+                    .help(
+                        showSessionPRsOnly ? "Showing session PRs only" : "Show only session PRs"
                     )
-                    .listRowInsets(EdgeInsets())
+                    .padding(.trailing, 4)
+
+                    Button {
+                        hideDrafts.toggle()
+                    } label: {
+                        Image(systemName: hideDrafts ? "eye.slash" : "eye")
+                            .font(.callout)
+                    }
+                    .buttonStyle(IconButtonStyle())
+                    .help(hideDrafts ? "Show drafts" : "Hide drafts")
+                    .padding(.trailing, 4)
+
+                    Button(action: onRefresh) {
+                        Image(systemName: "arrow.clockwise")
+                            .font(.callout)
+                    }
+                    .buttonStyle(IconButtonStyle())
+                    .padding(.trailing, 8)
                 }
+                .listRowInsets(EdgeInsets())
+                .listRowSeparator(.hidden)
+
+                // Filter bar
+                PRFilterBar(
+                    filter: Binding(
+                        get: { filterState },
+                        set: { filterState = $0 }
+                    ),
+                    pullRequests: filteredPRs
+                )
+                .listRowInsets(EdgeInsets())
+                .listRowSeparator(.hidden)
+
+                // Column headers
+                PRColumnHeader(
+                    sortField: Binding(
+                        get: { sortField },
+                        set: { sortField = $0 }
+                    ),
+                    sortOrder: Binding(
+                        get: { sortOrder },
+                        set: { sortOrder = $0 }
+                    ),
+                    columnWidths: Binding(
+                        get: { columnWidths },
+                        set: { columnWidths = $0 }
+                    )
+                )
+                .listRowInsets(EdgeInsets())
 
                 // PR rows
                 ForEach(sortedPRs) { pr in

--- a/Sources/Views/PRDashboard/PRDashboardView.swift
+++ b/Sources/Views/PRDashboard/PRDashboardView.swift
@@ -39,6 +39,12 @@ public struct PRDashboardView: View {
     @AppStorage("prFilterChecks") private var filterChecksRaw: String = ""
     @AppStorage("prFilterReview") private var filterReviewRaw: String = ""
     @AppStorage("prFilterMerge") private var filterMergeRaw: String = ""
+    @AppStorage("prColRepo") private var colRepo: Double = Double(PRColumnWidths.defaults.repo)
+    @AppStorage("prColAuthor") private var colAuthor: Double = Double(PRColumnWidths.defaults.author)
+    @AppStorage("prColAge") private var colAge: Double = Double(PRColumnWidths.defaults.age)
+    @AppStorage("prColChecks") private var colChecks: Double = Double(PRColumnWidths.defaults.checks)
+    @AppStorage("prColReview") private var colReview: Double = Double(PRColumnWidths.defaults.review)
+    @AppStorage("prColMerge") private var colMerge: Double = Double(PRColumnWidths.defaults.merge)
     @Environment(\.theme) private var theme
 
     private var sortField: PRSortField {
@@ -69,6 +75,23 @@ public struct PRDashboardView: View {
             filterChecksRaw = newValue.checks?.rawValue ?? ""
             filterReviewRaw = newValue.review?.rawValue ?? ""
             filterMergeRaw = newValue.mergeFilter?.rawValue ?? ""
+        }
+    }
+
+    private var columnWidths: PRColumnWidths {
+        get {
+            PRColumnWidths(
+                repo: CGFloat(colRepo), author: CGFloat(colAuthor), age: CGFloat(colAge),
+                checks: CGFloat(colChecks), review: CGFloat(colReview), merge: CGFloat(colMerge)
+            )
+        }
+        nonmutating set {
+            colRepo = Double(newValue.repo)
+            colAuthor = Double(newValue.author)
+            colAge = Double(newValue.age)
+            colChecks = Double(newValue.checks)
+            colReview = Double(newValue.review)
+            colMerge = Double(newValue.merge)
         }
     }
 
@@ -286,6 +309,10 @@ public struct PRDashboardView: View {
                     sortOrder: Binding(
                         get: { sortOrder },
                         set: { sortOrder = $0 }
+                    ),
+                    columnWidths: Binding(
+                        get: { columnWidths },
+                        set: { columnWidths = $0 }
                     )
                 )
 
@@ -341,6 +368,7 @@ public struct PRDashboardView: View {
                                         ForEach(entry.prs) { pr in
                                             PRRowView(
                                                 pr: pr,
+                                                columnWidths: columnWidths,
                                                 onReview: onReviewPR.map { callback in { callback(pr) } }
                                             )
                                             .tag(pr.id)
@@ -487,6 +515,7 @@ public enum PRTab: String, CaseIterable, Sendable {
 
 struct PRRowView: View {
     let pr: PullRequest
+    let columnWidths: PRColumnWidths
     var onReview: (() -> Void)?
     @Environment(\.theme) private var theme
 
@@ -510,32 +539,32 @@ struct PRRowView: View {
                 .font(.caption)
                 .foregroundColor(theme.chrome.cyan)
                 .lineLimit(1)
-                .frame(width: 100, alignment: .leading)
+                .frame(width: columnWidths.repo, alignment: .leading)
 
             // Author column
             Text(pr.author)
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
-                .frame(width: 70, alignment: .leading)
+                .frame(width: columnWidths.author, alignment: .leading)
 
             // Age column
             Text(pr.ageText)
                 .font(.caption)
                 .foregroundStyle(.secondary)
-                .frame(width: 50, alignment: .leading)
+                .frame(width: columnWidths.age, alignment: .leading)
 
             // Checks column
             CheckSummaryBadge(checks: pr.checks)
-                .frame(width: 55, alignment: .leading)
+                .frame(width: columnWidths.checks, alignment: .leading)
 
             // Review column
             ReviewDecisionBadge(decision: pr.reviewDecision)
-                .frame(width: 55, alignment: .leading)
+                .frame(width: columnWidths.review, alignment: .leading)
 
             // Merge column
             MergeStatusBadge(mergeable: pr.mergeable, mergeStateStatus: pr.mergeStateStatus)
-                .frame(width: 65, alignment: .leading)
+                .frame(width: columnWidths.merge, alignment: .leading)
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 4)

--- a/Sources/Views/PRDashboard/PRDashboardView.swift
+++ b/Sources/Views/PRDashboard/PRDashboardView.swift
@@ -280,7 +280,7 @@ public struct PRDashboardView: View {
                     .listRowInsets(EdgeInsets())
                 }
             }
-            .listStyle(.inset(alternatesRowBackgrounds: false))
+            .listStyle(.plain)
             .scrollContentBackground(.hidden)
             .frame(minWidth: 300)
             .frame(maxWidth: selectedPR == nil ? .infinity : CGFloat(prListWidth))

--- a/Sources/Views/PRDashboard/PRDashboardView.swift
+++ b/Sources/Views/PRDashboard/PRDashboardView.swift
@@ -186,125 +186,104 @@ public struct PRDashboardView: View {
 
     public var body: some View {
         HStack(spacing: 0) {
-            // Left: PR list
-            VStack(spacing: 0) {
-                // Toolbar
-                HStack(spacing: 0) {
-                    ForEach(PRTab.allCases, id: \.self) { tab in
-                        tabButton(tab)
+            // Left: PR list — single List containing everything
+            List(
+                selection: Binding(
+                    get: { selectedPRID },
+                    set: { id in
+                        let pr = sortedPRs.first(where: { $0.id == id })
+                        onSelectPR(pr)
                     }
-                    Spacer()
-
-                    if isLoading {
-                        ProgressView()
-                            .controlSize(.small)
-                            .padding(.trailing, 8)
-                    }
-
-                    // Sessions filter toggle
-                    Button {
-                        showSessionPRsOnly.toggle()
-                    } label: {
-                        Image(systemName: showSessionPRsOnly ? "terminal.fill" : "terminal")
-                            .font(.callout)
-                    }
-                    .buttonStyle(IconButtonStyle())
-                    .help(showSessionPRsOnly ? "Showing session PRs only" : "Show only session PRs")
-                    .padding(.trailing, 4)
-
-                    Button {
-                        hideDrafts.toggle()
-                    } label: {
-                        Image(systemName: hideDrafts ? "eye.slash" : "eye")
-                            .font(.callout)
-                    }
-                    .buttonStyle(IconButtonStyle())
-                    .help(hideDrafts ? "Show drafts" : "Hide drafts")
-                    .padding(.trailing, 4)
-
-                    Button(action: onRefresh) {
-                        Image(systemName: "arrow.clockwise")
-                            .font(.callout)
-                    }
-                    .buttonStyle(IconButtonStyle())
-                    .padding(.trailing, 8)
-                }
-                .padding(.horizontal)
-                .padding(.vertical, 8)
-                .background(theme.chrome.surface)
-
-                Divider()
-
-                PRFilterBar(
-                    filter: Binding(
-                        get: { filterState },
-                        set: { filterState = $0 }
-                    ),
-                    pullRequests: filteredPRs
                 )
-                Divider()
-                PRColumnHeader(
-                    sortField: Binding(
-                        get: { sortField },
-                        set: { sortField = $0 }
-                    ),
-                    sortOrder: Binding(
-                        get: { sortOrder },
-                        set: { sortOrder = $0 }
-                    ),
-                    columnWidths: Binding(
-                        get: { columnWidths },
-                        set: { columnWidths = $0 }
-                    )
-                )
-                Divider()
+            ) {
+                // Toolbar row
+                Section {
+                    HStack(spacing: 0) {
+                        ForEach(PRTab.allCases, id: \.self) { tab in
+                            tabButton(tab)
+                        }
+                        Spacer()
 
-                GeometryReader { _ in
-                    List(
-                        selection: Binding(
-                            get: { selectedPRID },
-                            set: { id in
-                                let pr = sortedPRs.first(where: { $0.id == id })
-                                onSelectPR(pr)
-                            }
+                        if isLoading {
+                            ProgressView()
+                                .controlSize(.small)
+                                .padding(.trailing, 8)
+                        }
+
+                        Button {
+                            showSessionPRsOnly.toggle()
+                        } label: {
+                            Image(systemName: showSessionPRsOnly ? "terminal.fill" : "terminal")
+                                .font(.callout)
+                        }
+                        .buttonStyle(IconButtonStyle())
+                        .help(
+                            showSessionPRsOnly ? "Showing session PRs only" : "Show only session PRs"
                         )
-                    ) {
-                        ForEach(sortedPRs) { pr in
-                            PRRowView(
-                                pr: pr,
-                                columnWidths: columnWidths,
-                                onReview: onReviewPR.map { callback in { callback(pr) } }
-                            )
-                            .tag(pr.id)
-                            .listRowInsets(EdgeInsets())
+                        .padding(.trailing, 4)
+
+                        Button {
+                            hideDrafts.toggle()
+                        } label: {
+                            Image(systemName: hideDrafts ? "eye.slash" : "eye")
+                                .font(.callout)
                         }
-                    }
-                    .listStyle(.plain)
-                    .scrollContentBackground(.hidden)
-                    .overlay {
-                        if sortedPRs.isEmpty && !isLoading {
-                            VStack(spacing: 8) {
-                                Image(systemName: "pull.request")
-                                    .font(.largeTitle)
-                                    .foregroundStyle(.secondary)
-                                if filterState.isActive {
-                                    Text("No PRs match current filters")
-                                        .foregroundStyle(.secondary)
-                                    Button("Clear Filters") {
-                                        filterState = PRFilterState()
-                                    }
-                                    .controlSize(.small)
-                                } else {
-                                    Text("No pull requests")
-                                        .foregroundStyle(.secondary)
-                                    Button("Refresh") { onRefresh() }
-                                        .controlSize(.small)
-                                }
-                            }
+                        .buttonStyle(IconButtonStyle())
+                        .help(hideDrafts ? "Show drafts" : "Hide drafts")
+                        .padding(.trailing, 4)
+
+                        Button(action: onRefresh) {
+                            Image(systemName: "arrow.clockwise")
+                                .font(.callout)
                         }
+                        .buttonStyle(IconButtonStyle())
+                        .padding(.trailing, 8)
                     }
+                    .listRowInsets(EdgeInsets())
+                    .listRowSeparator(.hidden)
+
+                    // Filter bar
+                    PRFilterBar(
+                        filter: Binding(
+                            get: { filterState },
+                            set: { filterState = $0 }
+                        ),
+                        pullRequests: filteredPRs
+                    )
+                    .listRowInsets(EdgeInsets())
+                    .listRowSeparator(.hidden)
+
+                    // Column headers
+                    PRColumnHeader(
+                        sortField: Binding(
+                            get: { sortField },
+                            set: { sortField = $0 }
+                        ),
+                        sortOrder: Binding(
+                            get: { sortOrder },
+                            set: { sortOrder = $0 }
+                        ),
+                        columnWidths: Binding(
+                            get: { columnWidths },
+                            set: { columnWidths = $0 }
+                        )
+                    )
+                    .listRowInsets(EdgeInsets())
+                }
+
+                // PR rows
+                ForEach(sortedPRs) { pr in
+                    PRRowView(
+                        pr: pr,
+                        columnWidths: columnWidths,
+                        onReview: onReviewPR.map { callback in { callback(pr) } }
+                    )
+                    .tag(pr.id)
+                    .listRowInsets(EdgeInsets())
                 }
             }
+            .listStyle(.inset(alternatesRowBackgrounds: false))
+            .scrollContentBackground(.hidden)
             .frame(minWidth: 300)
             .frame(maxWidth: selectedPR == nil ? .infinity : CGFloat(prListWidth))
 

--- a/Sources/Views/PRDashboard/PRDashboardView.swift
+++ b/Sources/Views/PRDashboard/PRDashboardView.swift
@@ -408,55 +408,53 @@ struct PRRowView: View {
     @Environment(\.theme) private var theme
 
     var body: some View {
-        HStack(spacing: 8) {
-            stateBadge
-
-            VStack(alignment: .leading, spacing: 2) {
-                HStack(spacing: 4) {
-                    Text("#\(pr.number)")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                    Text(pr.title)
-                        .font(.body)
-                        .foregroundStyle(.primary)
-                        .lineLimit(1)
-                }
-
-                HStack(spacing: 8) {
-                    Text(pr.repo)
-                        .font(.caption)
-                        .foregroundColor(theme.chrome.cyan)
-                    Text(pr.author)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                    if !pr.headBranch.isEmpty {
-                        Text(pr.headBranch)
-                            .font(.caption)
-                            .foregroundColor(theme.chrome.accent)
-                    }
-                    Text(pr.ageText)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                    CheckSummaryBadge(checks: pr.checks)
-                    ReviewDecisionBadge(decision: pr.reviewDecision)
-                    MergeStatusBadge(mergeable: pr.mergeable, mergeStateStatus: pr.mergeStateStatus)
-                }
-            }
-
-            Spacer()
-
-            if pr.additions > 0 || pr.deletions > 0 {
-                Text("+\(pr.additions) -\(pr.deletions)")
+        HStack(spacing: 0) {
+            // Title column (flexible)
+            HStack(spacing: 4) {
+                stateBadge
+                Text("#\(pr.number)")
                     .font(.caption)
                     .foregroundStyle(.secondary)
-                    .frame(minWidth: 60, alignment: .trailing)
-            } else if pr.checks.total == 0 {
-                // Unenriched — reserve space with loading indicator
-                ProgressView()
-                    .controlSize(.mini)
-                    .frame(minWidth: 60, alignment: .trailing)
+                Text(pr.title)
+                    .font(.callout)
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            // Repo column
+            Text(repoShortName)
+                .font(.caption)
+                .foregroundColor(theme.chrome.cyan)
+                .lineLimit(1)
+                .frame(width: 100, alignment: .leading)
+
+            // Author column
+            Text(pr.author)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .frame(width: 70, alignment: .leading)
+
+            // Age column
+            Text(pr.ageText)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .frame(width: 50, alignment: .leading)
+
+            // Checks column
+            CheckSummaryBadge(checks: pr.checks)
+                .frame(width: 55, alignment: .leading)
+
+            // Review column
+            ReviewDecisionBadge(decision: pr.reviewDecision)
+                .frame(width: 55, alignment: .leading)
+
+            // Merge column
+            MergeStatusBadge(mergeable: pr.mergeable, mergeStateStatus: pr.mergeStateStatus)
+                .frame(width: 65, alignment: .leading)
         }
+        .padding(.horizontal, 12)
         .padding(.vertical, 4)
         .opacity(pr.isDraft ? 0.5 : 1.0)
         .contextMenu {
@@ -464,6 +462,14 @@ struct PRRowView: View {
                 Button("Open Review Session") { onReview() }
             }
         }
+    }
+
+    /// Extract short repo name from "owner/repo" format.
+    private var repoShortName: String {
+        if let slashIndex = pr.repo.lastIndex(of: "/") {
+            return String(pr.repo[pr.repo.index(after: slashIndex)...])
+        }
+        return pr.repo
     }
 
     @ViewBuilder

--- a/Sources/Views/PRDashboard/PRDashboardView.swift
+++ b/Sources/Views/PRDashboard/PRDashboardView.swift
@@ -186,17 +186,131 @@ public struct PRDashboardView: View {
 
     public var body: some View {
         HStack(spacing: 0) {
-            // Left: PR list — single List containing everything
-            List(
-                selection: Binding(
-                    get: { selectedPRID },
-                    set: { id in
-                        let pr = sortedPRs.first(where: { $0.id == id })
-                        onSelectPR(pr)
+            // Left: PR table
+            prTable
+                .frame(minWidth: 300)
+                .frame(maxWidth: selectedPR == nil ? .infinity : CGFloat(prListWidth))
+
+            // Right: PR detail drawer
+            if let pr = selectedPR {
+                ResizableDivider(width: $prListWidth)
+                PRDetailDrawer(
+                    pr: pr,
+                    detail: detail,
+                    onClose: { onSelectPR(nil) },
+                    onApprove: { onApprove(pr) },
+                    onComment: { body in onComment(pr, body) },
+                    onRequestChanges: { body in onRequestChanges?(pr, body) },
+                    onMerge: { strategy in onMerge?(pr, strategy) },
+                    onToggleDraft: { onToggleDraft?(pr) },
+                    onUpdateBranch: onUpdateBranch.map { callback in
+                        { rebase in callback(pr, rebase) }
+                    },
+                    onSendToSession: onSendToSession.map { callback in
+                        { context in callback(pr, context) }
+                    },
+                    onEnableAutoMerge: onEnableAutoMerge.map { callback in
+                        { strategy in callback(pr, strategy) }
+                    },
+                    onDisableAutoMerge: onDisableAutoMerge.map { callback in
+                        { callback(pr) }
                     }
                 )
-            ) {
-                // Toolbar row
+                .frame(maxWidth: .infinity)
+            }
+        }
+        .task { onRefresh() }
+    }
+
+    // MARK: - PR Table
+
+    private var prTable: some View {
+        Table(
+            of: PullRequest.self,
+            selection: Binding(
+                get: { selectedPRID },
+                set: { id in
+                    let pr = sortedPRs.first(where: { $0.id == id })
+                    onSelectPR(pr)
+                }
+            )
+        ) {
+            TableColumn("Title") { pr in
+                HStack(spacing: 4) {
+                    prStateBadge(pr)
+                    Text("#\(pr.number)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Text(pr.title)
+                        .font(.callout)
+                        .lineLimit(1)
+                }
+            }
+            .width(min: 150)
+
+            TableColumn("Repo") { pr in
+                Text(prRepoShortName(pr))
+                    .font(.caption)
+                    .foregroundColor(theme.chrome.cyan)
+                    .lineLimit(1)
+            }
+            .width(min: 70, ideal: 130, max: 250)
+
+            TableColumn("Author") { pr in
+                Text(pr.author)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            .width(min: 60, ideal: 90, max: 200)
+
+            TableColumn("Age") { pr in
+                Text(pr.ageText)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .width(min: 40, ideal: 60, max: 80)
+
+            TableColumn("Checks") { pr in
+                if pr.checks.total > 0 {
+                    Text("\(pr.checks.passed)/\(pr.checks.total)")
+                        .font(.caption)
+                        .foregroundColor(
+                            pr.checks.allPassed
+                                ? theme.chrome.green
+                                : pr.checks.hasFailed ? theme.chrome.red : theme.chrome.yellow
+                        )
+                }
+            }
+            .width(min: 40, ideal: 55, max: 80)
+
+            TableColumn("Review") { pr in
+                Text(reviewLabel(pr.reviewDecision))
+                    .font(.caption)
+                    .foregroundColor(reviewColor(pr.reviewDecision))
+            }
+            .width(min: 50, ideal: 70, max: 100)
+
+            TableColumn("Merge") { pr in
+                Text(mergeLabel(pr))
+                    .font(.caption)
+                    .foregroundColor(mergeColor(pr))
+            }
+            .width(min: 50, ideal: 70, max: 100)
+        } rows: {
+            ForEach(sortedPRs) { pr in
+                TableRow(pr)
+                    .contextMenu {
+                        if let onReviewPR {
+                            Button("Open Review Session") { onReviewPR(pr) }
+                        }
+                    }
+            }
+        }
+        .tableStyle(.inset(alternatesRowBackgrounds: true))
+        .safeAreaInset(edge: .top, spacing: 0) {
+            VStack(spacing: 0) {
+                // Toolbar
                 HStack(spacing: 0) {
                     ForEach(PRTab.allCases, id: \.self) { tab in
                         tabButton(tab)
@@ -238,9 +352,11 @@ public struct PRDashboardView: View {
                     .buttonStyle(IconButtonStyle())
                     .padding(.trailing, 8)
                 }
-                .listRowInsets(EdgeInsets())
-                .listRowSeparator(.hidden)
-                .tag("__toolbar__")
+                .padding(.horizontal)
+                .padding(.vertical, 8)
+                .background(theme.chrome.surface)
+
+                Divider()
 
                 // Filter bar
                 PRFilterBar(
@@ -250,73 +366,73 @@ public struct PRDashboardView: View {
                     ),
                     pullRequests: filteredPRs
                 )
-                .listRowInsets(EdgeInsets())
-                .listRowSeparator(.hidden)
-                .tag("__filter__")
 
-                // Column headers
-                PRColumnHeader(
-                    sortField: Binding(
-                        get: { sortField },
-                        set: { sortField = $0 }
-                    ),
-                    sortOrder: Binding(
-                        get: { sortOrder },
-                        set: { sortOrder = $0 }
-                    ),
-                    columnWidths: Binding(
-                        get: { columnWidths },
-                        set: { columnWidths = $0 }
-                    )
-                )
-                .listRowInsets(EdgeInsets())
-                .tag("__columns__")
-
-                // PR rows
-                ForEach(sortedPRs) { pr in
-                    PRRowView(
-                        pr: pr,
-                        columnWidths: columnWidths,
-                        onReview: onReviewPR.map { callback in { callback(pr) } }
-                    )
-                    .tag(pr.id)
-                    .listRowInsets(EdgeInsets())
-                }
-            }
-            .listStyle(.plain)
-            .scrollContentBackground(.hidden)
-            .frame(minWidth: 300)
-            .frame(maxWidth: selectedPR == nil ? .infinity : CGFloat(prListWidth))
-
-            // Right: PR detail drawer
-            if let pr = selectedPR {
-                ResizableDivider(width: $prListWidth)
-                PRDetailDrawer(
-                    pr: pr,
-                    detail: detail,
-                    onClose: { onSelectPR(nil) },
-                    onApprove: { onApprove(pr) },
-                    onComment: { body in onComment(pr, body) },
-                    onRequestChanges: { body in onRequestChanges?(pr, body) },
-                    onMerge: { strategy in onMerge?(pr, strategy) },
-                    onToggleDraft: { onToggleDraft?(pr) },
-                    onUpdateBranch: onUpdateBranch.map { callback in
-                        { rebase in callback(pr, rebase) }
-                    },
-                    onSendToSession: onSendToSession.map { callback in
-                        { context in callback(pr, context) }
-                    },
-                    onEnableAutoMerge: onEnableAutoMerge.map { callback in
-                        { strategy in callback(pr, strategy) }
-                    },
-                    onDisableAutoMerge: onDisableAutoMerge.map { callback in
-                        { callback(pr) }
-                    }
-                )
-                .frame(maxWidth: .infinity)
+                Divider()
             }
         }
-        .task { onRefresh() }
+    }
+
+    // MARK: - Cell Helpers
+
+    @ViewBuilder
+    private func prStateBadge(_ pr: PullRequest) -> some View {
+        switch pr.state {
+        case .open:
+            Circle().fill(theme.chrome.green).frame(width: 8, height: 8)
+        case .draft:
+            Circle().stroke(theme.chrome.textDim, lineWidth: 1.5).frame(width: 8, height: 8)
+        case .merged:
+            Circle().fill(theme.chrome.purple).frame(width: 8, height: 8)
+        case .closed:
+            Circle().fill(theme.chrome.red).frame(width: 8, height: 8)
+        }
+    }
+
+    private func prRepoShortName(_ pr: PullRequest) -> String {
+        if let idx = pr.repo.lastIndex(of: "/") {
+            return String(pr.repo[pr.repo.index(after: idx)...])
+        }
+        return pr.repo
+    }
+
+    private func reviewLabel(_ decision: ReviewDecision) -> String {
+        switch decision {
+        case .approved: "Approved"
+        case .changesRequested: "Changes"
+        case .pending: "Review"
+        case .none: ""
+        }
+    }
+
+    private func reviewColor(_ decision: ReviewDecision) -> Color {
+        switch decision {
+        case .approved: theme.chrome.green
+        case .changesRequested: theme.chrome.orange
+        case .pending: theme.chrome.yellow
+        case .none: .clear
+        }
+    }
+
+    private func mergeLabel(_ pr: PullRequest) -> String {
+        if pr.mergeable == .conflicting { return "Conflicts" }
+        switch pr.mergeStateStatus {
+        case .blocked: return "Blocked"
+        case .behind: return "Behind"
+        case .clean, .hasHooks: return "Clean"
+        case .dirty: return "Dirty"
+        case .unstable: return "Unstable"
+        default: return ""
+        }
+    }
+
+    private func mergeColor(_ pr: PullRequest) -> Color {
+        if pr.mergeable == .conflicting { return theme.chrome.red }
+        switch pr.mergeStateStatus {
+        case .blocked, .dirty: return theme.chrome.orange
+        case .behind, .unstable: return theme.chrome.yellow
+        case .clean, .hasHooks: return theme.chrome.green
+        default: return .clear
+        }
     }
 
     // MARK: - Tab Button
@@ -388,166 +504,4 @@ public enum PRTab: String, CaseIterable, Sendable {
     case all = "All"
     case mine = "Mine"
     case reviewRequested = "Review Requests"
-}
-
-// MARK: - PR Row View
-
-struct PRRowView: View {
-    let pr: PullRequest
-    let columnWidths: PRColumnWidths
-    var onReview: (() -> Void)?
-    @Environment(\.theme) private var theme
-
-    var body: some View {
-        HStack(spacing: 0) {
-            // Title column (flexible)
-            HStack(spacing: 4) {
-                stateBadge
-                Text("#\(pr.number)")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                Text(pr.title)
-                    .font(.callout)
-                    .foregroundStyle(.primary)
-                    .lineLimit(1)
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .clipped()
-
-            // Repo column
-            Text(repoShortName)
-                .font(.caption)
-                .foregroundColor(theme.chrome.cyan)
-                .lineLimit(1)
-                .frame(width: columnWidths.repo, alignment: .leading)
-                .clipped()
-
-            // Author column
-            Text(pr.author)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .lineLimit(1)
-                .frame(width: columnWidths.author, alignment: .leading)
-                .clipped()
-
-            // Age column
-            Text(pr.ageText)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .lineLimit(1)
-                .frame(width: columnWidths.age, alignment: .leading)
-                .clipped()
-
-            // Checks column
-            checksText
-                .frame(width: columnWidths.checks, alignment: .leading)
-
-            // Review column
-            reviewText
-                .frame(width: columnWidths.review, alignment: .leading)
-
-            // Merge column
-            mergeText
-                .frame(width: columnWidths.merge, alignment: .leading)
-        }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 4)
-        .opacity(pr.isDraft ? 0.5 : 1.0)
-        .contextMenu {
-            if let onReview {
-                Button("Open Review Session") { onReview() }
-            }
-        }
-    }
-
-    // MARK: - Column Text
-
-    @ViewBuilder
-    private var checksText: some View {
-        if pr.checks.total > 0 {
-            Text("\(pr.checks.passed)/\(pr.checks.total)")
-                .font(.caption)
-                .foregroundColor(
-                    pr.checks.allPassed
-                        ? theme.chrome.green
-                        : pr.checks.hasFailed ? theme.chrome.red : theme.chrome.yellow
-                )
-        }
-    }
-
-    @ViewBuilder
-    private var reviewText: some View {
-        switch pr.reviewDecision {
-        case .approved:
-            Text("Approved")
-                .font(.caption)
-                .foregroundColor(theme.chrome.green)
-        case .changesRequested:
-            Text("Changes")
-                .font(.caption)
-                .foregroundColor(theme.chrome.orange)
-        case .pending:
-            Text("Review")
-                .font(.caption)
-                .foregroundColor(theme.chrome.yellow)
-        case .none:
-            EmptyView()
-        }
-    }
-
-    @ViewBuilder
-    private var mergeText: some View {
-        if pr.mergeable == .conflicting {
-            Text("Conflicts")
-                .font(.caption)
-                .foregroundColor(theme.chrome.red)
-        } else {
-            switch pr.mergeStateStatus {
-            case .blocked:
-                Text("Blocked")
-                    .font(.caption)
-                    .foregroundColor(theme.chrome.orange)
-            case .behind:
-                Text("Behind")
-                    .font(.caption)
-                    .foregroundColor(theme.chrome.yellow)
-            case .clean, .hasHooks:
-                Text("Clean")
-                    .font(.caption)
-                    .foregroundColor(theme.chrome.green)
-            case .dirty:
-                Text("Dirty")
-                    .font(.caption)
-                    .foregroundColor(theme.chrome.orange)
-            case .unstable:
-                Text("Unstable")
-                    .font(.caption)
-                    .foregroundColor(theme.chrome.yellow)
-            default:
-                EmptyView()
-            }
-        }
-    }
-
-    /// Extract short repo name from "owner/repo" format.
-    private var repoShortName: String {
-        if let slashIndex = pr.repo.lastIndex(of: "/") {
-            return String(pr.repo[pr.repo.index(after: slashIndex)...])
-        }
-        return pr.repo
-    }
-
-    @ViewBuilder
-    private var stateBadge: some View {
-        switch pr.state {
-        case .open:
-            Circle().fill(theme.chrome.green).frame(width: 8, height: 8)
-        case .draft:
-            Circle().stroke(theme.chrome.textDim, lineWidth: 1.5).frame(width: 8, height: 8)
-        case .merged:
-            Circle().fill(theme.chrome.purple).frame(width: 8, height: 8)
-        case .closed:
-            Circle().fill(theme.chrome.red).frame(width: 8, height: 8)
-        }
-    }
 }

--- a/Sources/Views/PRDashboard/PRDashboardView.swift
+++ b/Sources/Views/PRDashboard/PRDashboardView.swift
@@ -438,22 +438,16 @@ struct PRRowView: View {
                 .clipped()
 
             // Checks column
-            CheckSummaryBadge(checks: pr.checks)
-                .lineLimit(1)
+            checksText
                 .frame(width: columnWidths.checks, alignment: .leading)
-                .clipped()
 
             // Review column
-            ReviewDecisionBadge(decision: pr.reviewDecision)
-                .lineLimit(1)
+            reviewText
                 .frame(width: columnWidths.review, alignment: .leading)
-                .clipped()
 
             // Merge column
-            MergeStatusBadge(mergeable: pr.mergeable, mergeStateStatus: pr.mergeStateStatus)
-                .lineLimit(1)
+            mergeText
                 .frame(width: columnWidths.merge, alignment: .leading)
-                .clipped()
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 4)
@@ -461,6 +455,75 @@ struct PRRowView: View {
         .contextMenu {
             if let onReview {
                 Button("Open Review Session") { onReview() }
+            }
+        }
+    }
+
+    // MARK: - Column Text
+
+    @ViewBuilder
+    private var checksText: some View {
+        if pr.checks.total > 0 {
+            Text("\(pr.checks.passed)/\(pr.checks.total)")
+                .font(.caption)
+                .foregroundColor(
+                    pr.checks.allPassed
+                        ? theme.chrome.green
+                        : pr.checks.hasFailed ? theme.chrome.red : theme.chrome.yellow
+                )
+        }
+    }
+
+    @ViewBuilder
+    private var reviewText: some View {
+        switch pr.reviewDecision {
+        case .approved:
+            Text("Approved")
+                .font(.caption)
+                .foregroundColor(theme.chrome.green)
+        case .changesRequested:
+            Text("Changes")
+                .font(.caption)
+                .foregroundColor(theme.chrome.orange)
+        case .pending:
+            Text("Review")
+                .font(.caption)
+                .foregroundColor(theme.chrome.yellow)
+        case .none:
+            EmptyView()
+        }
+    }
+
+    @ViewBuilder
+    private var mergeText: some View {
+        if pr.mergeable == .conflicting {
+            Text("Conflicts")
+                .font(.caption)
+                .foregroundColor(theme.chrome.red)
+        } else {
+            switch pr.mergeStateStatus {
+            case .blocked:
+                Text("Blocked")
+                    .font(.caption)
+                    .foregroundColor(theme.chrome.orange)
+            case .behind:
+                Text("Behind")
+                    .font(.caption)
+                    .foregroundColor(theme.chrome.yellow)
+            case .clean, .hasHooks:
+                Text("Clean")
+                    .font(.caption)
+                    .foregroundColor(theme.chrome.green)
+            case .dirty:
+                Text("Dirty")
+                    .font(.caption)
+                    .foregroundColor(theme.chrome.orange)
+            case .unstable:
+                Text("Unstable")
+                    .font(.caption)
+                    .foregroundColor(theme.chrome.yellow)
+            default:
+                EmptyView()
             }
         }
     }

--- a/Sources/Views/PRDashboard/PRFilterBar.swift
+++ b/Sources/Views/PRDashboard/PRFilterBar.swift
@@ -125,11 +125,11 @@ struct PRFilterBar: View {
 
     private func reviewLabel(_ decision: ReviewDecision?) -> String {
         switch decision {
-        case .approved: "Approved"
-        case .changesRequested: "Changes Requested"
-        case .pending: "Pending"
-        case .none: "All"
+        case .some(.approved): "Approved"
+        case .some(.changesRequested): "Changes Requested"
+        case .some(.pending): "Pending"
         case .some(.none): "All"
+        case nil: "All"
         }
     }
 }

--- a/Sources/Views/PRDashboard/PRFilterBar.swift
+++ b/Sources/Views/PRDashboard/PRFilterBar.swift
@@ -1,0 +1,135 @@
+import Models
+import SwiftUI
+import Theme
+
+/// Persistent filter bar with dropdown menus for each filter dimension.
+struct PRFilterBar: View {
+    @Binding var filter: PRFilterState
+    let pullRequests: [PullRequest]
+    @Environment(\.theme) private var theme
+
+    /// Distinct repo values from current PRs, sorted alphabetically.
+    private var repoOptions: [String] {
+        Array(Set(pullRequests.map(\.repo))).sorted()
+    }
+
+    /// Distinct author values from current PRs, sorted alphabetically.
+    private var authorOptions: [String] {
+        Array(Set(pullRequests.map(\.author))).sorted()
+    }
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Text("Filter:")
+                .font(.caption)
+                .foregroundColor(theme.chrome.textDim)
+
+            filterMenu("Repo", selection: filter.repo ?? "All", isActive: filter.repo != nil) {
+                Button("All") { filter.repo = nil }
+                Divider()
+                ForEach(repoOptions, id: \.self) { repo in
+                    Button(repo) { filter.repo = repo }
+                }
+            }
+
+            filterMenu("Author", selection: filter.author ?? "All", isActive: filter.author != nil) {
+                Button("All") { filter.author = nil }
+                Divider()
+                ForEach(authorOptions, id: \.self) { author in
+                    Button(author) { filter.author = author }
+                }
+            }
+
+            filterMenu("Age", selection: filter.ageBucket.rawValue, isActive: filter.ageBucket != .any) {
+                ForEach(PRAgeBucket.allCases, id: \.self) { bucket in
+                    Button(bucket.rawValue) { filter.ageBucket = bucket }
+                }
+            }
+
+            filterMenu(
+                "Checks",
+                selection: filter.checks?.label ?? "All",
+                isActive: filter.checks != nil
+            ) {
+                Button("All") { filter.checks = nil }
+                Divider()
+                Button("Passing") { filter.checks = .passed }
+                Button("Failing") { filter.checks = .failed }
+                Button("Pending") { filter.checks = .pending }
+            }
+
+            filterMenu(
+                "Review",
+                selection: reviewLabel(filter.review),
+                isActive: filter.review != nil
+            ) {
+                Button("All") { filter.review = nil }
+                Divider()
+                Button("Approved") { filter.review = .approved }
+                Button("Changes Requested") { filter.review = .changesRequested }
+                Button("Pending") { filter.review = .pending }
+            }
+
+            filterMenu(
+                "Merge",
+                selection: filter.mergeFilter?.rawValue ?? "All",
+                isActive: filter.mergeFilter != nil
+            ) {
+                Button("All") { filter.mergeFilter = nil }
+                Divider()
+                ForEach(PRMergeFilter.allCases, id: \.self) { mergeFilter in
+                    Button(mergeFilter.rawValue) { filter.mergeFilter = mergeFilter }
+                }
+            }
+
+            if filter.isActive {
+                Button("Clear") { filter.clear() }
+                    .font(.caption)
+                    .foregroundColor(theme.chrome.accent)
+                    .buttonStyle(.plain)
+            }
+
+            Spacer()
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+        .background(theme.chrome.surface)
+    }
+
+    private func filterMenu<Content: View>(
+        _ label: String,
+        selection: String,
+        isActive: Bool,
+        @ViewBuilder content: @escaping () -> Content
+    ) -> some View {
+        Menu {
+            content()
+        } label: {
+            Text("\(label): \(selection)")
+                .font(.caption)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(isActive ? theme.chrome.accent.opacity(0.15) : theme.chrome.surface)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 4)
+                        .stroke(isActive ? theme.chrome.accent.opacity(0.4) : theme.chrome.border, lineWidth: 1)
+                )
+                .foregroundColor(isActive ? theme.chrome.accent : theme.chrome.textDim)
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize()
+    }
+
+    private func reviewLabel(_ decision: ReviewDecision?) -> String {
+        switch decision {
+        case .approved: "Approved"
+        case .changesRequested: "Changes Requested"
+        case .pending: "Pending"
+        case .none: "All"
+        case .some(.none): "All"
+        }
+    }
+}

--- a/Sources/Views/PRDashboard/PRSortFilter.swift
+++ b/Sources/Views/PRDashboard/PRSortFilter.swift
@@ -121,6 +121,38 @@ public struct PRFilterState: Sendable {
     }
 }
 
+// MARK: - Comparable Sort Properties
+
+extension PullRequest {
+    /// Checks pass ratio for column sorting. -1 when no checks configured.
+    public var checksPassRatio: Double {
+        checks.total > 0 ? Double(checks.passed) / Double(checks.total) : -1
+    }
+
+    /// Numeric rank for review decision sorting (lower = better).
+    public var reviewSortRank: Int {
+        switch reviewDecision {
+        case .approved: 0
+        case .pending: 1
+        case .none: 2
+        case .changesRequested: 3
+        }
+    }
+
+    /// Numeric rank for merge status sorting (lower = more ready).
+    public var mergeSortRank: Int {
+        if mergeable == .conflicting { return 4 }
+        switch mergeStateStatus {
+        case .clean, .hasHooks: return 0
+        case .behind: return 1
+        case .unstable: return 2
+        case .dirty: return 3
+        case .blocked: return 5
+        default: return 6
+        }
+    }
+}
+
 // MARK: - Column Widths
 
 /// Resizable column widths for the PR list grid.

--- a/Sources/Views/PRDashboard/PRSortFilter.swift
+++ b/Sources/Views/PRDashboard/PRSortFilter.swift
@@ -1,0 +1,170 @@
+import Foundation
+import Models
+
+// MARK: - Sort Types
+
+public enum PRSortField: String, CaseIterable, Sendable {
+    case title
+    case repo
+    case author
+    case age
+    case checks
+    case review
+    case mergeStatus
+
+    public var label: String {
+        switch self {
+        case .title: "Title"
+        case .repo: "Repo"
+        case .author: "Author"
+        case .age: "Age"
+        case .checks: "Checks"
+        case .review: "Review"
+        case .mergeStatus: "Merge"
+        }
+    }
+}
+
+public enum PRSortOrder: String, Sendable {
+    case ascending
+    case descending
+}
+
+// MARK: - Age Bucket
+
+public enum PRAgeBucket: String, CaseIterable, Sendable {
+    case any = "Any"
+    case last24h = "Last 24h"
+    case last7d = "Last 7 days"
+    case last30d = "Last 30 days"
+    case olderThan30d = "Older than 30 days"
+
+    func matches(createdAt: Date) -> Bool {
+        let age = Date().timeIntervalSince(createdAt)
+        switch self {
+        case .any: return true
+        case .last24h: return age <= 86400
+        case .last7d: return age <= 86400 * 7
+        case .last30d: return age <= 86400 * 30
+        case .olderThan30d: return age > 86400 * 30
+        }
+    }
+}
+
+// MARK: - Merge Filter
+
+public enum PRMergeFilter: String, CaseIterable, Sendable {
+    case clean = "Clean"
+    case conflicts = "Conflicts"
+    case behind = "Behind"
+    case blocked = "Blocked"
+
+    public func matches(mergeable: MergeableState?, mergeStateStatus: MergeStateStatus?) -> Bool {
+        switch self {
+        case .clean:
+            return mergeStateStatus == .clean || mergeStateStatus == .hasHooks
+        case .conflicts:
+            return mergeable == .conflicting || mergeStateStatus == .dirty
+        case .behind:
+            return mergeStateStatus == .behind
+        case .blocked:
+            return mergeStateStatus == .blocked
+        }
+    }
+}
+
+// MARK: - Filter State
+
+public struct PRFilterState: Sendable {
+    public var repo: String?
+    public var author: String?
+    public var ageBucket: PRAgeBucket = .any
+    public var checks: CheckStatus?
+    public var review: ReviewDecision?
+    public var mergeFilter: PRMergeFilter?
+
+    public init() {}
+
+    public var isActive: Bool {
+        repo != nil || author != nil || ageBucket != .any
+            || checks != nil || review != nil || mergeFilter != nil
+    }
+
+    public func matches(_ pr: PullRequest) -> Bool {
+        if let repo, pr.repo != repo { return false }
+        if let author, pr.author != author { return false }
+        if !ageBucket.matches(createdAt: pr.createdAt) { return false }
+        if let checks {
+            switch checks {
+            case .passed: if !pr.checks.allPassed { return false }
+            case .failed: if !pr.checks.hasFailed { return false }
+            case .pending:
+                if pr.checks.pending == 0 || pr.checks.hasFailed { return false }
+            }
+        }
+        if let review, pr.reviewDecision != review { return false }
+        if let mergeFilter {
+            if !mergeFilter.matches(mergeable: pr.mergeable, mergeStateStatus: pr.mergeStateStatus) {
+                return false
+            }
+        }
+        return true
+    }
+
+    public mutating func clear() {
+        repo = nil
+        author = nil
+        ageBucket = .any
+        checks = nil
+        review = nil
+        mergeFilter = nil
+    }
+}
+
+// MARK: - Sorting
+
+/// Sort an array of PRs by the given field and order.
+public func sortPRs(_ prs: [PullRequest], by field: PRSortField, order: PRSortOrder) -> [PullRequest] {
+    let sorted = prs.sorted { lhs, rhs in
+        switch field {
+        case .title:
+            return lhs.title.localizedCaseInsensitiveCompare(rhs.title) == .orderedAscending
+        case .repo:
+            return lhs.repo.localizedCaseInsensitiveCompare(rhs.repo) == .orderedAscending
+        case .author:
+            return lhs.author.localizedCaseInsensitiveCompare(rhs.author) == .orderedAscending
+        case .age:
+            return lhs.createdAt < rhs.createdAt
+        case .checks:
+            let lhsRatio = lhs.checks.total > 0 ? Double(lhs.checks.passed) / Double(lhs.checks.total) : 0
+            let rhsRatio = rhs.checks.total > 0 ? Double(rhs.checks.passed) / Double(rhs.checks.total) : 0
+            if lhsRatio != rhsRatio { return lhsRatio < rhsRatio }
+            return lhs.checks.total < rhs.checks.total
+        case .review:
+            return reviewSortOrder(lhs.reviewDecision) < reviewSortOrder(rhs.reviewDecision)
+        case .mergeStatus:
+            return mergeSortOrder(lhs.mergeStateStatus) < mergeSortOrder(rhs.mergeStateStatus)
+        }
+    }
+    return order == .ascending ? sorted : sorted.reversed()
+}
+
+private func reviewSortOrder(_ decision: ReviewDecision) -> Int {
+    switch decision {
+    case .approved: 0
+    case .pending: 1
+    case .none: 2
+    case .changesRequested: 3
+    }
+}
+
+private func mergeSortOrder(_ status: MergeStateStatus?) -> Int {
+    switch status {
+    case .clean, .hasHooks: 0
+    case .behind: 1
+    case .unstable: 2
+    case .dirty: 3
+    case .blocked: 4
+    case .unknown, .none: 5
+    }
+}

--- a/Sources/Views/PRDashboard/PRSortFilter.swift
+++ b/Sources/Views/PRDashboard/PRSortFilter.swift
@@ -134,15 +134,15 @@ public struct PRColumnWidths: Sendable {
     public var merge: CGFloat
 
     public static let defaults = PRColumnWidths(
-        repo: 100, author: 70, age: 50, checks: 55, review: 55, merge: 65
+        repo: 140, author: 100, age: 60, checks: 60, review: 80, merge: 85
     )
 
     public static let minimums = PRColumnWidths(
-        repo: 50, author: 40, age: 35, checks: 40, review: 40, merge: 45
+        repo: 70, author: 60, age: 45, checks: 45, review: 60, merge: 60
     )
 
     public static let maximums = PRColumnWidths(
-        repo: 200, author: 150, age: 80, checks: 100, review: 100, merge: 120
+        repo: 250, author: 200, age: 100, checks: 120, review: 130, merge: 140
     )
 
     public init(

--- a/Sources/Views/PRDashboard/PRSortFilter.swift
+++ b/Sources/Views/PRDashboard/PRSortFilter.swift
@@ -121,6 +121,66 @@ public struct PRFilterState: Sendable {
     }
 }
 
+// MARK: - Column Widths
+
+/// Resizable column widths for the PR list grid.
+/// Title is always flexible (fills remaining space), so it's not stored here.
+public struct PRColumnWidths: Sendable {
+    public var repo: CGFloat
+    public var author: CGFloat
+    public var age: CGFloat
+    public var checks: CGFloat
+    public var review: CGFloat
+    public var merge: CGFloat
+
+    public static let defaults = PRColumnWidths(
+        repo: 100, author: 70, age: 50, checks: 55, review: 55, merge: 65
+    )
+
+    public static let minimums = PRColumnWidths(
+        repo: 50, author: 40, age: 35, checks: 40, review: 40, merge: 45
+    )
+
+    public static let maximums = PRColumnWidths(
+        repo: 200, author: 150, age: 80, checks: 100, review: 100, merge: 120
+    )
+
+    public init(
+        repo: CGFloat = 100, author: CGFloat = 70, age: CGFloat = 50,
+        checks: CGFloat = 55, review: CGFloat = 55, merge: CGFloat = 65
+    ) {
+        self.repo = repo
+        self.author = author
+        self.age = age
+        self.checks = checks
+        self.review = review
+        self.merge = merge
+    }
+
+    /// Width for a given sort field (title excluded — it's flexible).
+    public func width(for field: PRSortField) -> CGFloat {
+        switch field {
+        case .title: 0  // not used — title is flexible
+        case .repo: repo
+        case .author: author
+        case .age: age
+        case .checks: checks
+        case .review: review
+        case .mergeStatus: merge
+        }
+    }
+
+    /// Minimum width for a given sort field.
+    public static func min(for field: PRSortField) -> CGFloat {
+        Self.minimums.width(for: field)
+    }
+
+    /// Maximum width for a given sort field.
+    public static func max(for field: PRSortField) -> CGFloat {
+        Self.maximums.width(for: field)
+    }
+}
+
 // MARK: - Sorting
 
 /// Sort an array of PRs by the given field and order.

--- a/Tests/ViewsTests/PRSortFilterTests.swift
+++ b/Tests/ViewsTests/PRSortFilterTests.swift
@@ -1,0 +1,312 @@
+import Foundation
+import Testing
+
+@testable import Models
+@testable import Views
+
+// MARK: - PRAgeBucket Tests
+
+@Test func ageBucketAnyMatchesEverything() {
+    let pr = PullRequest(
+        number: 1, title: "Test", state: .open, headBranch: "f", baseBranch: "main",
+        author: "alice", repo: "backend-api",
+        createdAt: Date().addingTimeInterval(-86400 * 60)
+    )
+    var filter = PRFilterState()
+    filter.ageBucket = .any
+    #expect(filter.matches(pr))
+}
+
+@Test func ageBucketLast24hFiltersOldPRs() {
+    let oldPR = PullRequest(
+        number: 1, title: "Old", state: .open, headBranch: "f", baseBranch: "main",
+        author: "alice", repo: "r",
+        createdAt: Date().addingTimeInterval(-86400 * 2)
+    )
+    let newPR = PullRequest(
+        number: 2, title: "New", state: .open, headBranch: "f", baseBranch: "main",
+        author: "bob", repo: "r",
+        createdAt: Date().addingTimeInterval(-3600)
+    )
+    var filter = PRFilterState()
+    filter.ageBucket = .last24h
+    #expect(!filter.matches(oldPR))
+    #expect(filter.matches(newPR))
+}
+
+@Test func ageBucketLast7dFiltersOlderPRs() {
+    let oldPR = PullRequest(
+        number: 1, title: "Old", state: .open, headBranch: "f", baseBranch: "main",
+        author: "alice", repo: "r",
+        createdAt: Date().addingTimeInterval(-86400 * 10)
+    )
+    let recentPR = PullRequest(
+        number: 2, title: "Recent", state: .open, headBranch: "f", baseBranch: "main",
+        author: "bob", repo: "r",
+        createdAt: Date().addingTimeInterval(-86400 * 3)
+    )
+    var filter = PRFilterState()
+    filter.ageBucket = .last7d
+    #expect(!filter.matches(oldPR))
+    #expect(filter.matches(recentPR))
+}
+
+@Test func ageBucketLast30dFiltersOlderPRs() {
+    let oldPR = PullRequest(
+        number: 1, title: "Old", state: .open, headBranch: "f", baseBranch: "main",
+        author: "alice", repo: "r",
+        createdAt: Date().addingTimeInterval(-86400 * 45)
+    )
+    let recentPR = PullRequest(
+        number: 2, title: "Recent", state: .open, headBranch: "f", baseBranch: "main",
+        author: "bob", repo: "r",
+        createdAt: Date().addingTimeInterval(-86400 * 15)
+    )
+    var filter = PRFilterState()
+    filter.ageBucket = .last30d
+    #expect(!filter.matches(oldPR))
+    #expect(filter.matches(recentPR))
+}
+
+@Test func ageBucketOlderThan30dFiltersRecentPRs() {
+    let oldPR = PullRequest(
+        number: 1, title: "Old", state: .open, headBranch: "f", baseBranch: "main",
+        author: "alice", repo: "r",
+        createdAt: Date().addingTimeInterval(-86400 * 45)
+    )
+    let recentPR = PullRequest(
+        number: 2, title: "Recent", state: .open, headBranch: "f", baseBranch: "main",
+        author: "bob", repo: "r",
+        createdAt: Date().addingTimeInterval(-86400 * 5)
+    )
+    var filter = PRFilterState()
+    filter.ageBucket = .olderThan30d
+    #expect(filter.matches(oldPR))
+    #expect(!filter.matches(recentPR))
+}
+
+// MARK: - Repo & Author Filter Tests
+
+@Test func repoFilterMatchesExactRepo() {
+    let pr = PullRequest(
+        number: 1, title: "Test", state: .open, headBranch: "f", baseBranch: "main",
+        author: "alice", repo: "owner/backend-api"
+    )
+    var filter = PRFilterState()
+    filter.repo = "owner/backend-api"
+    #expect(filter.matches(pr))
+    filter.repo = "owner/web-app"
+    #expect(!filter.matches(pr))
+}
+
+@Test func authorFilterMatchesExactAuthor() {
+    let pr = PullRequest(
+        number: 1, title: "Test", state: .open, headBranch: "f", baseBranch: "main",
+        author: "alice", repo: "r"
+    )
+    var filter = PRFilterState()
+    filter.author = "alice"
+    #expect(filter.matches(pr))
+    filter.author = "bob"
+    #expect(!filter.matches(pr))
+}
+
+@Test func nilRepoAndAuthorMatchAll() {
+    let pr = PullRequest(
+        number: 1, title: "Test", state: .open, headBranch: "f", baseBranch: "main",
+        author: "alice", repo: "r"
+    )
+    let filter = PRFilterState()
+    #expect(filter.repo == nil)
+    #expect(filter.author == nil)
+    #expect(filter.matches(pr))
+}
+
+// MARK: - Checks Filter Tests
+
+@Test func checksFilterMatchesByStatus() {
+    let passingPR = PullRequest(
+        number: 1, title: "Pass", state: .open, headBranch: "f", baseBranch: "main",
+        author: "a", repo: "r",
+        checks: CheckSummary(passed: 5, failed: 0, pending: 0)
+    )
+    let failingPR = PullRequest(
+        number: 2, title: "Fail", state: .open, headBranch: "f", baseBranch: "main",
+        author: "a", repo: "r",
+        checks: CheckSummary(passed: 3, failed: 2, pending: 0)
+    )
+    let pendingPR = PullRequest(
+        number: 3, title: "Pending", state: .open, headBranch: "f", baseBranch: "main",
+        author: "a", repo: "r",
+        checks: CheckSummary(passed: 0, failed: 0, pending: 3)
+    )
+    var filter = PRFilterState()
+
+    filter.checks = .passed
+    #expect(filter.matches(passingPR))
+    #expect(!filter.matches(failingPR))
+    #expect(!filter.matches(pendingPR))
+
+    filter.checks = .failed
+    #expect(!filter.matches(passingPR))
+    #expect(filter.matches(failingPR))
+    #expect(!filter.matches(pendingPR))
+
+    filter.checks = .pending
+    #expect(!filter.matches(passingPR))
+    #expect(!filter.matches(failingPR))
+    #expect(filter.matches(pendingPR))
+}
+
+// MARK: - Review & Merge Filter Tests
+
+@Test func reviewFilterMatchesByDecision() {
+    let approvedPR = PullRequest(
+        number: 1, title: "Approved", state: .open, headBranch: "f", baseBranch: "main",
+        author: "a", repo: "r", reviewDecision: .approved
+    )
+    var filter = PRFilterState()
+    filter.review = .approved
+    #expect(filter.matches(approvedPR))
+    filter.review = .changesRequested
+    #expect(!filter.matches(approvedPR))
+}
+
+@Test func mergeFilterMatchesClean() {
+    let cleanPR = PullRequest(
+        number: 1, title: "Clean", state: .open, headBranch: "f", baseBranch: "main",
+        author: "a", repo: "r", mergeStateStatus: .clean
+    )
+    var filter = PRFilterState()
+    filter.mergeFilter = .clean
+    #expect(filter.matches(cleanPR))
+    filter.mergeFilter = .blocked
+    #expect(!filter.matches(cleanPR))
+}
+
+@Test func mergeFilterConflictsMatchesBothMergeableAndStatus() {
+    let conflictingPR = PullRequest(
+        number: 1, title: "Conflicts", state: .open, headBranch: "f", baseBranch: "main",
+        author: "a", repo: "r", mergeable: .conflicting
+    )
+    let dirtyPR = PullRequest(
+        number: 2, title: "Dirty", state: .open, headBranch: "f", baseBranch: "main",
+        author: "a", repo: "r", mergeStateStatus: .dirty
+    )
+    var filter = PRFilterState()
+    filter.mergeFilter = .conflicts
+    #expect(filter.matches(conflictingPR))
+    #expect(filter.matches(dirtyPR))
+}
+
+// MARK: - Combined (AND) Filter Tests
+
+@Test func multipleFiltersApplyAsAND() {
+    let pr = PullRequest(
+        number: 1, title: "Test", state: .open, headBranch: "f", baseBranch: "main",
+        author: "alice", repo: "owner/backend-api",
+        checks: CheckSummary(passed: 5, failed: 0, pending: 0),
+        reviewDecision: .approved
+    )
+    var filter = PRFilterState()
+    filter.repo = "owner/backend-api"
+    filter.author = "alice"
+    #expect(filter.matches(pr))
+
+    filter.author = "bob"
+    #expect(!filter.matches(pr))
+}
+
+// MARK: - isActive Tests
+
+@Test func isActiveReturnsFalseForDefaultFilter() {
+    let filter = PRFilterState()
+    #expect(!filter.isActive)
+}
+
+@Test func isActiveReturnsTrueWhenAnyFilterSet() {
+    var filter = PRFilterState()
+    filter.repo = "r"
+    #expect(filter.isActive)
+}
+
+// MARK: - Sorting Tests
+
+@Test func sortByAgeAscendingReturnsOldestFirst() {
+    let old = PullRequest(
+        number: 1, title: "Old", state: .open, headBranch: "f", baseBranch: "main",
+        author: "a", repo: "r",
+        createdAt: Date().addingTimeInterval(-86400 * 10)
+    )
+    let new = PullRequest(
+        number: 2, title: "New", state: .open, headBranch: "f", baseBranch: "main",
+        author: "a", repo: "r",
+        createdAt: Date().addingTimeInterval(-3600)
+    )
+    let sorted = sortPRs([new, old], by: .age, order: .ascending)
+    #expect(sorted[0].number == 1)
+    #expect(sorted[1].number == 2)
+}
+
+@Test func sortByAgeDescendingReturnsNewestFirst() {
+    let old = PullRequest(
+        number: 1, title: "Old", state: .open, headBranch: "f", baseBranch: "main",
+        author: "a", repo: "r",
+        createdAt: Date().addingTimeInterval(-86400 * 10)
+    )
+    let new = PullRequest(
+        number: 2, title: "New", state: .open, headBranch: "f", baseBranch: "main",
+        author: "a", repo: "r",
+        createdAt: Date().addingTimeInterval(-3600)
+    )
+    let sorted = sortPRs([old, new], by: .age, order: .descending)
+    #expect(sorted[0].number == 2)
+    #expect(sorted[1].number == 1)
+}
+
+@Test func sortByRepoAlphabetical() {
+    let prA = PullRequest(
+        number: 1, title: "A", state: .open, headBranch: "f", baseBranch: "main",
+        author: "a", repo: "z-repo"
+    )
+    let prB = PullRequest(
+        number: 2, title: "B", state: .open, headBranch: "f", baseBranch: "main",
+        author: "a", repo: "a-repo"
+    )
+    let sorted = sortPRs([prA, prB], by: .repo, order: .ascending)
+    #expect(sorted[0].number == 2)
+    #expect(sorted[1].number == 1)
+}
+
+@Test func sortByAuthorAlphabetical() {
+    let prA = PullRequest(
+        number: 1, title: "A", state: .open, headBranch: "f", baseBranch: "main",
+        author: "zara", repo: "r"
+    )
+    let prB = PullRequest(
+        number: 2, title: "B", state: .open, headBranch: "f", baseBranch: "main",
+        author: "alice", repo: "r"
+    )
+    let sorted = sortPRs([prA, prB], by: .author, order: .ascending)
+    #expect(sorted[0].number == 2)
+    #expect(sorted[1].number == 1)
+}
+
+@Test func sortByReviewPutsApprovedFirst() {
+    let approved = PullRequest(
+        number: 1, title: "A", state: .open, headBranch: "f", baseBranch: "main",
+        author: "a", repo: "r", reviewDecision: .approved
+    )
+    let changes = PullRequest(
+        number: 2, title: "B", state: .open, headBranch: "f", baseBranch: "main",
+        author: "a", repo: "r", reviewDecision: .changesRequested
+    )
+    let pending = PullRequest(
+        number: 3, title: "C", state: .open, headBranch: "f", baseBranch: "main",
+        author: "a", repo: "r", reviewDecision: .pending
+    )
+    let sorted = sortPRs([changes, pending, approved], by: .review, order: .ascending)
+    #expect(sorted[0].number == 1)  // approved
+    #expect(sorted[1].number == 3)  // pending
+    #expect(sorted[2].number == 2)  // changes
+}

--- a/docs/superpowers/plans/2026-04-10-pr-sorting-filtering.md
+++ b/docs/superpowers/plans/2026-04-10-pr-sorting-filtering.md
@@ -1,0 +1,1132 @@
+# PR Column Sorting & Filtering Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add sortable columns and a persistent filter bar to the PR dashboard, keeping the existing group-based layout.
+
+**Architecture:** New sort/filter types live in `Sources/Views/PRDashboard/PRSortFilter.swift`. Two new view files (`PRFilterBar.swift`, `PRColumnHeader.swift`) slot into the existing `PRDashboardView` hierarchy above the grouped list. `PRRowView` is refactored from a free-form HStack to a grid-aligned row. All state persists via `@AppStorage`.
+
+**Tech Stack:** SwiftUI, Swift Testing framework, `@AppStorage` for persistence, existing Models/Theme modules.
+
+---
+
+### Task 1: Add PRSortFilter types with tests
+
+**Files:**
+- Create: `Sources/Views/PRDashboard/PRSortFilter.swift`
+- Create: `Tests/ViewsTests/PRSortFilterTests.swift`
+
+- [ ] **Step 1: Write failing tests for PRFilterState.matches()**
+
+In `Tests/ViewsTests/PRSortFilterTests.swift`:
+
+```swift
+import Foundation
+import Testing
+
+@testable import Models
+@testable import Views
+
+// MARK: - PRAgeBucket Tests
+
+@Test func ageBucketAnyMatchesEverything() {
+    let pr = PullRequest(
+        number: 1, title: "Test", state: .open, headBranch: "f", baseBranch: "main",
+        author: "alice", repo: "backend-api",
+        createdAt: Date().addingTimeInterval(-86400 * 60)
+    )
+    var filter = PRFilterState()
+    filter.ageBucket = .any
+    #expect(filter.matches(pr))
+}
+
+@Test func ageBucketLast24hFiltersOldPRs() {
+    let oldPR = PullRequest(
+        number: 1, title: "Old", state: .open, headBranch: "f", baseBranch: "main",
+        author: "alice", repo: "r",
+        createdAt: Date().addingTimeInterval(-86400 * 2)
+    )
+    let newPR = PullRequest(
+        number: 2, title: "New", state: .open, headBranch: "f", baseBranch: "main",
+        author: "bob", repo: "r",
+        createdAt: Date().addingTimeInterval(-3600)
+    )
+    var filter = PRFilterState()
+    filter.ageBucket = .last24h
+    #expect(!filter.matches(oldPR))
+    #expect(filter.matches(newPR))
+}
+
+@Test func ageBucketLast7dFiltersOlderPRs() {
+    let oldPR = PullRequest(
+        number: 1, title: "Old", state: .open, headBranch: "f", baseBranch: "main",
+        author: "alice", repo: "r",
+        createdAt: Date().addingTimeInterval(-86400 * 10)
+    )
+    let recentPR = PullRequest(
+        number: 2, title: "Recent", state: .open, headBranch: "f", baseBranch: "main",
+        author: "bob", repo: "r",
+        createdAt: Date().addingTimeInterval(-86400 * 3)
+    )
+    var filter = PRFilterState()
+    filter.ageBucket = .last7d
+    #expect(!filter.matches(oldPR))
+    #expect(filter.matches(recentPR))
+}
+
+@Test func ageBucketLast30dFiltersOlderPRs() {
+    let oldPR = PullRequest(
+        number: 1, title: "Old", state: .open, headBranch: "f", baseBranch: "main",
+        author: "alice", repo: "r",
+        createdAt: Date().addingTimeInterval(-86400 * 45)
+    )
+    let recentPR = PullRequest(
+        number: 2, title: "Recent", state: .open, headBranch: "f", baseBranch: "main",
+        author: "bob", repo: "r",
+        createdAt: Date().addingTimeInterval(-86400 * 15)
+    )
+    var filter = PRFilterState()
+    filter.ageBucket = .last30d
+    #expect(!filter.matches(oldPR))
+    #expect(filter.matches(recentPR))
+}
+
+@Test func ageBucketOlderThan30dFiltersRecentPRs() {
+    let oldPR = PullRequest(
+        number: 1, title: "Old", state: .open, headBranch: "f", baseBranch: "main",
+        author: "alice", repo: "r",
+        createdAt: Date().addingTimeInterval(-86400 * 45)
+    )
+    let recentPR = PullRequest(
+        number: 2, title: "Recent", state: .open, headBranch: "f", baseBranch: "main",
+        author: "bob", repo: "r",
+        createdAt: Date().addingTimeInterval(-86400 * 5)
+    )
+    var filter = PRFilterState()
+    filter.ageBucket = .olderThan30d
+    #expect(filter.matches(oldPR))
+    #expect(!filter.matches(recentPR))
+}
+
+// MARK: - Repo & Author Filter Tests
+
+@Test func repoFilterMatchesExactRepo() {
+    let pr = PullRequest(
+        number: 1, title: "Test", state: .open, headBranch: "f", baseBranch: "main",
+        author: "alice", repo: "owner/backend-api"
+    )
+    var filter = PRFilterState()
+    filter.repo = "owner/backend-api"
+    #expect(filter.matches(pr))
+    filter.repo = "owner/web-app"
+    #expect(!filter.matches(pr))
+}
+
+@Test func authorFilterMatchesExactAuthor() {
+    let pr = PullRequest(
+        number: 1, title: "Test", state: .open, headBranch: "f", baseBranch: "main",
+        author: "alice", repo: "r"
+    )
+    var filter = PRFilterState()
+    filter.author = "alice"
+    #expect(filter.matches(pr))
+    filter.author = "bob"
+    #expect(!filter.matches(pr))
+}
+
+@Test func nilRepoAndAuthorMatchAll() {
+    let pr = PullRequest(
+        number: 1, title: "Test", state: .open, headBranch: "f", baseBranch: "main",
+        author: "alice", repo: "r"
+    )
+    let filter = PRFilterState()
+    #expect(filter.repo == nil)
+    #expect(filter.author == nil)
+    #expect(filter.matches(pr))
+}
+
+// MARK: - Checks Filter Tests
+
+@Test func checksFilterMatchesByStatus() {
+    let passingPR = PullRequest(
+        number: 1, title: "Pass", state: .open, headBranch: "f", baseBranch: "main",
+        author: "a", repo: "r",
+        checks: CheckSummary(passed: 5, failed: 0, pending: 0)
+    )
+    let failingPR = PullRequest(
+        number: 2, title: "Fail", state: .open, headBranch: "f", baseBranch: "main",
+        author: "a", repo: "r",
+        checks: CheckSummary(passed: 3, failed: 2, pending: 0)
+    )
+    let pendingPR = PullRequest(
+        number: 3, title: "Pending", state: .open, headBranch: "f", baseBranch: "main",
+        author: "a", repo: "r",
+        checks: CheckSummary(passed: 0, failed: 0, pending: 3)
+    )
+    var filter = PRFilterState()
+
+    filter.checks = .passed
+    #expect(filter.matches(passingPR))
+    #expect(!filter.matches(failingPR))
+    #expect(!filter.matches(pendingPR))
+
+    filter.checks = .failed
+    #expect(!filter.matches(passingPR))
+    #expect(filter.matches(failingPR))
+    #expect(!filter.matches(pendingPR))
+
+    filter.checks = .pending
+    #expect(!filter.matches(passingPR))
+    #expect(!filter.matches(failingPR))
+    #expect(filter.matches(pendingPR))
+}
+
+// MARK: - Review & Merge Filter Tests
+
+@Test func reviewFilterMatchesByDecision() {
+    let approvedPR = PullRequest(
+        number: 1, title: "Approved", state: .open, headBranch: "f", baseBranch: "main",
+        author: "a", repo: "r", reviewDecision: .approved
+    )
+    var filter = PRFilterState()
+    filter.review = .approved
+    #expect(filter.matches(approvedPR))
+    filter.review = .changesRequested
+    #expect(!filter.matches(approvedPR))
+}
+
+@Test func mergeFilterMatchesClean() {
+    let cleanPR = PullRequest(
+        number: 1, title: "Clean", state: .open, headBranch: "f", baseBranch: "main",
+        author: "a", repo: "r", mergeStateStatus: .clean
+    )
+    var filter = PRFilterState()
+    filter.mergeFilter = .clean
+    #expect(filter.matches(cleanPR))
+    filter.mergeFilter = .blocked
+    #expect(!filter.matches(cleanPR))
+}
+
+@Test func mergeFilterConflictsMatchesBothMergeableAndStatus() {
+    let conflictingPR = PullRequest(
+        number: 1, title: "Conflicts", state: .open, headBranch: "f", baseBranch: "main",
+        author: "a", repo: "r", mergeable: .conflicting
+    )
+    let dirtyPR = PullRequest(
+        number: 2, title: "Dirty", state: .open, headBranch: "f", baseBranch: "main",
+        author: "a", repo: "r", mergeStateStatus: .dirty
+    )
+    var filter = PRFilterState()
+    filter.mergeFilter = .conflicts
+    #expect(filter.matches(conflictingPR))
+    #expect(filter.matches(dirtyPR))
+}
+
+// MARK: - Combined (AND) Filter Tests
+
+@Test func multipleFiltersApplyAsAND() {
+    let pr = PullRequest(
+        number: 1, title: "Test", state: .open, headBranch: "f", baseBranch: "main",
+        author: "alice", repo: "owner/backend-api",
+        checks: CheckSummary(passed: 5, failed: 0, pending: 0),
+        reviewDecision: .approved
+    )
+    var filter = PRFilterState()
+    filter.repo = "owner/backend-api"
+    filter.author = "alice"
+    #expect(filter.matches(pr))
+
+    // Change author to mismatch — AND means both must match
+    filter.author = "bob"
+    #expect(!filter.matches(pr))
+}
+
+// MARK: - isActive Tests
+
+@Test func isActiveReturnsFalseForDefaultFilter() {
+    let filter = PRFilterState()
+    #expect(!filter.isActive)
+}
+
+@Test func isActiveReturnsTrueWhenAnyFilterSet() {
+    var filter = PRFilterState()
+    filter.repo = "r"
+    #expect(filter.isActive)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `swift test --filter PRSortFilterTests 2>&1 | tail -20`
+Expected: Compilation failure — `PRFilterState` and related types don't exist yet.
+
+- [ ] **Step 3: Implement PRSortFilter types**
+
+Create `Sources/Views/PRDashboard/PRSortFilter.swift`:
+
+```swift
+import Foundation
+import Models
+
+// MARK: - Sort Types
+
+public enum PRSortField: String, CaseIterable, Sendable {
+    case title
+    case repo
+    case author
+    case age
+    case checks
+    case review
+    case mergeStatus
+
+    public var label: String {
+        switch self {
+        case .title: "Title"
+        case .repo: "Repo"
+        case .author: "Author"
+        case .age: "Age"
+        case .checks: "Checks"
+        case .review: "Review"
+        case .mergeStatus: "Merge"
+        }
+    }
+}
+
+public enum PRSortOrder: String, Sendable {
+    case ascending
+    case descending
+}
+
+// MARK: - Age Bucket
+
+public enum PRAgeBucket: String, CaseIterable, Sendable {
+    case any = "Any"
+    case last24h = "Last 24h"
+    case last7d = "Last 7 days"
+    case last30d = "Last 30 days"
+    case olderThan30d = "Older than 30 days"
+
+    func matches(createdAt: Date) -> Bool {
+        let age = Date().timeIntervalSince(createdAt)
+        switch self {
+        case .any: return true
+        case .last24h: return age <= 86400
+        case .last7d: return age <= 86400 * 7
+        case .last30d: return age <= 86400 * 30
+        case .olderThan30d: return age > 86400 * 30
+        }
+    }
+}
+
+// MARK: - Merge Filter
+
+public enum PRMergeFilter: String, CaseIterable, Sendable {
+    case clean = "Clean"
+    case conflicts = "Conflicts"
+    case behind = "Behind"
+    case blocked = "Blocked"
+
+    public func matches(mergeable: MergeableState?, mergeStateStatus: MergeStateStatus?) -> Bool {
+        switch self {
+        case .clean:
+            return mergeStateStatus == .clean || mergeStateStatus == .hasHooks
+        case .conflicts:
+            return mergeable == .conflicting || mergeStateStatus == .dirty
+        case .behind:
+            return mergeStateStatus == .behind
+        case .blocked:
+            return mergeStateStatus == .blocked
+        }
+    }
+}
+
+// MARK: - Filter State
+
+public struct PRFilterState: Sendable {
+    public var repo: String?
+    public var author: String?
+    public var ageBucket: PRAgeBucket = .any
+    public var checks: CheckStatus?
+    public var review: ReviewDecision?
+    public var mergeFilter: PRMergeFilter?
+
+    public init() {}
+
+    public var isActive: Bool {
+        repo != nil || author != nil || ageBucket != .any
+            || checks != nil || review != nil || mergeFilter != nil
+    }
+
+    public func matches(_ pr: PullRequest) -> Bool {
+        if let repo, pr.repo != repo { return false }
+        if let author, pr.author != author { return false }
+        if !ageBucket.matches(createdAt: pr.createdAt) { return false }
+        if let checks {
+            switch checks {
+            case .passed: if !pr.checks.allPassed { return false }
+            case .failed: if !pr.checks.hasFailed { return false }
+            case .pending:
+                if pr.checks.pending == 0 || pr.checks.hasFailed { return false }
+            }
+        }
+        if let review, pr.reviewDecision != review { return false }
+        if let mergeFilter {
+            if !mergeFilter.matches(mergeable: pr.mergeable, mergeStateStatus: pr.mergeStateStatus) {
+                return false
+            }
+        }
+        return true
+    }
+
+    public mutating func clear() {
+        repo = nil
+        author = nil
+        ageBucket = .any
+        checks = nil
+        review = nil
+        mergeFilter = nil
+    }
+}
+
+// MARK: - Sorting
+
+/// Sort an array of PRs by the given field and order.
+public func sortPRs(_ prs: [PullRequest], by field: PRSortField, order: PRSortOrder) -> [PullRequest] {
+    let sorted = prs.sorted { a, b in
+        switch field {
+        case .title:
+            return a.title.localizedCaseInsensitiveCompare(b.title) == .orderedAscending
+        case .repo:
+            return a.repo.localizedCaseInsensitiveCompare(b.repo) == .orderedAscending
+        case .author:
+            return a.author.localizedCaseInsensitiveCompare(b.author) == .orderedAscending
+        case .age:
+            // Ascending = oldest first (smallest date)
+            return a.createdAt < b.createdAt
+        case .checks:
+            let aRatio = a.checks.total > 0 ? Double(a.checks.passed) / Double(a.checks.total) : 0
+            let bRatio = b.checks.total > 0 ? Double(b.checks.passed) / Double(b.checks.total) : 0
+            if aRatio != bRatio { return aRatio < bRatio }
+            return a.checks.total < b.checks.total
+        case .review:
+            return reviewSortOrder(a.reviewDecision) < reviewSortOrder(b.reviewDecision)
+        case .mergeStatus:
+            return mergeSortOrder(a.mergeStateStatus) < mergeSortOrder(b.mergeStateStatus)
+        }
+    }
+    return order == .ascending ? sorted : sorted.reversed()
+}
+
+private func reviewSortOrder(_ decision: ReviewDecision) -> Int {
+    switch decision {
+    case .approved: 0
+    case .pending: 1
+    case .none: 2
+    case .changesRequested: 3
+    }
+}
+
+private func mergeSortOrder(_ status: MergeStateStatus?) -> Int {
+    switch status {
+    case .clean, .hasHooks: 0
+    case .behind: 1
+    case .unstable: 2
+    case .dirty: 3
+    case .blocked: 4
+    case .unknown, .none: 5
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --filter PRSortFilterTests 2>&1 | tail -20`
+Expected: All tests pass.
+
+- [ ] **Step 5: Add sorting tests**
+
+Append to `Tests/ViewsTests/PRSortFilterTests.swift`:
+
+```swift
+// MARK: - Sorting Tests
+
+@Test func sortByAgeAscendingReturnsOldestFirst() {
+    let old = PullRequest(
+        number: 1, title: "Old", state: .open, headBranch: "f", baseBranch: "main",
+        author: "a", repo: "r",
+        createdAt: Date().addingTimeInterval(-86400 * 10)
+    )
+    let new = PullRequest(
+        number: 2, title: "New", state: .open, headBranch: "f", baseBranch: "main",
+        author: "a", repo: "r",
+        createdAt: Date().addingTimeInterval(-3600)
+    )
+    let sorted = sortPRs([new, old], by: .age, order: .ascending)
+    #expect(sorted[0].number == 1)
+    #expect(sorted[1].number == 2)
+}
+
+@Test func sortByAgeDescendingReturnsNewestFirst() {
+    let old = PullRequest(
+        number: 1, title: "Old", state: .open, headBranch: "f", baseBranch: "main",
+        author: "a", repo: "r",
+        createdAt: Date().addingTimeInterval(-86400 * 10)
+    )
+    let new = PullRequest(
+        number: 2, title: "New", state: .open, headBranch: "f", baseBranch: "main",
+        author: "a", repo: "r",
+        createdAt: Date().addingTimeInterval(-3600)
+    )
+    let sorted = sortPRs([old, new], by: .age, order: .descending)
+    #expect(sorted[0].number == 2)
+    #expect(sorted[1].number == 1)
+}
+
+@Test func sortByRepoAlphabetical() {
+    let prA = PullRequest(
+        number: 1, title: "A", state: .open, headBranch: "f", baseBranch: "main",
+        author: "a", repo: "z-repo"
+    )
+    let prB = PullRequest(
+        number: 2, title: "B", state: .open, headBranch: "f", baseBranch: "main",
+        author: "a", repo: "a-repo"
+    )
+    let sorted = sortPRs([prA, prB], by: .repo, order: .ascending)
+    #expect(sorted[0].number == 2)
+    #expect(sorted[1].number == 1)
+}
+
+@Test func sortByAuthorAlphabetical() {
+    let prA = PullRequest(
+        number: 1, title: "A", state: .open, headBranch: "f", baseBranch: "main",
+        author: "zara", repo: "r"
+    )
+    let prB = PullRequest(
+        number: 2, title: "B", state: .open, headBranch: "f", baseBranch: "main",
+        author: "alice", repo: "r"
+    )
+    let sorted = sortPRs([prA, prB], by: .author, order: .ascending)
+    #expect(sorted[0].number == 2)
+    #expect(sorted[1].number == 1)
+}
+
+@Test func sortByReviewPutsApprovedFirst() {
+    let approved = PullRequest(
+        number: 1, title: "A", state: .open, headBranch: "f", baseBranch: "main",
+        author: "a", repo: "r", reviewDecision: .approved
+    )
+    let changes = PullRequest(
+        number: 2, title: "B", state: .open, headBranch: "f", baseBranch: "main",
+        author: "a", repo: "r", reviewDecision: .changesRequested
+    )
+    let pending = PullRequest(
+        number: 3, title: "C", state: .open, headBranch: "f", baseBranch: "main",
+        author: "a", repo: "r", reviewDecision: .pending
+    )
+    let sorted = sortPRs([changes, pending, approved], by: .review, order: .ascending)
+    #expect(sorted[0].number == 1) // approved
+    #expect(sorted[1].number == 3) // pending
+    #expect(sorted[2].number == 2) // changes
+}
+```
+
+- [ ] **Step 6: Run all sort/filter tests**
+
+Run: `swift test --filter PRSortFilterTests 2>&1 | tail -20`
+Expected: All tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Sources/Views/PRDashboard/PRSortFilter.swift Tests/ViewsTests/PRSortFilterTests.swift
+git commit -m "feat: add PRSortFilter types with filtering and sorting logic
+
+Introduces PRSortField, PRSortOrder, PRAgeBucket, PRFilterState,
+and sortPRs() function. Full test coverage for filter matching
+(repo, author, age, checks, review, merge) and sort ordering."
+```
+
+---
+
+### Task 2: Create PRColumnHeader view
+
+**Files:**
+- Create: `Sources/Views/PRDashboard/PRColumnHeader.swift`
+
+- [ ] **Step 1: Create the column header view**
+
+Create `Sources/Views/PRDashboard/PRColumnHeader.swift`:
+
+```swift
+import Models
+import SwiftUI
+import Theme
+
+/// Clickable column header row for the PR list. Tapping a column toggles sort.
+struct PRColumnHeader: View {
+    @Binding var sortField: PRSortField
+    @Binding var sortOrder: PRSortOrder
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        HStack(spacing: 0) {
+            columnButton(.title)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            columnButton(.repo)
+                .frame(width: 100, alignment: .leading)
+            columnButton(.author)
+                .frame(width: 70, alignment: .leading)
+            columnButton(.age)
+                .frame(width: 50, alignment: .leading)
+            columnButton(.checks)
+                .frame(width: 55, alignment: .leading)
+            columnButton(.review)
+                .frame(width: 55, alignment: .leading)
+            columnButton(.mergeStatus)
+                .frame(width: 65, alignment: .leading)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 4)
+        .background(theme.chrome.surface)
+    }
+
+    private func columnButton(_ field: PRSortField) -> some View {
+        Button {
+            if sortField == field {
+                sortOrder = sortOrder == .ascending ? .descending : .ascending
+            } else {
+                sortField = field
+                sortOrder = field == .age ? .descending : .ascending
+            }
+        } label: {
+            HStack(spacing: 2) {
+                Text(field.label)
+                    .font(.caption)
+                    .foregroundColor(
+                        sortField == field ? theme.chrome.accent : theme.chrome.textDim
+                    )
+                if sortField == field {
+                    Image(systemName: sortOrder == .ascending ? "chevron.up" : "chevron.down")
+                        .font(.system(size: 8))
+                        .foregroundColor(theme.chrome.accent)
+                }
+            }
+        }
+        .buttonStyle(.plain)
+    }
+}
+```
+
+- [ ] **Step 2: Build to verify compilation**
+
+Run: `swift build 2>&1 | tail -10`
+Expected: Build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/Views/PRDashboard/PRColumnHeader.swift
+git commit -m "feat: add PRColumnHeader view with sort toggle controls
+
+Clickable column headers that toggle sort field and direction.
+Active column highlighted with accent color and chevron indicator."
+```
+
+---
+
+### Task 3: Create PRFilterBar view
+
+**Files:**
+- Create: `Sources/Views/PRDashboard/PRFilterBar.swift`
+
+- [ ] **Step 1: Create the filter bar view**
+
+Create `Sources/Views/PRDashboard/PRFilterBar.swift`:
+
+```swift
+import Models
+import SwiftUI
+import Theme
+
+/// Persistent filter bar with dropdown menus for each filter dimension.
+struct PRFilterBar: View {
+    @Binding var filter: PRFilterState
+    let pullRequests: [PullRequest]
+    @Environment(\.theme) private var theme
+
+    /// Distinct repo values from current PRs, sorted alphabetically.
+    private var repoOptions: [String] {
+        Array(Set(pullRequests.map(\.repo))).sorted()
+    }
+
+    /// Distinct author values from current PRs, sorted alphabetically.
+    private var authorOptions: [String] {
+        Array(Set(pullRequests.map(\.author))).sorted()
+    }
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Text("Filter:")
+                .font(.caption)
+                .foregroundColor(theme.chrome.textDim)
+
+            filterMenu("Repo", selection: filter.repo ?? "All", isActive: filter.repo != nil) {
+                Button("All") { filter.repo = nil }
+                Divider()
+                ForEach(repoOptions, id: \.self) { repo in
+                    Button(repo) { filter.repo = repo }
+                }
+            }
+
+            filterMenu("Author", selection: filter.author ?? "All", isActive: filter.author != nil) {
+                Button("All") { filter.author = nil }
+                Divider()
+                ForEach(authorOptions, id: \.self) { author in
+                    Button(author) { filter.author = author }
+                }
+            }
+
+            filterMenu("Age", selection: filter.ageBucket.rawValue, isActive: filter.ageBucket != .any) {
+                ForEach(PRAgeBucket.allCases, id: \.self) { bucket in
+                    Button(bucket.rawValue) { filter.ageBucket = bucket }
+                }
+            }
+
+            filterMenu(
+                "Checks",
+                selection: filter.checks?.label ?? "All",
+                isActive: filter.checks != nil
+            ) {
+                Button("All") { filter.checks = nil }
+                Divider()
+                Button("Passing") { filter.checks = .passed }
+                Button("Failing") { filter.checks = .failed }
+                Button("Pending") { filter.checks = .pending }
+            }
+
+            filterMenu(
+                "Review",
+                selection: reviewLabel(filter.review),
+                isActive: filter.review != nil
+            ) {
+                Button("All") { filter.review = nil }
+                Divider()
+                Button("Approved") { filter.review = .approved }
+                Button("Changes Requested") { filter.review = .changesRequested }
+                Button("Pending") { filter.review = .pending }
+            }
+
+            filterMenu(
+                "Merge",
+                selection: filter.mergeFilter?.rawValue ?? "All",
+                isActive: filter.mergeFilter != nil
+            ) {
+                Button("All") { filter.mergeFilter = nil }
+                Divider()
+                ForEach(PRMergeFilter.allCases, id: \.self) { mergeFilter in
+                    Button(mergeFilter.rawValue) { filter.mergeFilter = mergeFilter }
+                }
+            }
+
+            if filter.isActive {
+                Button("Clear") { filter.clear() }
+                    .font(.caption)
+                    .foregroundColor(theme.chrome.accent)
+                    .buttonStyle(.plain)
+            }
+
+            Spacer()
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+        .background(theme.chrome.surface)
+    }
+
+    private func filterMenu<Content: View>(
+        _ label: String,
+        selection: String,
+        isActive: Bool,
+        @ViewBuilder content: @escaping () -> Content
+    ) -> some View {
+        Menu {
+            content()
+        } label: {
+            Text("\(label): \(selection)")
+                .font(.caption)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(isActive ? theme.chrome.accent.opacity(0.15) : theme.chrome.surface)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 4)
+                        .stroke(isActive ? theme.chrome.accent.opacity(0.4) : theme.chrome.border, lineWidth: 1)
+                )
+                .foregroundColor(isActive ? theme.chrome.accent : theme.chrome.textDim)
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize()
+    }
+
+    private func reviewLabel(_ decision: ReviewDecision?) -> String {
+        switch decision {
+        case .approved: "Approved"
+        case .changesRequested: "Changes Requested"
+        case .pending: "Pending"
+        case .none: "All"
+        }
+    }
+
+}
+```
+
+- [ ] **Step 2: Build to verify compilation**
+
+Run: `swift build 2>&1 | tail -10`
+Expected: Build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/Views/PRDashboard/PRFilterBar.swift
+git commit -m "feat: add PRFilterBar view with dropdown menu filters
+
+Persistent filter bar with Menu dropdowns for repo, author, age,
+checks, review, and merge status. Dynamic options for repo/author.
+Clear button appears when any filter is active."
+```
+
+---
+
+### Task 4: Refactor PRRowView to grid-aligned columns
+
+**Files:**
+- Modify: `Sources/Views/PRDashboard/PRDashboardView.swift:405-482` (PRRowView)
+
+- [ ] **Step 1: Refactor PRRowView to use column-aligned HStack**
+
+Replace the `PRRowView` struct body (lines 410-461 in `PRDashboardView.swift`) with a grid-aligned layout. The HStack widths must match `PRColumnHeader` exactly.
+
+Replace the existing `PRRowView` body with:
+
+```swift
+struct PRRowView: View {
+    let pr: PullRequest
+    var onReview: (() -> Void)?
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        HStack(spacing: 0) {
+            // Title column (flexible)
+            HStack(spacing: 4) {
+                stateBadge
+                Text("#\(pr.number)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text(pr.title)
+                    .font(.callout)
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            // Repo column
+            Text(repoShortName)
+                .font(.caption)
+                .foregroundColor(theme.chrome.cyan)
+                .lineLimit(1)
+                .frame(width: 100, alignment: .leading)
+
+            // Author column
+            Text(pr.author)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .frame(width: 70, alignment: .leading)
+
+            // Age column
+            Text(pr.ageText)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .frame(width: 50, alignment: .leading)
+
+            // Checks column
+            CheckSummaryBadge(checks: pr.checks)
+                .frame(width: 55, alignment: .leading)
+
+            // Review column
+            ReviewDecisionBadge(decision: pr.reviewDecision)
+                .frame(width: 55, alignment: .leading)
+
+            // Merge column
+            MergeStatusBadge(mergeable: pr.mergeable, mergeStateStatus: pr.mergeStateStatus)
+                .frame(width: 65, alignment: .leading)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 4)
+        .opacity(pr.isDraft ? 0.5 : 1.0)
+        .contextMenu {
+            if let onReview {
+                Button("Open Review Session") { onReview() }
+            }
+        }
+    }
+
+    /// Extract short repo name from "owner/repo" format.
+    private var repoShortName: String {
+        if let slashIndex = pr.repo.lastIndex(of: "/") {
+            return String(pr.repo[pr.repo.index(after: slashIndex)...])
+        }
+        return pr.repo
+    }
+
+    @ViewBuilder
+    private var stateBadge: some View {
+        switch pr.state {
+        case .open:
+            Circle().fill(theme.chrome.green).frame(width: 8, height: 8)
+        case .draft:
+            Circle().stroke(theme.chrome.textDim, lineWidth: 1.5).frame(width: 8, height: 8)
+        case .merged:
+            Circle().fill(theme.chrome.purple).frame(width: 8, height: 8)
+        case .closed:
+            Circle().fill(theme.chrome.red).frame(width: 8, height: 8)
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Build to verify compilation**
+
+Run: `swift build 2>&1 | tail -10`
+Expected: Build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/Views/PRDashboard/PRDashboardView.swift
+git commit -m "refactor: PRRowView to grid-aligned columns
+
+Columns now match PRColumnHeader widths: title (flex), repo (100pt),
+author (70pt), age (50pt), checks (55pt), review (55pt), merge (65pt).
+Extracts short repo name from owner/repo format."
+```
+
+---
+
+### Task 5: Integrate filter bar, column header, and sorting into PRDashboardView
+
+**Files:**
+- Modify: `Sources/Views/PRDashboard/PRDashboardView.swift:1-34` (storage properties)
+- Modify: `Sources/Views/PRDashboard/PRDashboardView.swift:80-123` (filtering/grouping)
+- Modify: `Sources/Views/PRDashboard/PRDashboardView.swift:167-306` (body)
+
+- [ ] **Step 1: Add @AppStorage properties for sort/filter state**
+
+In `PRDashboardView`, after the existing `@AppStorage` lines (line 33), add:
+
+```swift
+@AppStorage("prSortField") private var sortFieldRaw: String = PRSortField.age.rawValue
+@AppStorage("prSortOrder") private var sortOrderRaw: String = PRSortOrder.descending.rawValue
+@AppStorage("prFilterRepo") private var filterRepo: String = ""
+@AppStorage("prFilterAuthor") private var filterAuthor: String = ""
+@AppStorage("prFilterAge") private var filterAgeRaw: String = PRAgeBucket.any.rawValue
+@AppStorage("prFilterChecks") private var filterChecksRaw: String = ""
+@AppStorage("prFilterReview") private var filterReviewRaw: String = ""
+@AppStorage("prFilterMerge") private var filterMergeRaw: String = ""
+
+```
+
+Add computed property bindings after the `@Environment` line:
+
+```swift
+private var sortField: PRSortField {
+    get { PRSortField(rawValue: sortFieldRaw) ?? .age }
+    nonmutating set { sortFieldRaw = newValue.rawValue }
+}
+
+private var sortOrder: PRSortOrder {
+    get { PRSortOrder(rawValue: sortOrderRaw) ?? .descending }
+    nonmutating set { sortOrderRaw = newValue.rawValue }
+}
+
+private var filterState: PRFilterState {
+    get {
+        var state = PRFilterState()
+        state.repo = filterRepo.isEmpty ? nil : filterRepo
+        state.author = filterAuthor.isEmpty ? nil : filterAuthor
+        state.ageBucket = PRAgeBucket(rawValue: filterAgeRaw) ?? .any
+        state.checks = CheckStatus(rawValue: filterChecksRaw)
+        state.review = filterReviewRaw.isEmpty ? nil : ReviewDecision(rawValue: filterReviewRaw)
+        state.mergeFilter = filterMergeRaw.isEmpty ? nil : PRMergeFilter(rawValue: filterMergeRaw)
+        return state
+    }
+    nonmutating set {
+        filterRepo = newValue.repo ?? ""
+        filterAuthor = newValue.author ?? ""
+        filterAgeRaw = newValue.ageBucket.rawValue
+        filterChecksRaw = newValue.checks?.rawValue ?? ""
+        filterReviewRaw = newValue.review?.rawValue ?? ""
+        filterMergeRaw = newValue.mergeFilter?.rawValue ?? ""
+    }
+}
+```
+
+- [ ] **Step 2: Update filteredPRs to include PRFilterState**
+
+Modify the `filteredPRs` computed property to apply the new filter after existing filters:
+
+```swift
+private var filteredPRs: [PullRequest] {
+    var result = applyFilters(to: pullRequests, tab: selectedTab)
+    let currentFilter = filterState
+    if currentFilter.isActive {
+        result = result.filter { currentFilter.matches($0) }
+    }
+    return result
+}
+```
+
+Update `tabCount` similarly:
+
+```swift
+private func tabCount(_ tab: PRTab) -> Int {
+    var prs = applyFilters(to: pullRequests, tab: tab)
+    if hideDrafts { prs = prs.filter { !$0.isDraft } }
+    let currentFilter = filterState
+    if currentFilter.isActive {
+        prs = prs.filter { currentFilter.matches($0) }
+    }
+    return prs.count
+}
+```
+
+- [ ] **Step 3: Update groupedPRs to sort within groups**
+
+Modify `groupedPRs()` to apply sorting:
+
+```swift
+private func groupedPRs() -> [(group: PRGroup, prs: [PullRequest])] {
+    var byGroup: [PRGroup: [PullRequest]] = [:]
+    for pr in filteredPRs {
+        let g = prGroup(for: pr)
+        byGroup[g, default: []].append(pr)
+    }
+    let currentSortField = sortField
+    let currentSortOrder = sortOrder
+    return PRGroup.allCases.compactMap { g in
+        guard var prs = byGroup[g], !prs.isEmpty else { return nil }
+        prs = sortPRs(prs, by: currentSortField, order: currentSortOrder)
+        return (g, prs)
+    }
+}
+```
+
+- [ ] **Step 4: Insert PRFilterBar and PRColumnHeader into the body**
+
+In the body, between the `Divider()` (after toolbar, line 216) and the PR list content, insert the filter bar and column header:
+
+```swift
+Divider()
+
+// Filter bar
+PRFilterBar(
+    filter: Binding(
+        get: { filterState },
+        set: { filterState = $0 }
+    ),
+    pullRequests: filteredPRs
+)
+
+Divider()
+
+// Column headers
+PRColumnHeader(
+    sortField: Binding(
+        get: { sortField },
+        set: { sortField = $0 }
+    ),
+    sortOrder: Binding(
+        get: { sortOrder },
+        set: { sortOrder = $0 }
+    )
+)
+
+Divider()
+```
+
+- [ ] **Step 5: Update the empty state for filtered-out PRs**
+
+Replace the existing empty state block (the `if filteredPRs.isEmpty && !isLoading` check) to handle filter-specific messaging:
+
+```swift
+if filteredPRs.isEmpty && !isLoading {
+    Spacer()
+    VStack(spacing: 8) {
+        Image(systemName: "pull.request")
+            .font(.largeTitle)
+            .foregroundStyle(.secondary)
+        if filterState.isActive {
+            Text("No PRs match current filters")
+                .foregroundStyle(.secondary)
+            Button("Clear Filters") { filterState = PRFilterState() }
+                .controlSize(.small)
+        } else {
+            Text("No pull requests")
+                .foregroundStyle(.secondary)
+            Button("Refresh") { onRefresh() }
+                .controlSize(.small)
+        }
+    }
+    Spacer()
+}
+```
+
+- [ ] **Step 6: Build and run tests**
+
+Run: `swift build 2>&1 | tail -10`
+Then: `swift test 2>&1 | tail -20`
+Expected: Build succeeds, all tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Sources/Views/PRDashboard/PRDashboardView.swift
+git commit -m "feat: integrate filter bar, column headers, and sorting into PR dashboard
+
+Adds @AppStorage-backed sort/filter state, PRFilterBar and PRColumnHeader
+above the grouped list, sorts within groups, and updates empty states
+for filter-specific messaging."
+```
+
+---
+
+### Task 6: Run full test suite and verify
+
+**Files:**
+- No new files — verification only.
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `swift test 2>&1 | tail -30`
+Expected: All 273+ tests pass (existing tests still green, new PRSortFilter tests green).
+
+- [ ] **Step 2: Build release to verify no warnings**
+
+Run: `swift build -c release 2>&1 | tail -10`
+Expected: Clean build with no errors.
+
+- [ ] **Step 3: Run the app and verify visually**
+
+Run: `swift run Runway`
+Expected: PR dashboard shows filter bar, column headers, and grid-aligned rows. Sorting and filtering work as expected.
+
+- [ ] **Step 4: Final commit if any fixups needed**
+
+If any adjustments were needed during verification, commit them:
+
+```bash
+git add -A
+git commit -m "fix: address issues found during PR sort/filter verification"
+```

--- a/docs/superpowers/specs/2026-04-10-pr-sorting-filtering-design.md
+++ b/docs/superpowers/specs/2026-04-10-pr-sorting-filtering-design.md
@@ -1,0 +1,157 @@
+# PR Column Layout, Sorting & Filtering
+
+## Overview
+
+Add sortable columns and a persistent filter bar to the PR dashboard. PRs remain organized in their existing groups (Needs Attention, In Progress, Waiting for Review, Ready, Drafts), but within each group the data is displayed in aligned columns that can be sorted, and a filter bar lets users narrow the list by repo, author, age, checks, review status, and merge status.
+
+## Column Layout
+
+The PR list switches from badge-based rows to a compact column grid. Column headers appear once at the top of the list, below the filter bar and above the first group.
+
+### Columns (left to right)
+
+| Column | Content | Width | Sort Behavior |
+|--------|---------|-------|---------------|
+| Title | State badge + PR # + title text | Flexible (fills remaining) | Alphabetical by title |
+| Repo | Repository short name | Fixed ~100pt, truncates | Alphabetical |
+| Author | GitHub username | Fixed ~70pt, truncates | Alphabetical |
+| Age | Relative time from `createdAt` | Fixed ~50pt | Oldest/newest by date |
+| Checks | Pass/total with colored icon | Fixed ~55pt | By pass ratio, then total |
+| Review | Approved / Changes / Pending | Fixed ~55pt | Approved > Pending > Changes |
+| Merge | Clean / Conflicts / Behind / Blocked | Fixed ~65pt | Clean > Behind > Conflicts > Blocked |
+
+### Sorting
+
+- Click a column header to sort ascending; click again for descending.
+- Active sort column shows ▲ (ascending) or ▼ (descending) indicator.
+- Sorting applies within each group — group order is fixed.
+- Default sort: Age descending (newest first).
+- Sort preference persists via `@AppStorage`.
+
+## Filter Bar
+
+A persistent bar above the column headers, always visible. Contains a row of SwiftUI `Menu` dropdown buttons.
+
+### Filter Dimensions
+
+| Filter | Options |
+|--------|---------|
+| Repo | "All", then each distinct repo from current PRs (dynamic) |
+| Author | "All", then each distinct author from current PRs (dynamic) |
+| Age | "Any", "Last 24h", "Last 7 days", "Last 30 days", "Older than 30 days" |
+| Checks | "All", "Passing", "Failing", "Pending" |
+| Review | "All", "Approved", "Changes Requested", "Pending" |
+| Merge | "All", "Clean", "Conflicts", "Behind", "Blocked" |
+
+### Behavior
+
+- Filters are additive (AND logic).
+- Active filter buttons are highlighted (accent color).
+- A "Clear" button appears when any filter is non-default, resetting all to defaults.
+- Filters apply before grouping — empty groups are hidden.
+- Group counts update to reflect filtered totals.
+- Existing Hide Drafts and Session PRs Only toggles remain in the toolbar (separate from the filter bar).
+- Filter selections persist via `@AppStorage`.
+
+## Data Model
+
+### New Types
+
+```swift
+enum PRSortField: String, CaseIterable {
+    case title, repo, author, age, checks, review, mergeStatus
+}
+
+enum PRSortOrder: String {
+    case ascending, descending
+}
+
+enum PRAgeBucket: String, CaseIterable {
+    case any
+    case last24h
+    case last7d
+    case last30d
+    case olderThan30d
+}
+
+struct PRFilterState {
+    var repo: String?              // nil = All
+    var author: String?            // nil = All
+    var ageBucket: PRAgeBucket = .any
+    var checks: CheckStatus?       // nil = All (reuses existing enum)
+    var review: ReviewDecision?    // nil = All (reuses existing enum)
+    var mergeStatus: MergeStateStatus? // nil = All (reuses existing enum)
+
+    var isActive: Bool { /* true if any filter is non-default */ }
+    func matches(_ pr: PullRequest) -> Bool { /* AND logic across all fields */ }
+    mutating func clear() { /* reset all to defaults */ }
+}
+```
+
+### Filtering Pipeline (in order)
+
+1. Tab filter (All / Mine / Review Requested) — existing
+2. Hide Drafts toggle — existing
+3. Session PRs Only toggle — existing
+4. **`PRFilterState.matches()` — NEW**
+5. Group into `PRGroup` sections — existing
+6. **Sort within each group by `PRSortField` — NEW**
+
+## View Architecture
+
+### Modified Files
+
+- **`PRDashboardView.swift`** — Add `PRFilterBar` above the list, add column header row, refactor PR list to use grid-aligned rows. Add `@AppStorage` for sort/filter state.
+- **`PRRowView.swift`** — Refactor body from free-form `HStack` with badges to a grid-aligned row matching column widths.
+
+### New Files
+
+- **`PRFilterBar.swift`** (in `Views/PRDashboard/`) — Persistent filter bar with `Menu` buttons + Clear. Takes `Binding<PRFilterState>` and current PR list for computing dynamic options.
+- **`PRColumnHeader.swift`** (in `Views/PRDashboard/`) — Clickable column header row. Takes `Binding<PRSortField>` and `Binding<PRSortOrder>`. Active column shows sort direction indicator.
+- **`PRSortFilter.swift`** (in `Views/PRDashboard/` or `Models/`) — Contains `PRSortField`, `PRSortOrder`, `PRAgeBucket`, `PRFilterState` types plus sorting comparator and filter matching logic.
+
+### Unchanged
+
+- `PRDetailDrawer` — untouched
+- `PRGroup` enum and `prGroup(for:)` — untouched
+- Group collapsibility — untouched
+- `PRBadges.swift` — badges reused in column cells
+- `ProjectPRsTab` — out of scope
+
+### Layout Hierarchy
+
+```
+PRDashboardView
+├── Toolbar (tabs, refresh, session toggle, hide drafts)
+├── PRFilterBar              ← NEW
+├── PRColumnHeader           ← NEW
+├── ForEach(groups)
+│   ├── Group header (collapsible, with filtered count)
+│   └── ForEach(sorted PRs in group)
+│       └── PRRowView        ← MODIFIED (grid-aligned)
+└── PRDetailDrawer (resizable, on selection)
+```
+
+## Edge Cases
+
+- **All PRs filtered out**: Centered message "No PRs match current filters" with Clear button.
+- **Empty group after filter**: Group header hidden entirely.
+- **Window resize**: Title column flexes; fixed columns hold width. At very narrow widths, columns truncate with ellipsis.
+
+## Theme Integration
+
+- Column headers: `chrome.secondaryText` for labels, `chrome.accent` for active sort indicator.
+- Filter bar background: `chrome.surface`.
+- Active filter buttons: subtle accent highlight.
+
+## Persistence
+
+All stored in `@AppStorage` with `"pr"` key prefix:
+- `prSortField` (String, default: "age")
+- `prSortOrder` (String, default: "descending")
+- `prFilterRepo` (String, default: "" for All)
+- `prFilterAuthor` (String, default: "" for All)
+- `prFilterAge` (String, default: "any")
+- `prFilterChecks` (String, default: "" for All)
+- `prFilterReview` (String, default: "" for All)
+- `prFilterMerge` (String, default: "" for All)


### PR DESCRIPTION
## Summary

Replaces the PR dashboard's grouped badge-based list with a native SwiftUI `Table` providing sortable columns, resizable column widths, and a persistent filter bar.

- **Sortable columns**: Title, Repo, Author, Age, Checks, Review, Merge — click any column header to sort ascending/descending
- **Resizable columns**: Drag column borders in the header to resize (built into SwiftUI Table)
- **Filter bar**: Persistent dropdown menus for Repo, Author, Age (preset ranges), Checks, Review, and Merge status with AND logic and a Clear button
- **Filter persistence**: All filter selections saved via `@AppStorage` across app launches
- **Flat sorted list**: Removed the old grouped sections (Needs Attention/In Progress/etc.) since sortable columns make grouping redundant
- **20 new tests**: Full coverage for filter matching (repo, author, age buckets, checks, review, merge) and sort ordering

### Files changed

| File | Change |
|------|--------|
| `PRSortFilter.swift` | New — sort/filter types, PRFilterState, PRColumnWidths, sort helpers |
| `PRFilterBar.swift` | New — persistent dropdown filter bar with dynamic options |
| `PRColumnHeader.swift` | New — column header view (kept for potential future custom sort UI) |
| `PRDashboardView.swift` | Rebuilt — SwiftUI Table replaces List+HStack, toolbar+filter pinned via safeAreaInset |
| `PRSortFilterTests.swift` | New — 20 tests covering all filter and sort logic |

## Test plan

- [x] `swift test` — 293 tests pass (20 new + 273 existing)
- [x] `swift build -c release` — clean, 0 warnings
- [ ] Visual: verify columns align, sorting works on all 7 columns, filters narrow the list
- [ ] Visual: verify column resizing by dragging header borders
- [ ] Visual: verify filter bar Clear button resets all filters
- [ ] Verify PR detail drawer still opens on row selection