### PR TITLE
feat: add Close PR button to PR dashboard

### DIFF
--- a/Sources/App/RunwayApp.swift
+++ b/Sources/App/RunwayApp.swift
@@ -504,7 +504,8 @@ struct ContentView: View {
                 },
                 onReviewPR: { pr in store.reviewPR(pr) },
                 onEnableAutoMerge: { pr, strategy in Task { await store.enableAutoMerge(pr, strategy: strategy) } },
-                onDisableAutoMerge: { pr in Task { await store.disableAutoMerge(pr) } }
+                onDisableAutoMerge: { pr in Task { await store.disableAutoMerge(pr) } },
+                onClosePR: { pr in Task { await store.closePR(pr) } }
             )
         }
     }

--- a/Sources/App/RunwayStore.swift
+++ b/Sources/App/RunwayStore.swift
@@ -1285,6 +1285,17 @@ public final class RunwayStore {
         }
     }
 
+    func closePR(_ pr: PullRequest) async {
+        let host = prManager.hostFromURL(pr.url)
+        do {
+            try await prManager.close(repo: pr.repo, number: pr.number, host: host)
+            statusMessage = .success("Closed #\(pr.number)")
+            await refreshPRAfterAction(pr)
+        } catch {
+            statusMessage = .error("Close failed: \(error.localizedDescription)")
+        }
+    }
+
     func updatePRBranch(_ pr: PullRequest, rebase: Bool = false) async {
         let host = prManager.hostFromURL(pr.url)
         do {

--- a/Sources/GitHubOperations/PRManager.swift
+++ b/Sources/GitHubOperations/PRManager.swift
@@ -253,6 +253,14 @@ public actor PRManager {
         )
     }
 
+    /// Close a PR without merging.
+    public func close(repo: String, number: Int, host: String? = nil) async throws {
+        try await runGH(
+            args: ["pr", "close", "\(number)", "--repo", repo],
+            host: host
+        )
+    }
+
     /// Update a PR branch with the latest base branch (merge or rebase).
     public func updateBranch(repo: String, number: Int, rebase: Bool = false, host: String? = nil) async throws {
         var args = ["pr", "update-branch", "\(number)", "--repo", repo]

--- a/Sources/Views/PRDashboard/PRDashboardView.swift
+++ b/Sources/Views/PRDashboard/PRDashboardView.swift
@@ -22,6 +22,7 @@ public struct PRDashboardView: View {
     var onReviewPR: ((PullRequest) -> Void)?
     var onEnableAutoMerge: ((PullRequest, MergeStrategy) -> Void)?
     var onDisableAutoMerge: ((PullRequest) -> Void)?
+    var onClosePR: ((PullRequest) -> Void)?
 
     @AppStorage("prListWidth") private var prListWidth: Double = 380
     @AppStorage("hideDrafts") private var hideDrafts: Bool = false
@@ -76,7 +77,8 @@ public struct PRDashboardView: View {
         onSendToSession: ((PullRequest, String) -> Void)? = nil,
         onReviewPR: ((PullRequest) -> Void)? = nil,
         onEnableAutoMerge: ((PullRequest, MergeStrategy) -> Void)? = nil,
-        onDisableAutoMerge: ((PullRequest) -> Void)? = nil
+        onDisableAutoMerge: ((PullRequest) -> Void)? = nil,
+        onClosePR: ((PullRequest) -> Void)? = nil
     ) {
         self.pullRequests = pullRequests
         self.selectedPRID = selectedPRID
@@ -96,6 +98,7 @@ public struct PRDashboardView: View {
         self.onReviewPR = onReviewPR
         self.onEnableAutoMerge = onEnableAutoMerge
         self.onDisableAutoMerge = onDisableAutoMerge
+        self.onClosePR = onClosePR
     }
 
     private var selectedPR: PullRequest? {
@@ -181,6 +184,9 @@ public struct PRDashboardView: View {
                         { strategy in callback(pr, strategy) }
                     },
                     onDisableAutoMerge: onDisableAutoMerge.map { callback in
+                        { callback(pr) }
+                    },
+                    onClosePR: onClosePR.map { callback in
                         { callback(pr) }
                     }
                 )
@@ -272,6 +278,10 @@ public struct PRDashboardView: View {
                     .contextMenu {
                         if let onReviewPR {
                             Button("Open Review Session") { onReviewPR(pr) }
+                        }
+                        if let onClosePR, pr.state == .open || pr.state == .draft {
+                            Divider()
+                            Button("Close PR", role: .destructive) { onClosePR(pr) }
                         }
                     }
             }

--- a/Sources/Views/PRDashboard/PRDetailDrawer.swift
+++ b/Sources/Views/PRDashboard/PRDetailDrawer.swift
@@ -17,11 +17,13 @@ public struct PRDetailDrawer: View {
     var onSendToSession: ((String) -> Void)?
     var onEnableAutoMerge: ((MergeStrategy) -> Void)?
     var onDisableAutoMerge: (() -> Void)?
+    var onClosePR: (() -> Void)?
 
     @State private var selectedTab: PRDetailTab = .overview
     @State private var sheetCommentText: String = ""
     @State private var inlineCommentText: String = ""
     @State private var showMergeConfirm: Bool = false
+    @State private var showCloseConfirm: Bool = false
     @State private var selectedMergeStrategy: MergeStrategy = .squash
     @State private var requestChangesText: String = ""
     @State private var activeSheet: ActiveSheet?
@@ -46,7 +48,8 @@ public struct PRDetailDrawer: View {
         onUpdateBranch: ((Bool) -> Void)? = nil,
         onSendToSession: ((String) -> Void)? = nil,
         onEnableAutoMerge: ((MergeStrategy) -> Void)? = nil,
-        onDisableAutoMerge: (() -> Void)? = nil
+        onDisableAutoMerge: (() -> Void)? = nil,
+        onClosePR: (() -> Void)? = nil
     ) {
         self.pr = pr
         self.detail = detail
@@ -60,6 +63,7 @@ public struct PRDetailDrawer: View {
         self.onUpdateBranch = onUpdateBranch
         self.onEnableAutoMerge = onEnableAutoMerge
         self.onDisableAutoMerge = onDisableAutoMerge
+        self.onClosePR = onClosePR
     }
 
     public var body: some View {
@@ -175,6 +179,16 @@ public struct PRDetailDrawer: View {
                     autoMergeButton
                 }
 
+                if let onClosePR, pr.state == .open || pr.state == .draft {
+                    Button {
+                        showCloseConfirm = true
+                    } label: {
+                        Label("Close", systemImage: "xmark.circle")
+                    }
+                    .controlSize(.small)
+                    .tint(theme.chrome.red)
+                }
+
                 if let onSendToSession {
                     Button {
                         let context = "Review PR #\(pr.number): \(pr.title)"
@@ -203,6 +217,14 @@ public struct PRDetailDrawer: View {
                 }
             } message: {
                 Text("This will \(selectedMergeStrategy.displayName.lowercased()) #\(pr.number) into \(pr.baseBranch).")
+            }
+            .alert("Close Pull Request", isPresented: $showCloseConfirm) {
+                Button("Cancel", role: .cancel) {}
+                Button("Close", role: .destructive) {
+                    onClosePR?()
+                }
+            } message: {
+                Text("Close #\(pr.number) without merging?")
             }
             .sheet(item: $activeSheet) { sheet in
                 switch sheet {


### PR DESCRIPTION
## Summary

- Adds a **Close PR** action to the PR dashboard, allowing users to close pull requests without merging directly from Runway
- Button appears in the detail drawer action bar (with confirmation dialog) and in the right-click context menu on PR table rows
- Follows the existing callback chain pattern: `PRManager → RunwayStore → PRDashboardView → PRDetailDrawer`

## What Changed

- **PRManager** (`Sources/GitHubOperations/PRManager.swift`): New `close()` method wrapping `gh pr close`
- **RunwayStore** (`Sources/App/RunwayStore.swift`): New `closePR()` handler with status message and refresh
- **PRDetailDrawer** (`Sources/Views/PRDashboard/PRDetailDrawer.swift`): Close button with `xmark.circle` icon and confirmation alert
- **PRDashboardView** (`Sources/Views/PRDashboard/PRDashboardView.swift`): `onClosePR` callback threaded through init and context menu
- **RunwayApp** (`Sources/App/RunwayApp.swift`): Wires callback to store

## Design Decisions

- Named `onClosePR` (not `onClose`) to avoid collision with the existing drawer-dismiss callback
- Confirmation dialog on the detail drawer button ("Close #N without merging?") since accidental clicks are easy
- Context menu uses `role: .destructive` (red text) — right-click is intentional enough
- Only visible for `.open` or `.draft` PRs

## Test plan

- [x] `swift build` passes
- [x] All 293 tests pass (`swift test`)
- [x] Pre-commit hooks pass (swiftlint + swift-format)
- [ ] Manual: open PR detail drawer → verify Close button appears for open PRs
- [ ] Manual: click Close → confirm dialog appears → confirm → PR closes and list refreshes
- [ ] Manual: right-click PR row → "Close PR" appears in context menu
- [ ] Manual: verify Close button does not appear for already-merged or already-closed PRs