### PR TITLE
feat: complete v1.0 roadmap — tests, PRCoordinator, a11y, UX, cleanup

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -141,12 +141,12 @@ let package = Package(
         ),
         .testTarget(
             name: "StatusDetectionTests",
-            dependencies: ["StatusDetection"],
+            dependencies: ["StatusDetection", "Models"],
             path: "Tests/StatusDetectionTests"
         ),
         .testTarget(
             name: "GitOperationsTests",
-            dependencies: ["GitOperations"],
+            dependencies: ["GitOperations", "Models"],
             path: "Tests/GitOperationsTests"
         ),
         .testTarget(
@@ -163,6 +163,11 @@ let package = Package(
             name: "TerminalTests",
             dependencies: ["Terminal"],
             path: "Tests/TerminalTests"
+        ),
+        .testTarget(
+            name: "TerminalViewTests",
+            dependencies: ["TerminalView"],
+            path: "Tests/TerminalViewTests"
         ),
         .testTarget(
             name: "ViewsTests",

--- a/ROADMAP-1.0.md
+++ b/ROADMAP-1.0.md
@@ -87,14 +87,15 @@
 - ProjectPageView (tab bar)
 - SessionHeaderView (cost badge, tool badge, PR number)
 
-#### Remaining Tests (5 from QA2's top 10)
+#### Remaining Tests (5 from QA2's top 10) — DONE
 Tests already added: migration safety, cost tracking, housekeeping, saved prompts, branch sanitization, worktree with slashes, HookEvent cost fields, Session Equatable.
-**Still needed:**
-1. `RunwayStore.deleteSession(deleteWorktree: true)` — most destructive user operation
-2. `TerminalSessionCache` LRU eviction — validate process cleanup
-3. `ShellRunner.run()` timeout behavior — verify SIGTERM on timeout
-4. `RunwayStore.cleanOrphanedWorktrees()` — protect unmerged branches
-5. HookServer → StatusDetector end-to-end — event wiring
+**Added (17 tests across 4 files):**
+1. [x] `deleteSession(deleteWorktree: true)` — removeWorktree protects unmerged branches via `-d`, deletes merged
+2. [x] `TerminalSessionCache` LRU eviction — eviction order, refresh on access, removal, get-or-create identity
+3. [x] `ShellRunner.run()` timeout — SIGTERM on timeout, success within timeout, non-zero exit handling
+4. [x] `cleanOrphanedWorktrees()` — full list→identify→merge-check→remove flow, owned preserved, unmerged preserved
+5. [x] HookServer → handler e2e — full JSON decode with header override + cost fields, without header
+**Bug fixed:** `isBranchMerged` didn't strip `+ ` prefix from `git branch --merged` output (worktree checkout marker)
 
 ### Medium Priority
 
@@ -136,7 +137,7 @@ Backend exists (`commitLog`, `resetToCommit` on WorktreeManager). Needs:
 |--------|--------|-------------------|---------------|
 | Critical bugs | 4 | **0** | 0 |
 | Major bugs | ~20 | **~2** | 0 |
-| Test count | 292 | **312** | 340+ |
+| Test count | 292 | **329** | 340+ |
 | DB migrations | 14 | **17** | 17+ |
 | Features added | — | **8 new** | — |
 | RunwayStore LOC | 1708 | ~1850 | ~1200 (after P1) |

--- a/ROADMAP-1.0.md
+++ b/ROADMAP-1.0.md
@@ -66,21 +66,18 @@
 All PR state, polling, enrichment, actions, and detail caching moved to separate @Observable class.
 RunwayStore holds `let prCoordinator: PRCoordinator` with weak back-reference for cross-cutting concerns.
 
-#### U1: VoiceOver Accessibility Pass
+#### U1: VoiceOver Accessibility Pass — DONE
 **Impact:** Required for 1.0 — app is essentially unusable with VoiceOver.
 **Scope:** ~25 view files need `.accessibilityLabel()` added.
 **Already done:** SendTextBar, sidebar search/clear/action buttons, PRDetailDrawer close, IssueDetailDrawer close, PRBadges (already had labels), ResizableDivider (already had labels).
-**Still needs labels:**
-- DiffView (file headers, line numbers)
-- ChangesSidebarView (file entries)
-- FileTreeView (file status)
-- PRDashboardView (table cells, action buttons)
-- PRFilterBar (filter toggles)
-- NewSessionDialog (form fields)
-- NewProjectDialog (form fields)
-- NewIssueSheet, EditIssueSheet, ManageLabelsSheet, ManageAssigneesSheet
-- ProjectPageView (tab bar)
-- SessionHeaderView (cost badge, tool badge, PR number)
+**Added (14 labels across 8 files):**
+- [x] DiffView — file expand/collapse toggle button
+- [x] ChangesSidebarView — comparison mode picker label
+- [x] FileTreeView — directory expand/collapse, file row with status and diff stats
+- [x] PRDashboardView — session PRs toggle, hide drafts toggle, refresh button
+- [x] PRFilterBar — clear all filters button
+- [x] ProjectPageView — settings gear button
+- [x] SessionHeaderView — parent session link, PR number button, inline comments badge
 
 #### Remaining Tests (5 from QA2's top 10) — DONE
 Tests already added: migration safety, cost tracking, housekeeping, saved prompts, branch sanitization, worktree with slashes, HookEvent cost fields, Session Equatable.

--- a/ROADMAP-1.0.md
+++ b/ROADMAP-1.0.md
@@ -109,20 +109,20 @@ NewSessionDialog, NewProjectDialog, ReviewPRSheet (2), ProjectSettingsSheet.
 Replaced 4 independent booleans (`showNewSessionDialog`, `showNewProjectDialog`, `showReviewPRSheet`,
 `showReviewPRDialog`) with single `ActiveSheet` enum + `.sheet(item:)` modifier.
 
-### Low Priority
+### Low Priority — DONE
 
-| Item | File | Notes |
-|------|------|-------|
-| DatabaseQueue → DatabasePool | Database.swift | Concurrent reads during writes |
-| Consolidate 3 Color(hex:) initializers | Theme module | Dedup |
-| startSessionFromIssue hardcoded .claude | RunwayStore.swift | Use project default tool when available |
-| P4: async let actor serialization | PRManager.swift | Needs nonisolated helper methods |
-| P2: Reduce enrichPath timeout to 1s | ShellRunner.swift | Minor launch time improvement |
-| [weak self] on bufferDetectionTask | RunwayStore.swift | Consistency (already has jitter) |
-| PullRequest + CheckSummary Equatable | Models | Optimize SwiftUI diffing |
-| Remove precondition(inMemory) from Database test init | Database.swift | Replace with throwing |
-| HookServer stop() cancel in-flight connections | HookServer.swift | Track + cancel active connections |
-| Orphaned Task tracking | RunwayStore.swift | Store provisioning Tasks, cancel on delete |
+| Item | File | Status |
+|------|------|--------|
+| DatabaseQueue → DatabasePool | Database.swift | ✅ Pool for prod, Queue for tests, via `any DatabaseWriter` |
+| Consolidate 3 Color(hex:) initializers | Theme module | ✅ Failable `init?(hex:)` moved to Theme, removed from NewIssueSheet |
+| startSessionFromIssue hardcoded .claude | RunwayStore.swift | ✅ Uses project's most recent session tool |
+| P4: async let actor serialization | PRManager.swift | ✅ Nonisolated static helper for parallel fetch |
+| P2: Reduce enrichPath timeout to 1s | ShellRunner.swift | ✅ 3s → 1s |
+| [weak self] on bufferDetectionTask | RunwayStore.swift | ✅ Already present |
+| PullRequest + CheckSummary Equatable | Models | ✅ Auto-synthesized conformance |
+| Remove precondition(inMemory) from Database test init | Database.swift | ✅ Removed (param kept, no default) |
+| HookServer stop() cancel in-flight connections | HookServer.swift | ✅ Tracks + cancels active connections |
+| Orphaned Task tracking | RunwayStore.swift | ✅ provisioningTasks dict, cancelled on delete |
 
 ---
 
@@ -131,7 +131,7 @@ Replaced 4 independent booleans (`showNewSessionDialog`, `showNewProjectDialog`,
 | Metric | v0.8.0 | Current (v0.9.0) | Target v1.0.0 |
 |--------|--------|-------------------|---------------|
 | Critical bugs | 4 | **0** | 0 |
-| Major bugs | ~20 | **~2** | 0 |
+| Major bugs | ~20 | **0** | 0 |
 | Test count | 292 | **329** | 340+ |
 | DB migrations | 14 | **17** | 17+ |
 | Features added | — | **8 new** | — |

--- a/ROADMAP-1.0.md
+++ b/ROADMAP-1.0.md
@@ -60,16 +60,11 @@
 
 ### High Priority
 
-#### P1: Extract PRCoordinator from RunwayStore
+#### P1: Extract PRCoordinator from RunwayStore — DONE
 **Impact:** Biggest remaining performance win — reduces @Observable view invalidation scope.
-**Scope:** ~400 LOC moved to new file, ~200 LOC of glue changes in RunwayStore + RunwayApp.
-**Risk:** Large refactor — do on clean baseline.
-**What to extract:**
-- `pullRequests`, `selectedPRID`, `prDetail`, `prTab`, `prLastFetched`, `isLoadingPRs`
-- `enrichPRsTask`, `lastPRFingerprint`, `prPollTask`, `sessionPRPollTask`
-- `detailCache`, `detailTTL`, `sessionPRs`, `sessionPRFetchedAt`
-- Methods: `fetchPRs`, `enrichPRs`, `linkSessionPRs`, `freshenSessionPRs`, `selectPR`, `startPRPoll`, `startSessionPRPoll`
-- `loadCachedPRs`, `refreshPRsIfStale`, `reEnrichPR`, `applyEnrichment`
+**Result:** 496 LOC in new `PRCoordinator.swift`, RunwayStore reduced from 1818 → 1391 LOC.
+All PR state, polling, enrichment, actions, and detail caching moved to separate @Observable class.
+RunwayStore holds `let prCoordinator: PRCoordinator` with weak back-reference for cross-cutting concerns.
 
 #### U1: VoiceOver Accessibility Pass
 **Impact:** Required for 1.0 — app is essentially unusable with VoiceOver.
@@ -140,6 +135,6 @@ Backend exists (`commitLog`, `resetToCommit` on WorktreeManager). Needs:
 | Test count | 292 | **329** | 340+ |
 | DB migrations | 14 | **17** | 17+ |
 | Features added | — | **8 new** | — |
-| RunwayStore LOC | 1708 | ~1850 | ~1200 (after P1) |
+| RunwayStore LOC | 1708 | **1391** | ~1200 (after P1) ✅ |
 | Accessibility labels | ~10 | **~25** | 200+ |
 | Force unwrap/precondition crash risks | 3 | **0** | 0 |

--- a/ROADMAP-1.0.md
+++ b/ROADMAP-1.0.md
@@ -100,11 +100,13 @@ Backend exists (`commitLog`, `resetToCommit` on WorktreeManager). Needs:
 #### U9: Unified Tab Bar Component
 4 different tab bar patterns exist (dashboard, project page, PR detail, issue detail). Extract shared `TabBarView`.
 
-#### U10: Adaptive Sheet Widths
-~10 sheets use hardcoded `frame(width:)`. Switch to `minWidth`/`idealWidth`/`maxWidth`.
+#### U10: Adaptive Sheet Widths — DONE
+Replaced hardcoded `frame(width:)` with `minWidth`/`idealWidth`/`maxWidth` on 5 sheets:
+NewSessionDialog, NewProjectDialog, ReviewPRSheet (2), ProjectSettingsSheet.
 
-#### U11: Consolidate Sheet Booleans
-4 independent sheet booleans (`showNewSessionDialog`, `showNewProjectDialog`, `showReviewPRSheet`, `showReviewPRDialog`) → single `ActiveSheet` enum.
+#### U11: Consolidate Sheet Booleans — DONE
+Replaced 4 independent booleans (`showNewSessionDialog`, `showNewProjectDialog`, `showReviewPRSheet`,
+`showReviewPRDialog`) with single `ActiveSheet` enum + `.sheet(item:)` modifier.
 
 ### Low Priority
 

--- a/ROADMAP-1.0.md
+++ b/ROADMAP-1.0.md
@@ -91,14 +91,15 @@ Tests already added: migration safety, cost tracking, housekeeping, saved prompt
 
 ### Medium Priority
 
-#### F6 UI: Git Rollback View
-Backend exists (`commitLog`, `resetToCommit` on WorktreeManager). Needs:
-- `CommitHistoryView.swift` showing commit list for the session's worktree branch
-- Rollback button with confirmation dialog
-- Integration into session detail (button or tab)
+#### F6 UI: Git Rollback View — DONE
+`CommitHistoryView.swift` shows commits since branch divergence with rollback capability.
+Integrated into SessionHeaderView as a popover from a clock icon next to the branch name.
+Rollback button with confirmation dialog, HEAD badge on latest commit.
 
-#### U9: Unified Tab Bar Component
-4 different tab bar patterns exist (dashboard, project page, PR detail, issue detail). Extract shared `TabBarView`.
+#### U9: Unified Tab Bar Component — DONE
+Extracted shared `TabBarButton` (title + count badge + underline indicator + selected trait).
+Replaces private TabButton in ProjectPageView and tabButton method in PRDashboardView.
+TerminalTabView's browser-style closeable tabs left as-is (fundamentally different pattern).
 
 #### U10: Adaptive Sheet Widths — DONE
 Replaced hardcoded `frame(width:)` with `minWidth`/`idealWidth`/`maxWidth` on 5 sheets:

--- a/Sources/App/MenuBarView.swift
+++ b/Sources/App/MenuBarView.swift
@@ -57,7 +57,7 @@ struct MenuBarView: View {
 
             // Actions
             actionButton("New Session…", icon: "plus.circle") {
-                store.showNewSessionDialog = true
+                store.activeSheet = .newSession
                 NSApplication.shared.activate()
             }
 

--- a/Sources/App/PRCoordinator.swift
+++ b/Sources/App/PRCoordinator.swift
@@ -29,8 +29,6 @@ public final class PRCoordinator {
     }
 
     var reviewPRCandidate: PullRequest? = nil
-    var showReviewPRDialog: Bool = false
-    var showReviewPRSheet: Bool = false
     var isResolvingPR: Bool = false
 
     // MARK: - Private State
@@ -489,7 +487,7 @@ public final class PRCoordinator {
         do {
             let pr = try await prManager.resolvePR(repo: repo, number: number, host: host)
             reviewPRCandidate = pr
-            showReviewPRSheet = true
+            store?.activeSheet = .reviewPRSheet
         } catch {
             store?.statusMessage = .error(
                 "Failed to resolve PR #\(number): \(error.localizedDescription)")

--- a/Sources/App/PRCoordinator.swift
+++ b/Sources/App/PRCoordinator.swift
@@ -1,0 +1,498 @@
+import AppKit
+import Foundation
+import GitHubOperations
+import Models
+import Persistence
+import Views
+
+/// Manages all pull request state and operations, extracted from RunwayStore
+/// to reduce @Observable invalidation scope. PR poll ticks no longer trigger
+/// re-evaluation of terminal, sidebar, and session detail views.
+@Observable
+@MainActor
+public final class PRCoordinator {
+    // MARK: - State
+
+    var pullRequests: [PullRequest] = []
+    var selectedPRID: String?
+    var prDetail: PRDetail?
+    var prTab: PRTab = .mine
+    var prLastFetched: Date?
+    var isLoadingPRs: Bool = false
+
+    /// Maps session ID → linked PullRequest (matched by worktree branch)
+    var sessionPRs: [String: PullRequest] = [:]
+
+    /// Set of PR IDs linked to active Runway sessions — used for the Sessions filter toggle.
+    var sessionPRIDs: Set<String> {
+        Set(sessionPRs.values.map(\.id))
+    }
+
+    var reviewPRCandidate: PullRequest? = nil
+    var showReviewPRDialog: Bool = false
+    var showReviewPRSheet: Bool = false
+    var isResolvingPR: Bool = false
+
+    // MARK: - Private State
+
+    private var prPollTask: Task<Void, Never>?
+    private var sessionPRPollTask: Task<Void, Never>?
+    private var enrichPRsTask: Task<Void, Never>?
+    private var lastPRFingerprint: PRFingerprint?
+    private var sessionPRFetchedAt: [String: Date] = [:]
+    private let sessionPRTTL: TimeInterval = 60
+    private var detailCache: [String: (detail: PRDetail, fetchedAt: Date)] = [:]
+    private let detailTTL: TimeInterval = 300
+
+    // MARK: - Dependencies
+
+    let prManager: PRManager
+    private let database: Database?
+
+    /// Back-reference to the store for cross-cutting concerns (statusMessage, navigation, sessions).
+    /// Weak to avoid retain cycle: RunwayStore → PRCoordinator → RunwayStore.
+    weak var store: RunwayStore?
+
+    // MARK: - Init
+
+    init(prManager: PRManager, database: Database?) {
+        self.prManager = prManager
+        self.database = database
+    }
+
+    // MARK: - Session Cleanup
+
+    /// Called by RunwayStore when a session is deleted — clears linked PR and fetch timestamps.
+    func sessionDeleted(id: String) {
+        sessionPRs.removeValue(forKey: id)
+        sessionPRFetchedAt.removeValue(forKey: id)
+    }
+
+    // MARK: - PR Detail for Session
+
+    /// Returns PRDetail for the selected session's linked PR, if available.
+    func prDetailForSession(_ sessionID: String) -> PRDetail? {
+        guard let pr = sessionPRs[sessionID] else { return nil }
+        if selectedPRID == pr.id { return prDetail }
+        return nil
+    }
+
+    // MARK: - PR Loading
+
+    /// Load cached PRs from database for instant display on startup.
+    func loadCachedPRs() {
+        if let cached = try? database?.cachedPRs(maxAge: 86400), !cached.isEmpty {
+            pullRequests = cached
+        }
+    }
+
+    func fetchPRs() async {
+        guard !isLoadingPRs else { return }
+        isLoadingPRs = true
+        defer { isLoadingPRs = false }
+
+        do {
+            let freshPRs = try await prManager.fetchAllPRs()
+            prLastFetched = Date()
+
+            // Merge: keep enriched data from cache/previous enrichment where available
+            let existingByID = Dictionary(
+                pullRequests.map { ($0.id, $0) }, uniquingKeysWith: { _, new in new })
+            pullRequests = freshPRs.map { fresh in
+                guard var existing = existingByID[fresh.id] else { return fresh }
+                existing.title = fresh.title
+                existing.state = fresh.state
+                existing.isDraft = fresh.isDraft
+                existing.author = fresh.author
+                existing.origin = fresh.origin
+                existing.createdAt = fresh.createdAt
+                existing.updatedAt = fresh.updatedAt
+                return existing
+            }
+
+            // Cancel any in-flight enrichment to prevent stale results overwriting fresh data
+            enrichPRsTask?.cancel()
+            enrichPRsTask = Task { await enrichPRs() }
+        } catch {
+            print("[Runway] Failed to fetch PRs: \(error)")
+            store?.statusMessage = .error("PR fetch failed: \(error.localizedDescription)")
+        }
+    }
+
+    func refreshPRsIfStale() async {
+        let staleness: TimeInterval = 60
+        if let last = prLastFetched, Date().timeIntervalSince(last) < staleness { return }
+        await fetchPRs()
+    }
+
+    // MARK: - PR Enrichment
+
+    /// Background-enrich PRs with checks and review decision only (not full detail).
+    private func enrichPRs() async {
+        let toEnrich = pullRequests.filter { $0.needsEnrichment }
+        guard !toEnrich.isEmpty else {
+            await linkSessionPRs()
+            return
+        }
+
+        var enriched: [String: PREnrichResult] = [:]
+        await withTaskGroup(of: (String, PREnrichResult?).self) { group in
+            var inFlight = 0
+            let maxConcurrency = 5
+
+            for pr in toEnrich {
+                if inFlight >= maxConcurrency {
+                    if let (id, result) = await group.next() {
+                        if let result { enriched[id] = result }
+                        inFlight -= 1
+                    }
+                }
+
+                let host = prManager.hostFromURL(pr.url)
+                group.addTask { [prManager] in
+                    let result = try? await prManager.enrichChecks(
+                        repo: pr.repo, number: pr.number, host: host
+                    )
+                    return (pr.id, result)
+                }
+                inFlight += 1
+            }
+
+            for await (id, result) in group {
+                if let result { enriched[id] = result }
+            }
+        }
+
+        guard !Task.isCancelled else { return }
+
+        var updated = pullRequests
+        for i in updated.indices {
+            guard let result = enriched[updated[i].id] else { continue }
+            applyEnrichment(result, to: &updated[i])
+        }
+        pullRequests = updated
+
+        try? database?.cachePRs(pullRequests)
+        try? database?.cleanPRCache()
+        try? database?.cleanIssueCache()
+
+        await linkSessionPRs()
+    }
+
+    /// Re-enrich a single PR immediately (called after user actions like approve/merge).
+    private func reEnrichPR(_ pr: PullRequest) async {
+        let host = prManager.hostFromURL(pr.url)
+        guard
+            let result = try? await prManager.enrichChecks(
+                repo: pr.repo, number: pr.number, host: host
+            )
+        else { return }
+
+        if let idx = pullRequests.firstIndex(where: { $0.id == pr.id }) {
+            applyEnrichment(result, to: &pullRequests[idx])
+            try? database?.cachePR(pullRequests[idx])
+        }
+    }
+
+    private func applyEnrichment(_ result: PREnrichResult, to pr: inout PullRequest) {
+        pr.checks = result.checks
+        pr.reviewDecision = result.reviewDecision
+        if !result.headBranch.isEmpty {
+            pr.headBranch = result.headBranch
+            pr.baseBranch = result.baseBranch
+        }
+        pr.additions = result.additions
+        pr.deletions = result.deletions
+        pr.changedFiles = result.changedFiles
+        pr.mergeable = result.mergeable
+        pr.mergeStateStatus = result.mergeStateStatus
+        pr.autoMergeEnabled = result.autoMergeEnabled
+        pr.enrichedAt = Date()
+    }
+
+    // MARK: - Session PR Linking
+
+    /// Link PRs to sessions — concurrent, like Hangar.
+    private func linkSessionPRs() async {
+        guard let store else { return }
+        let worktreeSessions = store.sessions.filter {
+            $0.worktreeBranch != nil && !store.provisioningWorktreeIDs.contains($0.id)
+        }
+        guard !worktreeSessions.isEmpty else { return }
+        let now = Date()
+
+        await withTaskGroup(of: (String, PullRequest?).self) { group in
+            for session in worktreeSessions {
+                group.addTask { [prManager] in
+                    let pr = try? await prManager.fetchPRForWorktree(path: session.path)
+                    return (session.id, pr)
+                }
+            }
+            for await (sessionID, pr) in group {
+                sessionPRFetchedAt[sessionID] = now
+                if let pr {
+                    sessionPRs[sessionID] = pr
+                } else {
+                    sessionPRs.removeValue(forKey: sessionID)
+                }
+            }
+        }
+    }
+
+    // MARK: - Polling
+
+    /// Seed the fingerprint so the first poll doesn't trigger a redundant fetch.
+    func seedFingerprint() async {
+        lastPRFingerprint = await prManager.prFingerprint(filter: .mine)
+    }
+
+    /// Start a lightweight background poll that checks for PR changes every 30 seconds.
+    func startPRPoll() {
+        prPollTask?.cancel()
+        prPollTask = Task { @MainActor [weak self] in
+            while !Task.isCancelled {
+                let jitter = Double.random(in: 0...3)
+                try? await Task.sleep(for: .seconds(30 + jitter))
+                guard !Task.isCancelled, let self else { return }
+                guard !self.isLoadingPRs else { continue }
+                let fingerprint = await self.prManager.prFingerprint(filter: .mine)
+                let isStale = self.prLastFetched.map { Date().timeIntervalSince($0) > 300 } ?? true
+                if let fingerprint, fingerprint != self.lastPRFingerprint {
+                    self.lastPRFingerprint = fingerprint
+                    await self.fetchPRs()
+                } else if isStale {
+                    await self.fetchPRs()
+                }
+            }
+        }
+    }
+
+    /// Independent session→PR linking loop with 60s TTL per session.
+    func startSessionPRPoll() {
+        sessionPRPollTask?.cancel()
+        sessionPRPollTask = Task { @MainActor [weak self] in
+            while !Task.isCancelled {
+                let jitter = Double.random(in: 0...2)
+                try? await Task.sleep(for: .seconds(15 + jitter))
+                guard !Task.isCancelled, let self else { return }
+                await self.freshenSessionPRs()
+            }
+        }
+    }
+
+    /// Check each worktree session's PR status, respecting per-session TTL.
+    private func freshenSessionPRs() async {
+        guard let store else { return }
+        let now = Date()
+        let worktreeSessions = store.sessions.filter {
+            $0.worktreeBranch != nil && !store.provisioningWorktreeIDs.contains($0.id)
+        }
+        guard !worktreeSessions.isEmpty else { return }
+
+        let stale = worktreeSessions.filter { session in
+            guard let fetchedAt = sessionPRFetchedAt[session.id] else { return true }
+            return now.timeIntervalSince(fetchedAt) >= sessionPRTTL
+        }
+        guard !stale.isEmpty else { return }
+
+        await withTaskGroup(of: (String, PullRequest?).self) { group in
+            for session in stale {
+                group.addTask { [prManager] in
+                    let pr = try? await prManager.fetchPRForWorktree(path: session.path)
+                    return (session.id, pr)
+                }
+            }
+            for await (sessionID, pr) in group {
+                sessionPRFetchedAt[sessionID] = now
+                if let pr {
+                    sessionPRs[sessionID] = pr
+                } else {
+                    sessionPRs.removeValue(forKey: sessionID)
+                }
+            }
+        }
+    }
+
+    // MARK: - PR Selection
+
+    func selectPR(_ pr: PullRequest?, navigate: Bool = true) async {
+        selectedPRID = pr?.id
+        prDetail = nil
+        guard let pr else { return }
+
+        if navigate {
+            store?.currentView = .prs
+        }
+
+        // Check cache first
+        if let cached = detailCache[pr.id], Date().timeIntervalSince(cached.fetchedAt) < detailTTL {
+            prDetail = cached.detail
+            return
+        }
+
+        do {
+            let host = prManager.hostFromURL(pr.url)
+            let detail = try await prManager.fetchDetail(
+                repo: pr.repo, number: pr.number, host: host)
+            detailCache[pr.id] = (detail, Date())
+            prDetail = detail
+        } catch {
+            print("[Runway] Failed to fetch PR detail: \(error)")
+        }
+    }
+
+    // MARK: - PR Actions
+
+    /// Unified post-action refresh: wait 1s for GitHub to propagate, then re-enrich
+    /// the PR list entry and refresh the detail view if this PR is currently selected.
+    private func refreshPRAfterAction(_ pr: PullRequest) async {
+        try? await Task.sleep(for: .seconds(1))
+        await reEnrichPR(pr)
+        if selectedPRID == pr.id {
+            let host = prManager.hostFromURL(pr.url)
+            if let detail = try? await prManager.fetchDetail(
+                repo: pr.repo, number: pr.number, host: host
+            ) {
+                detailCache[pr.id] = (detail, Date())
+                prDetail = detail
+            }
+        }
+    }
+
+    func approvePR(_ pr: PullRequest) async {
+        let host = prManager.hostFromURL(pr.url)
+        do {
+            try await prManager.approve(repo: pr.repo, number: pr.number, host: host)
+            store?.statusMessage = .success("Approved #\(pr.number)")
+            await refreshPRAfterAction(pr)
+        } catch {
+            store?.statusMessage = .error("Approve failed: \(error.localizedDescription)")
+        }
+    }
+
+    func commentOnPR(_ pr: PullRequest, body: String) async {
+        let host = prManager.hostFromURL(pr.url)
+        do {
+            try await prManager.comment(
+                repo: pr.repo, number: pr.number, body: body, host: host)
+            store?.statusMessage = .success("Commented on #\(pr.number)")
+            await refreshPRAfterAction(pr)
+        } catch {
+            store?.statusMessage = .error("Comment failed: \(error.localizedDescription)")
+        }
+    }
+
+    func requestChangesOnPR(_ pr: PullRequest, body: String) async {
+        let host = prManager.hostFromURL(pr.url)
+        do {
+            try await prManager.requestChanges(
+                repo: pr.repo, number: pr.number, body: body, host: host)
+            store?.statusMessage = .success("Requested changes on #\(pr.number)")
+            await refreshPRAfterAction(pr)
+        } catch {
+            store?.statusMessage = .error(
+                "Request changes failed: \(error.localizedDescription)")
+        }
+    }
+
+    func mergePR(_ pr: PullRequest, strategy: MergeStrategy = .squash) async {
+        let host = prManager.hostFromURL(pr.url)
+        do {
+            try await prManager.merge(
+                repo: pr.repo, number: pr.number, strategy: strategy, host: host)
+            store?.statusMessage = .success("Merged #\(pr.number)")
+            await refreshPRAfterAction(pr)
+        } catch {
+            store?.statusMessage = .error("Merge failed: \(error.localizedDescription)")
+        }
+    }
+
+    func closePR(_ pr: PullRequest) async {
+        let host = prManager.hostFromURL(pr.url)
+        do {
+            try await prManager.close(repo: pr.repo, number: pr.number, host: host)
+            store?.statusMessage = .success("Closed #\(pr.number)")
+            await refreshPRAfterAction(pr)
+        } catch {
+            store?.statusMessage = .error("Close failed: \(error.localizedDescription)")
+        }
+    }
+
+    func updatePRBranch(_ pr: PullRequest, rebase: Bool = false) async {
+        let host = prManager.hostFromURL(pr.url)
+        do {
+            try await prManager.updateBranch(
+                repo: pr.repo, number: pr.number, rebase: rebase, host: host)
+            store?.statusMessage = .success(
+                "Updated #\(pr.number) with latest \(pr.baseBranch)")
+            await refreshPRAfterAction(pr)
+        } catch {
+            store?.statusMessage = .error(
+                "Branch update failed: \(error.localizedDescription)")
+        }
+    }
+
+    func togglePRDraft(_ pr: PullRequest) async {
+        let host = prManager.hostFromURL(pr.url)
+        do {
+            try await prManager.toggleDraft(
+                repo: pr.repo, number: pr.number, makeDraft: !pr.isDraft, host: host)
+            store?.statusMessage = .success(
+                pr.isDraft
+                    ? "Marked #\(pr.number) as ready"
+                    : "Converted #\(pr.number) to draft")
+            await refreshPRAfterAction(pr)
+        } catch {
+            store?.statusMessage = .error(
+                "Draft toggle failed: \(error.localizedDescription)")
+        }
+    }
+
+    func enableAutoMerge(_ pr: PullRequest, strategy: MergeStrategy = .squash) async {
+        let host = prManager.hostFromURL(pr.url)
+        do {
+            try await prManager.enableAutoMerge(
+                repo: pr.repo, number: pr.number, strategy: strategy, host: host)
+            store?.statusMessage = .success("Auto-merge enabled for #\(pr.number)")
+            await refreshPRAfterAction(pr)
+        } catch {
+            store?.statusMessage = .error(
+                "Auto-merge failed: \(error.localizedDescription)")
+        }
+    }
+
+    func disableAutoMerge(_ pr: PullRequest) async {
+        let host = prManager.hostFromURL(pr.url)
+        do {
+            try await prManager.disableAutoMerge(
+                repo: pr.repo, number: pr.number, host: host)
+            store?.statusMessage = .success("Auto-merge disabled for #\(pr.number)")
+            await refreshPRAfterAction(pr)
+        } catch {
+            store?.statusMessage = .error(
+                "Disable auto-merge failed: \(error.localizedDescription)")
+        }
+    }
+
+    func openPRInBrowser(_ pr: PullRequest) {
+        if let url = URL(string: pr.url) {
+            NSWorkspace.shared.open(url)
+        }
+    }
+
+    // MARK: - PR Review Resolution
+
+    func resolvePRForReview(number: Int, repo: String, host: String?) async {
+        isResolvingPR = true
+        defer { isResolvingPR = false }
+
+        do {
+            let pr = try await prManager.resolvePR(repo: repo, number: number, host: host)
+            reviewPRCandidate = pr
+            showReviewPRSheet = true
+        } catch {
+            store?.statusMessage = .error(
+                "Failed to resolve PR #\(number): \(error.localizedDescription)")
+        }
+    }
+}

--- a/Sources/App/RunwayApp.swift
+++ b/Sources/App/RunwayApp.swift
@@ -60,11 +60,11 @@ struct RunwayApp: App {
             CommandGroup(after: .newItem) {
                 Button("New Session") {
                     store.newSessionProjectID = nil
-                    store.showNewSessionDialog = true
+                    store.activeSheet = .newSession
                 }
                 .keyboardShortcut("n", modifiers: .command)
 
-                Button("New Project") { store.showNewProjectDialog = true }
+                Button("New Project") { store.activeSheet = .newProject }
                     .keyboardShortcut("p", modifiers: [.command, .shift])
 
                 Button("Send to Session") { store.showSendBar.toggle() }
@@ -84,7 +84,7 @@ struct RunwayApp: App {
                 Button("Search Sessions") { store.focusSidebarSearch = true }
                     .keyboardShortcut("k", modifiers: .command)
 
-                Button("Review PR") { store.prCoordinator.showReviewPRDialog = true }
+                Button("Review PR") { store.activeSheet = .reviewPRDialog }
                     .keyboardShortcut("r", modifiers: [.command, .shift])
 
                 Divider()
@@ -146,87 +146,75 @@ struct ContentView: View {
                 toolbarContent
             }
             .sheet(
-                isPresented: Binding(
-                    get: { store.showNewSessionDialog },
+                item: Binding(
+                    get: { store.activeSheet },
                     set: {
-                        store.showNewSessionDialog = $0
-                        if !$0 {
+                        store.activeSheet = $0
+                        if $0 == nil {
                             store.newSessionProjectID = nil
                             store.newSessionParentID = nil
                             store.forkSourceSession = nil
                         }
                     }
                 )
-            ) {
-                NewSessionDialog(
-                    projects: store.projects,
-                    profiles: store.agentProfiles.isEmpty ? AgentProfile.builtIn : store.agentProfiles,
-                    initialProjectID: store.newSessionProjectID,
-                    parentID: store.newSessionParentID,
-                    templates: store.availableTemplates(forProjectID: store.newSessionProjectID),
-                    forkSource: store.forkSourceSession,
-                    onCreate: { request in
-                        Task { await store.handleNewSessionRequest(request) }
-                        store.newSessionProjectID = nil
-                        store.newSessionParentID = nil
-                        store.forkSourceSession = nil
-                    },
-                    onCreateReview: { request in
-                        try await store.handleReviewSessionRequest(request)
-                    }
-                )
-                .theme(theme)
-            }
-            .sheet(
-                isPresented: Binding(
-                    get: { store.showNewProjectDialog },
-                    set: { store.showNewProjectDialog = $0 }
-                )
-            ) {
-                NewProjectDialog { name, path, branch in
-                    store.createProject(name: name, path: path, defaultBranch: branch)
-                }
-                .theme(theme)
-            }
-            .sheet(
-                isPresented: Binding(
-                    get: { store.prCoordinator.showReviewPRSheet },
-                    set: { store.prCoordinator.showReviewPRSheet = $0 }
-                )
-            ) {
-                if let pr = store.prCoordinator.reviewPRCandidate {
-                    ReviewPRSheet(
-                        pr: pr,
-                        projects: store.projects
-                    ) { sessionName, projectID, initialPrompt in
-                        Task {
-                            await store.handleReviewPR(
-                                pr: pr,
-                                sessionName: sessionName,
-                                projectID: projectID,
-                                initialPrompt: initialPrompt
-                            )
+            ) { sheet in
+                switch sheet {
+                case .newSession:
+                    NewSessionDialog(
+                        projects: store.projects,
+                        profiles: store.agentProfiles.isEmpty ? AgentProfile.builtIn : store.agentProfiles,
+                        initialProjectID: store.newSessionProjectID,
+                        parentID: store.newSessionParentID,
+                        templates: store.availableTemplates(forProjectID: store.newSessionProjectID),
+                        forkSource: store.forkSourceSession,
+                        onCreate: { request in
+                            Task { await store.handleNewSessionRequest(request) }
+                            store.newSessionProjectID = nil
+                            store.newSessionParentID = nil
+                            store.forkSourceSession = nil
+                        },
+                        onCreateReview: { request in
+                            try await store.handleReviewSessionRequest(request)
                         }
-                        store.prCoordinator.reviewPRCandidate = nil
+                    )
+                    .theme(theme)
+
+                case .newProject:
+                    NewProjectDialog { name, path, branch in
+                        store.createProject(name: name, path: path, defaultBranch: branch)
                     }
                     .theme(theme)
-                }
-            }
-            .sheet(
-                isPresented: Binding(
-                    get: { store.prCoordinator.showReviewPRDialog },
-                    set: { store.prCoordinator.showReviewPRDialog = $0 }
-                )
-            ) {
-                ReviewPRNumberDialog(
-                    projects: store.projects,
-                    isResolving: store.prCoordinator.isResolvingPR,
-                    onResolve: { number, repo, host in
-                        Task { await store.prCoordinator.resolvePRForReview(number: number, repo: repo, host: host) }
-                        store.prCoordinator.showReviewPRDialog = false
+
+                case .reviewPRSheet:
+                    if let pr = store.prCoordinator.reviewPRCandidate {
+                        ReviewPRSheet(
+                            pr: pr,
+                            projects: store.projects
+                        ) { sessionName, projectID, initialPrompt in
+                            Task {
+                                await store.handleReviewPR(
+                                    pr: pr,
+                                    sessionName: sessionName,
+                                    projectID: projectID,
+                                    initialPrompt: initialPrompt
+                                )
+                            }
+                            store.prCoordinator.reviewPRCandidate = nil
+                        }
+                        .theme(theme)
                     }
-                )
-                .theme(theme)
+
+                case .reviewPRDialog:
+                    ReviewPRNumberDialog(
+                        projects: store.projects,
+                        isResolving: store.prCoordinator.isResolvingPR,
+                        onResolve: { number, repo, host in
+                            Task { await store.prCoordinator.resolvePRForReview(number: number, repo: repo, host: host) }
+                            store.activeSheet = nil
+                        }
+                    )
+                    .theme(theme)
+                }
             }
 
             // Status message toast — errors persist until dismissed, others auto-dismiss
@@ -487,7 +475,7 @@ struct ContentView: View {
                         title: "Welcome to Runway",
                         subtitle: "Add a project to get started with AI coding sessions, or jump straight in with a quick session.",
                         actionTitle: "Add Your First Project",
-                        onAction: { store.showNewProjectDialog = true }
+                        onAction: { store.activeSheet = .newProject }
                     )
                 } else {
                     EmptyStateView(
@@ -541,7 +529,7 @@ struct ContentView: View {
         ToolbarItem(placement: .primaryAction) {
             Button {
                 store.newSessionProjectID = nil
-                store.showNewSessionDialog = true
+                store.activeSheet = .newSession
             } label: {
                 Label("New Session", systemImage: "plus.rectangle")
             }

--- a/Sources/App/RunwayApp.swift
+++ b/Sources/App/RunwayApp.swift
@@ -84,7 +84,7 @@ struct RunwayApp: App {
                 Button("Search Sessions") { store.focusSidebarSearch = true }
                     .keyboardShortcut("k", modifiers: .command)
 
-                Button("Review PR") { store.showReviewPRDialog = true }
+                Button("Review PR") { store.prCoordinator.showReviewPRDialog = true }
                     .keyboardShortcut("r", modifiers: [.command, .shift])
 
                 Divider()
@@ -190,11 +190,11 @@ struct ContentView: View {
             }
             .sheet(
                 isPresented: Binding(
-                    get: { store.showReviewPRSheet },
-                    set: { store.showReviewPRSheet = $0 }
+                    get: { store.prCoordinator.showReviewPRSheet },
+                    set: { store.prCoordinator.showReviewPRSheet = $0 }
                 )
             ) {
-                if let pr = store.reviewPRCandidate {
+                if let pr = store.prCoordinator.reviewPRCandidate {
                     ReviewPRSheet(
                         pr: pr,
                         projects: store.projects
@@ -207,23 +207,23 @@ struct ContentView: View {
                                 initialPrompt: initialPrompt
                             )
                         }
-                        store.reviewPRCandidate = nil
+                        store.prCoordinator.reviewPRCandidate = nil
                     }
                     .theme(theme)
                 }
             }
             .sheet(
                 isPresented: Binding(
-                    get: { store.showReviewPRDialog },
-                    set: { store.showReviewPRDialog = $0 }
+                    get: { store.prCoordinator.showReviewPRDialog },
+                    set: { store.prCoordinator.showReviewPRDialog = $0 }
                 )
             ) {
                 ReviewPRNumberDialog(
                     projects: store.projects,
-                    isResolving: store.isResolvingPR,
+                    isResolving: store.prCoordinator.isResolvingPR,
                     onResolve: { number, repo, host in
-                        Task { await store.resolvePRForReview(number: number, repo: repo, host: host) }
-                        store.showReviewPRDialog = false
+                        Task { await store.prCoordinator.resolvePRForReview(number: number, repo: repo, host: host) }
+                        store.prCoordinator.showReviewPRDialog = false
                     }
                 )
                 .theme(theme)
@@ -318,7 +318,7 @@ struct ContentView: View {
         return ProjectTreeView(
             projects: store.projects,
             sessions: store.sessions,
-            sessionPRs: store.sessionPRs,
+            sessionPRs: store.prCoordinator.sessionPRs,
             provisioningWorktreeIDs: store.provisioningWorktreeIDs,
             selectedSessionID: $store.selectedSessionID,
             searchQuery: $store.sidebarSearchQuery,
@@ -380,7 +380,7 @@ struct ContentView: View {
                 ProjectPageView(
                     project: project,
                     issues: store.projectIssues[projectID] ?? [],
-                    pullRequests: store.pullRequests.filter { $0.repo == project.ghRepo },
+                    pullRequests: store.prCoordinator.pullRequests.filter { $0.repo == project.ghRepo },
                     labels: store.projectLabels[projectID] ?? [],
                     isLoadingIssues: store.isLoadingIssues,
                     onRefreshIssues: { Task { await store.fetchIssues(forProject: projectID) } },
@@ -402,20 +402,20 @@ struct ContentView: View {
                     onStartSessionFromIssue: { issue in
                         Task { await store.startSessionFromIssue(issue, projectID: projectID) }
                     },
-                    onSelectPR: { pr in Task { await store.selectPR(pr, navigate: false) } },
-                    onRefreshPRs: { Task { await store.refreshPRsIfStale() } },
-                    selectedPRID: store.selectedPRID,
-                    prDetail: store.prDetail,
-                    onApprovePR: { pr in Task { await store.approvePR(pr) } },
-                    onCommentPR: { pr, body in Task { await store.commentOnPR(pr, body: body) } },
-                    onRequestChangesPR: { pr, body in Task { await store.requestChangesOnPR(pr, body: body) } },
-                    onMergePR: { pr, strategy in Task { await store.mergePR(pr, strategy: strategy) } },
-                    onToggleDraftPR: { pr in Task { await store.togglePRDraft(pr) } },
-                    onUpdateBranchPR: { pr, rebase in Task { await store.updatePRBranch(pr, rebase: rebase) } },
+                    onSelectPR: { pr in Task { await store.prCoordinator.selectPR(pr, navigate: false) } },
+                    onRefreshPRs: { Task { await store.prCoordinator.refreshPRsIfStale() } },
+                    selectedPRID: store.prCoordinator.selectedPRID,
+                    prDetail: store.prCoordinator.prDetail,
+                    onApprovePR: { pr in Task { await store.prCoordinator.approvePR(pr) } },
+                    onCommentPR: { pr, body in Task { await store.prCoordinator.commentOnPR(pr, body: body) } },
+                    onRequestChangesPR: { pr, body in Task { await store.prCoordinator.requestChangesOnPR(pr, body: body) } },
+                    onMergePR: { pr, strategy in Task { await store.prCoordinator.mergePR(pr, strategy: strategy) } },
+                    onToggleDraftPR: { pr in Task { await store.prCoordinator.togglePRDraft(pr) } },
+                    onUpdateBranchPR: { pr, rebase in Task { await store.prCoordinator.updatePRBranch(pr, rebase: rebase) } },
                     onReviewPR: { pr in store.reviewPR(pr) },
-                    onEnableAutoMergePR: { pr, strategy in Task { await store.enableAutoMerge(pr, strategy: strategy) } },
-                    onDisableAutoMergePR: { pr in Task { await store.disableAutoMerge(pr) } },
-                    onDeselectPR: { Task { await store.selectPR(nil, navigate: false) } },
+                    onEnableAutoMergePR: { pr, strategy in Task { await store.prCoordinator.enableAutoMerge(pr, strategy: strategy) } },
+                    onDisableAutoMergePR: { pr in Task { await store.prCoordinator.disableAutoMerge(pr) } },
+                    onDeselectPR: { Task { await store.prCoordinator.selectPR(nil, navigate: false) } },
                     onUpdateProject: { store.updateProjectSettings($0) },
                     onDetectRepo: { await store.detectGHRepo(for: project) },
                     onFetchLabels: { Task { await store.fetchLabels(forProject: projectID) } },
@@ -429,9 +429,9 @@ struct ContentView: View {
                 SessionDetailView(
                     session: session,
                     tmuxManager: store.tmuxManager,
-                    linkedPR: store.sessionPRs[sessionID],
-                    prDetail: store.prDetailForSession(sessionID),
-                    onSelectPR: { pr in Task { await store.selectPR(pr) } },
+                    linkedPR: store.prCoordinator.sessionPRs[sessionID],
+                    prDetail: store.prCoordinator.prDetailForSession(sessionID),
+                    onSelectPR: { pr in Task { await store.prCoordinator.selectPR(pr) } },
                     parentSession: {
                         guard let parentID = session.parentID else { return nil }
                         return store.sessions.first(where: { $0.id == parentID })
@@ -498,33 +498,33 @@ struct ContentView: View {
             }
         case .prs:
             PRDashboardView(
-                pullRequests: store.pullRequests,
-                selectedPRID: store.selectedPRID,
-                detail: store.prDetail,
-                isLoading: store.isLoadingPRs,
-                sessionPRIDs: store.sessionPRIDs,
+                pullRequests: store.prCoordinator.pullRequests,
+                selectedPRID: store.prCoordinator.selectedPRID,
+                detail: store.prCoordinator.prDetail,
+                isLoading: store.prCoordinator.isLoadingPRs,
+                sessionPRIDs: store.prCoordinator.sessionPRIDs,
                 selectedTab: Binding(
-                    get: { store.prTab },
-                    set: { store.prTab = $0 }
+                    get: { store.prCoordinator.prTab },
+                    set: { store.prCoordinator.prTab = $0 }
                 ),
-                onSelectPR: { pr in Task { await store.selectPR(pr) } },
-                onRefresh: { Task { await store.fetchPRs() } },
-                onApprove: { pr in Task { await store.approvePR(pr) } },
-                onComment: { pr, body in Task { await store.commentOnPR(pr, body: body) } },
-                onRequestChanges: { pr, body in Task { await store.requestChangesOnPR(pr, body: body) } },
-                onMerge: { pr, strategy in Task { await store.mergePR(pr, strategy: strategy) } },
-                onToggleDraft: { pr in Task { await store.togglePRDraft(pr) } },
-                onUpdateBranch: { pr, rebase in Task { await store.updatePRBranch(pr, rebase: rebase) } },
+                onSelectPR: { pr in Task { await store.prCoordinator.selectPR(pr) } },
+                onRefresh: { Task { await store.prCoordinator.fetchPRs() } },
+                onApprove: { pr in Task { await store.prCoordinator.approvePR(pr) } },
+                onComment: { pr, body in Task { await store.prCoordinator.commentOnPR(pr, body: body) } },
+                onRequestChanges: { pr, body in Task { await store.prCoordinator.requestChangesOnPR(pr, body: body) } },
+                onMerge: { pr, strategy in Task { await store.prCoordinator.mergePR(pr, strategy: strategy) } },
+                onToggleDraft: { pr in Task { await store.prCoordinator.togglePRDraft(pr) } },
+                onUpdateBranch: { pr, rebase in Task { await store.prCoordinator.updatePRBranch(pr, rebase: rebase) } },
                 onSendToSession: { pr, _ in
-                    if let sessionID = store.sessionPRs.first(where: { $0.value.id == pr.id })?.key {
+                    if let sessionID = store.prCoordinator.sessionPRs.first(where: { $0.value.id == pr.id })?.key {
                         store.selectSession(sessionID)
                         store.showSendBar = true
                     }
                 },
                 onReviewPR: { pr in store.reviewPR(pr) },
-                onEnableAutoMerge: { pr, strategy in Task { await store.enableAutoMerge(pr, strategy: strategy) } },
-                onDisableAutoMerge: { pr in Task { await store.disableAutoMerge(pr) } },
-                onClosePR: { pr in Task { await store.closePR(pr) } }
+                onEnableAutoMerge: { pr, strategy in Task { await store.prCoordinator.enableAutoMerge(pr, strategy: strategy) } },
+                onDisableAutoMerge: { pr in Task { await store.prCoordinator.disableAutoMerge(pr) } },
+                onClosePR: { pr in Task { await store.prCoordinator.closePR(pr) } }
             )
         }
     }

--- a/Sources/App/RunwayApp.swift
+++ b/Sources/App/RunwayApp.swift
@@ -466,6 +466,11 @@ struct ContentView: View {
                     onActiveDiffPathChanged: { path in store.activeDiffPath = path },
                     onToggleChanges: { store.toggleChangesSidebar() },
                     onRestart: { Task { await store.restartSession(id: sessionID) } },
+                    worktreeManager: session.worktreeBranch != nil ? store.worktreeManager : nil,
+                    defaultBranch: store.projects.first(where: { $0.id == session.projectID })?.defaultBranch ?? "main",
+                    onRollback: { hash in
+                        Task { try? await store.worktreeManager.resetToCommit(path: session.path, hash: hash) }
+                    },
                     savedPrompts: store.savedPrompts
                 )
             } else {

--- a/Sources/App/RunwayStore.swift
+++ b/Sources/App/RunwayStore.swift
@@ -17,26 +17,11 @@ public final class RunwayStore {
     // MARK: - State
     var sessions: [Session] = []
     var projects: [Project] = []
-    var pullRequests: [PullRequest] = []
     var sessionTemplates: [SessionTemplate] = []
     var agentProfiles: [AgentProfile] = []
     var savedPrompts: [SavedPrompt] = []
 
     var selectedSessionID: String?
-    /// Incremented on every selection change to force SwiftUI re-render
-    /// when selectedSessionID goes nil→nil (no-op for @Observable).
-    var selectedPRID: String?
-    var prDetail: PRDetail?
-    var prTab: PRTab = .mine
-    var prLastFetched: Date?
-    var isLoadingPRs: Bool = false
-    private var prPollTask: Task<Void, Never>?
-    private var sessionPRPollTask: Task<Void, Never>?
-    private var enrichPRsTask: Task<Void, Never>?
-    private var lastPRFingerprint: PRFingerprint?
-    /// Per-session PR fetch timestamps — mirrors Hangar's sessionFetched map with 60s TTL.
-    private var sessionPRFetchedAt: [String: Date] = [:]
-    private let sessionPRTTL: TimeInterval = 60
     var currentView: AppView = .sessions
     var showNewSessionDialog: Bool = false
     var showNewProjectDialog: Bool = false
@@ -56,30 +41,9 @@ public final class RunwayStore {
     var terminalRestartTrigger: Int = 0
     var sidebarSearchQuery: String = ""
     var focusSidebarSearch: Bool = false
-    var showReviewPRDialog: Bool = false
-    var showReviewPRSheet: Bool = false
-    var reviewPRCandidate: PullRequest? = nil
-    var isResolvingPR: Bool = false
 
     /// Session IDs with in-progress worktree creation (transient, not persisted)
     var provisioningWorktreeIDs: Set<String> = []
-
-    /// Maps session ID → linked PullRequest (matched by worktree branch)
-    var sessionPRs: [String: PullRequest] = [:]
-
-    /// Set of PR IDs linked to active Runway sessions — used for the Sessions filter toggle.
-    var sessionPRIDs: Set<String> {
-        Set(sessionPRs.values.map(\.id))
-    }
-
-    /// Returns PRDetail for the selected session's linked PR, if available.
-    /// Fetches the detail asynchronously if not yet loaded.
-    func prDetailForSession(_ sessionID: String) -> PRDetail? {
-        guard let pr = sessionPRs[sessionID] else { return nil }
-        // prDetail is loaded when a PR is selected; return it if it matches
-        if selectedPRID == pr.id { return prDetail }
-        return nil
-    }
 
     func profileForSession(_ session: Session) -> AgentProfile {
         if case .custom(let name) = session.tool,
@@ -127,7 +91,7 @@ public final class RunwayStore {
     var hookServer: HookServer
     let statusDetector: StatusDetector
     let worktreeManager: WorktreeManager
-    let prManager: PRManager
+    let prCoordinator: PRCoordinator
     let hookInjector: HookInjector
     let tmuxManager: TmuxSessionManager
     let issueManager: IssueManager
@@ -140,22 +104,31 @@ public final class RunwayStore {
         self.hookServer = HookServer()
         self.statusDetector = StatusDetector()
         self.worktreeManager = WorktreeManager()
-        self.prManager = PRManager()
         self.hookInjector = HookInjector()
         self.tmuxManager = TmuxSessionManager()
         self.issueManager = IssueManager()
         self.notificationManager = NotificationManager()
 
         // Open database — surface failure to user since silent nil means all writes are lost
+        var db: Database?
         do {
-            self.database = try Database()
+            db = try Database()
         } catch {
             print("[Runway] Failed to open database: \(error)")
-            self.database = nil
+            db = nil
             self.databaseFailed = true
-            // Deferred to after init completes since statusMessage triggers UI
+        }
+        self.database = db
+
+        // PRCoordinator owns all PR state — separate @Observable reduces view invalidation scope
+        self.prCoordinator = PRCoordinator(prManager: PRManager(), database: db)
+
+        // Wire back-reference after all stored properties are initialized
+        prCoordinator.store = self
+
+        if databaseFailed {
             Task { @MainActor [weak self] in
-                self?.statusMessage = .error("Database failed to open — session data will not persist. \(error.localizedDescription)")
+                self?.statusMessage = .error("Database failed to open — session data will not persist.")
             }
         }
 
@@ -175,11 +148,10 @@ public final class RunwayStore {
                     "Missing tools: \(missing.joined(separator: ", ")) — install with `brew install \(missing.joined(separator: " "))`")
             }
             await loadState()
-            await fetchPRs()
-            // Seed the fingerprint so the first poll doesn't trigger a redundant fetch
-            lastPRFingerprint = await prManager.prFingerprint(filter: .mine)
-            startPRPoll()
-            startSessionPRPoll()
+            await prCoordinator.fetchPRs()
+            await prCoordinator.seedFingerprint()
+            prCoordinator.startPRPoll()
+            prCoordinator.startSessionPRPoll()
             notificationManager.requestAuthorization()
             notificationManager.onNotificationTapped = { [weak self] sessionID in
                 self?.selectSession(sessionID)
@@ -191,7 +163,7 @@ public final class RunwayStore {
         Task { await startHookServer() }
 
         // Load cached PRs synchronously for instant display while background fetch runs
-        loadCachedPRs()
+        prCoordinator.loadCachedPRs()
 
         // Start buffer-based status detection for sessions without hook events
         startBufferDetection()
@@ -632,8 +604,7 @@ public final class RunwayStore {
         sessions.removeAll { $0.id == id }
         try? database?.deleteSession(id: id)
         TerminalSessionCache.shared.removeAll(forSessionID: id)
-        sessionPRs.removeValue(forKey: id)
-        sessionPRFetchedAt.removeValue(forKey: id)
+        prCoordinator.sessionDeleted(id: id)
         lastHookEventTime.removeValue(forKey: id)
         sessionChanges.removeValue(forKey: id)
         sessionFileTree.removeValue(forKey: id)
@@ -797,8 +768,8 @@ public final class RunwayStore {
             NSApplication.shared.activate()
 
         case .pr(let number, let repo):
-            if let pr = pullRequests.first(where: { $0.number == number && $0.repo == repo }) {
-                Task { await selectPR(pr) }
+            if let pr = prCoordinator.pullRequests.first(where: { $0.number == number && $0.repo == repo }) {
+                Task { await prCoordinator.selectPR(pr) }
             } else {
                 statusMessage = .info("PR #\(number) not found in \(repo) — try refreshing the PR list")
             }
@@ -1082,391 +1053,6 @@ public final class RunwayStore {
         }
     }
 
-    // MARK: - Pull Requests
-
-    /// Load cached PRs from database for instant display on startup.
-    func loadCachedPRs() {
-        if let cached = try? database?.cachedPRs(maxAge: 86400), !cached.isEmpty {
-            pullRequests = cached
-        }
-    }
-
-    func fetchPRs() async {
-        guard !isLoadingPRs else { return }
-        isLoadingPRs = true
-        defer { isLoadingPRs = false }
-
-        do {
-            let freshPRs = try await prManager.fetchAllPRs()
-            prLastFetched = Date()
-
-            // Merge: keep enriched data from cache/previous enrichment where available
-            let existingByID = Dictionary(pullRequests.map { ($0.id, $0) }, uniquingKeysWith: { _, new in new })
-            pullRequests = freshPRs.map { fresh in
-                guard var existing = existingByID[fresh.id] else { return fresh }
-                // Update fields that search refreshes
-                existing.title = fresh.title
-                existing.state = fresh.state
-                existing.isDraft = fresh.isDraft
-                existing.author = fresh.author
-                existing.origin = fresh.origin
-                existing.createdAt = fresh.createdAt
-                existing.updatedAt = fresh.updatedAt
-                return existing
-            }
-
-            // Cancel any in-flight enrichment to prevent stale results overwriting fresh data
-            enrichPRsTask?.cancel()
-            enrichPRsTask = Task { await enrichPRs() }
-        } catch {
-            print("[Runway] Failed to fetch PRs: \(error)")
-            statusMessage = .error("PR fetch failed: \(error.localizedDescription)")
-        }
-    }
-
-    /// Background-enrich PRs with checks and review decision only (not full detail).
-    /// Like Hangar, fetches only statusCheckRollup+reviewDecision — 1 subprocess per PR
-    /// instead of 2 (fetchDetail + REST files).
-    private func enrichPRs() async {
-        let toEnrich = pullRequests.filter { $0.needsEnrichment }
-        guard !toEnrich.isEmpty else {
-            await linkSessionPRs()
-            return
-        }
-
-        // Lightweight enrichment: checks + review decision only
-        var enriched: [String: PREnrichResult] = [:]
-        await withTaskGroup(of: (String, PREnrichResult?).self) { group in
-            var inFlight = 0
-            let maxConcurrency = 5
-
-            for pr in toEnrich {
-                if inFlight >= maxConcurrency {
-                    if let (id, result) = await group.next() {
-                        if let result { enriched[id] = result }
-                        inFlight -= 1
-                    }
-                }
-
-                let host = prManager.hostFromURL(pr.url)
-                group.addTask { [prManager] in
-                    let result = try? await prManager.enrichChecks(
-                        repo: pr.repo, number: pr.number, host: host
-                    )
-                    return (pr.id, result)
-                }
-                inFlight += 1
-            }
-
-            for await (id, result) in group {
-                if let result { enriched[id] = result }
-            }
-        }
-
-        // Bail out if this enrichment was superseded by a newer fetch cycle
-        guard !Task.isCancelled else { return }
-
-        // Merge in a single pass
-        var updated = pullRequests
-        for i in updated.indices {
-            guard let result = enriched[updated[i].id] else { continue }
-            applyEnrichment(result, to: &updated[i])
-        }
-        pullRequests = updated
-
-        try? database?.cachePRs(pullRequests)
-        try? database?.cleanPRCache()
-        try? database?.cleanIssueCache()
-
-        await linkSessionPRs()
-    }
-
-    /// Re-enrich a single PR immediately (called after user actions like approve/merge).
-    private func reEnrichPR(_ pr: PullRequest) async {
-        let host = prManager.hostFromURL(pr.url)
-        guard
-            let result = try? await prManager.enrichChecks(
-                repo: pr.repo, number: pr.number, host: host
-            )
-        else { return }
-
-        if let idx = pullRequests.firstIndex(where: { $0.id == pr.id }) {
-            applyEnrichment(result, to: &pullRequests[idx])
-            try? database?.cachePR(pullRequests[idx])
-        }
-    }
-
-    private func applyEnrichment(_ result: PREnrichResult, to pr: inout PullRequest) {
-        pr.checks = result.checks
-        pr.reviewDecision = result.reviewDecision
-        if !result.headBranch.isEmpty {
-            pr.headBranch = result.headBranch
-            pr.baseBranch = result.baseBranch
-        }
-        pr.additions = result.additions
-        pr.deletions = result.deletions
-        pr.changedFiles = result.changedFiles
-        pr.mergeable = result.mergeable
-        pr.mergeStateStatus = result.mergeStateStatus
-        pr.autoMergeEnabled = result.autoMergeEnabled
-        pr.enrichedAt = Date()
-    }
-
-    /// Link PRs to sessions — concurrent, like Hangar.
-    /// Sets TTL timestamps so the independent freshen loop doesn't immediately re-fetch.
-    private func linkSessionPRs() async {
-        let worktreeSessions = sessions.filter {
-            $0.worktreeBranch != nil && !provisioningWorktreeIDs.contains($0.id)
-        }
-        guard !worktreeSessions.isEmpty else { return }
-        let now = Date()
-
-        await withTaskGroup(of: (String, PullRequest?).self) { group in
-            for session in worktreeSessions {
-                group.addTask { [prManager] in
-                    let pr = try? await prManager.fetchPRForWorktree(path: session.path)
-                    return (session.id, pr)
-                }
-            }
-            for await (sessionID, pr) in group {
-                sessionPRFetchedAt[sessionID] = now
-                if let pr {
-                    sessionPRs[sessionID] = pr
-                } else {
-                    sessionPRs.removeValue(forKey: sessionID)
-                }
-            }
-        }
-    }
-
-    func refreshPRsIfStale() async {
-        let staleness: TimeInterval = 60
-        if let last = prLastFetched, Date().timeIntervalSince(last) < staleness { return }
-        await fetchPRs()
-    }
-
-    /// Start a lightweight background poll that checks for PR changes every 30 seconds.
-    /// Only triggers a full fetch when the fingerprint (latest updatedAt) changes.
-    func startPRPoll() {
-        prPollTask?.cancel()
-        prPollTask = Task { @MainActor [weak self] in
-            while !Task.isCancelled {
-                let jitter = Double.random(in: 0...3)
-                try? await Task.sleep(for: .seconds(30 + jitter))
-                guard !Task.isCancelled, let self else { return }
-                guard !self.isLoadingPRs else { continue }
-                let fingerprint = await self.prManager.prFingerprint(filter: .mine)
-                // Fetch if fingerprint changed OR if stale (>5 min) to catch reviewRequested changes
-                let isStale = self.prLastFetched.map { Date().timeIntervalSince($0) > 300 } ?? true
-                if let fingerprint, fingerprint != self.lastPRFingerprint {
-                    self.lastPRFingerprint = fingerprint
-                    await self.fetchPRs()
-                } else if isStale {
-                    await self.fetchPRs()
-                }
-            }
-        }
-    }
-
-    /// Independent session→PR linking loop, modeled on Hangar's UpdateSessionPR with 60s TTL.
-    /// Runs every 15 seconds but only re-fetches sessions whose cache is stale (>60s old).
-    /// This decouples session PR detection from the heavier global fetch→enrich pipeline.
-    func startSessionPRPoll() {
-        sessionPRPollTask?.cancel()
-        sessionPRPollTask = Task { @MainActor [weak self] in
-            while !Task.isCancelled {
-                let jitter = Double.random(in: 0...2)
-                try? await Task.sleep(for: .seconds(15 + jitter))
-                guard !Task.isCancelled, let self else { return }
-                await self.freshenSessionPRs()
-            }
-        }
-    }
-
-    /// Check each worktree session's PR status, respecting per-session TTL.
-    /// Only fetches for sessions whose cache has expired — lightweight when nothing is stale.
-    private func freshenSessionPRs() async {
-        let now = Date()
-        let worktreeSessions = sessions.filter {
-            $0.worktreeBranch != nil && !provisioningWorktreeIDs.contains($0.id)
-        }
-        guard !worktreeSessions.isEmpty else { return }
-
-        // Find sessions that need refreshing (stale or never fetched)
-        let stale = worktreeSessions.filter { session in
-            guard let fetchedAt = sessionPRFetchedAt[session.id] else { return true }
-            return now.timeIntervalSince(fetchedAt) >= sessionPRTTL
-        }
-        guard !stale.isEmpty else { return }
-
-        await withTaskGroup(of: (String, PullRequest?).self) { group in
-            for session in stale {
-                group.addTask { [prManager] in
-                    let pr = try? await prManager.fetchPRForWorktree(path: session.path)
-                    return (session.id, pr)
-                }
-            }
-            for await (sessionID, pr) in group {
-                sessionPRFetchedAt[sessionID] = now
-                if let pr {
-                    sessionPRs[sessionID] = pr
-                } else {
-                    sessionPRs.removeValue(forKey: sessionID)
-                }
-            }
-        }
-    }
-
-    /// In-memory detail cache with 5-minute TTL (matches Hangar).
-    private var detailCache: [String: (detail: PRDetail, fetchedAt: Date)] = [:]
-    private let detailTTL: TimeInterval = 300
-
-    func selectPR(_ pr: PullRequest?, navigate: Bool = true) async {
-        selectedPRID = pr?.id
-        prDetail = nil
-        guard let pr else { return }
-
-        if navigate {
-            currentView = .prs
-        }
-
-        // Check cache first
-        if let cached = detailCache[pr.id], Date().timeIntervalSince(cached.fetchedAt) < detailTTL {
-            prDetail = cached.detail
-            return
-        }
-
-        do {
-            let host = prManager.hostFromURL(pr.url)
-            let detail = try await prManager.fetchDetail(repo: pr.repo, number: pr.number, host: host)
-            detailCache[pr.id] = (detail, Date())
-            prDetail = detail
-        } catch {
-            print("[Runway] Failed to fetch PR detail: \(error)")
-        }
-    }
-
-    /// Unified post-action refresh: wait 1s for GitHub to propagate, then re-enrich
-    /// the PR list entry and refresh the detail view if this PR is currently selected.
-    private func refreshPRAfterAction(_ pr: PullRequest) async {
-        try? await Task.sleep(for: .seconds(1))
-        await reEnrichPR(pr)
-        if selectedPRID == pr.id {
-            let host = prManager.hostFromURL(pr.url)
-            if let detail = try? await prManager.fetchDetail(
-                repo: pr.repo, number: pr.number, host: host
-            ) {
-                detailCache[pr.id] = (detail, Date())
-                prDetail = detail
-            }
-        }
-    }
-
-    func approvePR(_ pr: PullRequest) async {
-        let host = prManager.hostFromURL(pr.url)
-        do {
-            try await prManager.approve(repo: pr.repo, number: pr.number, host: host)
-            statusMessage = .success("Approved #\(pr.number)")
-            await refreshPRAfterAction(pr)
-        } catch {
-            statusMessage = .error("Approve failed: \(error.localizedDescription)")
-        }
-    }
-
-    func commentOnPR(_ pr: PullRequest, body: String) async {
-        let host = prManager.hostFromURL(pr.url)
-        do {
-            try await prManager.comment(repo: pr.repo, number: pr.number, body: body, host: host)
-            statusMessage = .success("Commented on #\(pr.number)")
-            await refreshPRAfterAction(pr)
-        } catch {
-            statusMessage = .error("Comment failed: \(error.localizedDescription)")
-        }
-    }
-
-    func requestChangesOnPR(_ pr: PullRequest, body: String) async {
-        let host = prManager.hostFromURL(pr.url)
-        do {
-            try await prManager.requestChanges(repo: pr.repo, number: pr.number, body: body, host: host)
-            statusMessage = .success("Requested changes on #\(pr.number)")
-            await refreshPRAfterAction(pr)
-        } catch {
-            statusMessage = .error("Request changes failed: \(error.localizedDescription)")
-        }
-    }
-
-    func mergePR(_ pr: PullRequest, strategy: MergeStrategy = .squash) async {
-        let host = prManager.hostFromURL(pr.url)
-        do {
-            try await prManager.merge(repo: pr.repo, number: pr.number, strategy: strategy, host: host)
-            statusMessage = .success("Merged #\(pr.number)")
-            await refreshPRAfterAction(pr)
-        } catch {
-            statusMessage = .error("Merge failed: \(error.localizedDescription)")
-        }
-    }
-
-    func closePR(_ pr: PullRequest) async {
-        let host = prManager.hostFromURL(pr.url)
-        do {
-            try await prManager.close(repo: pr.repo, number: pr.number, host: host)
-            statusMessage = .success("Closed #\(pr.number)")
-            await refreshPRAfterAction(pr)
-        } catch {
-            statusMessage = .error("Close failed: \(error.localizedDescription)")
-        }
-    }
-
-    func updatePRBranch(_ pr: PullRequest, rebase: Bool = false) async {
-        let host = prManager.hostFromURL(pr.url)
-        do {
-            try await prManager.updateBranch(repo: pr.repo, number: pr.number, rebase: rebase, host: host)
-            statusMessage = .success("Updated #\(pr.number) with latest \(pr.baseBranch)")
-            await refreshPRAfterAction(pr)
-        } catch {
-            statusMessage = .error("Branch update failed: \(error.localizedDescription)")
-        }
-    }
-
-    func togglePRDraft(_ pr: PullRequest) async {
-        let host = prManager.hostFromURL(pr.url)
-        do {
-            try await prManager.toggleDraft(repo: pr.repo, number: pr.number, makeDraft: !pr.isDraft, host: host)
-            statusMessage = .success(pr.isDraft ? "Marked #\(pr.number) as ready" : "Converted #\(pr.number) to draft")
-            await refreshPRAfterAction(pr)
-        } catch {
-            statusMessage = .error("Draft toggle failed: \(error.localizedDescription)")
-        }
-    }
-
-    func enableAutoMerge(_ pr: PullRequest, strategy: MergeStrategy = .squash) async {
-        let host = prManager.hostFromURL(pr.url)
-        do {
-            try await prManager.enableAutoMerge(repo: pr.repo, number: pr.number, strategy: strategy, host: host)
-            statusMessage = .success("Auto-merge enabled for #\(pr.number)")
-            await refreshPRAfterAction(pr)
-        } catch {
-            statusMessage = .error("Auto-merge failed: \(error.localizedDescription)")
-        }
-    }
-
-    func disableAutoMerge(_ pr: PullRequest) async {
-        let host = prManager.hostFromURL(pr.url)
-        do {
-            try await prManager.disableAutoMerge(repo: pr.repo, number: pr.number, host: host)
-            statusMessage = .success("Auto-merge disabled for #\(pr.number)")
-            await refreshPRAfterAction(pr)
-        } catch {
-            statusMessage = .error("Disable auto-merge failed: \(error.localizedDescription)")
-        }
-    }
-
-    func openPRInBrowser(_ pr: PullRequest) {
-        if let url = URL(string: pr.url) {
-            NSWorkspace.shared.open(url)
-        }
-    }
-
     // MARK: - Issues
 
     func fetchIssues(forProject projectID: String) async {
@@ -1647,7 +1233,7 @@ public final class RunwayStore {
         }
         selectedSessionID = session.id
         currentView = .sessions
-        sessionPRs[session.id] = pr
+        prCoordinator.sessionPRs[session.id] = pr
 
         // Provision worktree in background, then start tmux
         provisioningWorktreeIDs.insert(session.id)
@@ -1683,26 +1269,13 @@ public final class RunwayStore {
 
     /// Creates a PR review session from the new session dialog — resolves the PR then creates the session.
     func handleReviewSessionRequest(_ request: ReviewSessionRequest) async throws {
-        let pr = try await prManager.resolvePR(repo: request.repo, number: request.prNumber, host: request.host)
+        let pr = try await prCoordinator.prManager.resolvePR(repo: request.repo, number: request.prNumber, host: request.host)
         await handleReviewPR(
             pr: pr,
             sessionName: request.sessionName,
             projectID: request.projectID,
             initialPrompt: request.initialPrompt
         )
-    }
-
-    func resolvePRForReview(number: Int, repo: String, host: String?) async {
-        isResolvingPR = true
-        defer { isResolvingPR = false }
-
-        do {
-            let pr = try await prManager.resolvePR(repo: repo, number: number, host: host)
-            reviewPRCandidate = pr
-            showReviewPRSheet = true
-        } catch {
-            statusMessage = .error("Failed to resolve PR #\(number): \(error.localizedDescription)")
-        }
     }
 
 }
@@ -1730,14 +1303,14 @@ extension RunwayStore: SidebarActions {
         showNewProjectDialog = true
     }
 
-    // SidebarActions conformance — delegates to the full selectPR with navigate: true
+    // SidebarActions conformance — delegates to PRCoordinator
     public func selectPR(_ pr: PullRequest?) async {
-        await selectPR(pr, navigate: true)
+        await prCoordinator.selectPR(pr, navigate: true)
     }
 
     public func reviewPR(_ pr: PullRequest) {
-        reviewPRCandidate = pr
-        showReviewPRSheet = true
+        prCoordinator.reviewPRCandidate = pr
+        prCoordinator.showReviewPRSheet = true
     }
 
     // MARK: - Changes Sidebar Actions

--- a/Sources/App/RunwayStore.swift
+++ b/Sources/App/RunwayStore.swift
@@ -23,8 +23,7 @@ public final class RunwayStore {
 
     var selectedSessionID: String?
     var currentView: AppView = .sessions
-    var showNewSessionDialog: Bool = false
-    var showNewProjectDialog: Bool = false
+    var activeSheet: ActiveSheet?
     var newSessionProjectID: String?
     var newSessionParentID: String?
     var forkSourceSession: Session?
@@ -776,7 +775,7 @@ public final class RunwayStore {
             NSApplication.shared.activate()
 
         case .newSession:
-            showNewSessionDialog = true
+            activeSheet = .newSession
             NSApplication.shared.activate()
         }
     }
@@ -1286,7 +1285,7 @@ extension RunwayStore: SidebarActions {
     public func newSession(projectID: String?, parentID: String? = nil) {
         newSessionProjectID = projectID
         newSessionParentID = parentID
-        showNewSessionDialog = true
+        activeSheet = .newSession
     }
 
     public func forkSession(id: String) {
@@ -1296,11 +1295,11 @@ extension RunwayStore: SidebarActions {
         forkSourceSession = session
         newSessionProjectID = session.projectID
         newSessionParentID = session.id
-        showNewSessionDialog = true
+        activeSheet = .newSession
     }
 
     public func newProject() {
-        showNewProjectDialog = true
+        activeSheet = .newProject
     }
 
     // SidebarActions conformance — delegates to PRCoordinator
@@ -1310,7 +1309,7 @@ extension RunwayStore: SidebarActions {
 
     public func reviewPR(_ pr: PullRequest) {
         prCoordinator.reviewPRCandidate = pr
-        prCoordinator.showReviewPRSheet = true
+        activeSheet = .reviewPRSheet
     }
 
     // MARK: - Changes Sidebar Actions
@@ -1373,6 +1372,25 @@ extension RunwayStore: SidebarActions {
     private func stopChangesRefresh() {
         changesRefreshTask?.cancel()
         changesRefreshTask = nil
+    }
+}
+
+// MARK: - Active Sheet
+
+/// Mutually exclusive sheet presentation — replaces 4 independent booleans.
+enum ActiveSheet: Identifiable {
+    case newSession
+    case newProject
+    case reviewPRSheet
+    case reviewPRDialog
+
+    var id: String {
+        switch self {
+        case .newSession: "newSession"
+        case .newProject: "newProject"
+        case .reviewPRSheet: "reviewPRSheet"
+        case .reviewPRDialog: "reviewPRDialog"
+        }
     }
 }
 

--- a/Sources/App/RunwayStore.swift
+++ b/Sources/App/RunwayStore.swift
@@ -43,6 +43,8 @@ public final class RunwayStore {
 
     /// Session IDs with in-progress worktree creation (transient, not persisted)
     var provisioningWorktreeIDs: Set<String> = []
+    /// Tracks provisioning Tasks so they can be cancelled if the session is deleted mid-provision.
+    private var provisioningTasks: [String: Task<Void, Never>] = [:]
 
     func profileForSession(_ session: Session) -> AgentProfile {
         if case .custom(let name) = session.tool,
@@ -351,11 +353,14 @@ public final class RunwayStore {
 
         let prompt = "Implement the changes described in issue #\(issue.number): \(issue.title)"
 
+        // Use the project's most recent session tool, defaulting to .claude
+        let projectTool = sessions.last(where: { $0.projectID == projectID })?.tool ?? .claude
+
         let request = NewSessionRequest(
             title: issue.title,
             projectID: projectID,
             path: project.path,
-            tool: .claude,
+            tool: projectTool,
             useWorktree: true,
             branchName: branchName,
             permissionMode: project.permissionMode ?? .default,
@@ -413,7 +418,9 @@ public final class RunwayStore {
 
             provisioningWorktreeIDs.insert(session.id)
 
-            Task {
+            let sessionID = session.id
+            provisioningTasks[sessionID] = Task {
+                defer { provisioningTasks.removeValue(forKey: sessionID) }
                 let sessionPath: String
                 let actualBranch: String
                 do {
@@ -604,6 +611,8 @@ public final class RunwayStore {
         try? database?.deleteSession(id: id)
         TerminalSessionCache.shared.removeAll(forSessionID: id)
         prCoordinator.sessionDeleted(id: id)
+        provisioningTasks[id]?.cancel()
+        provisioningTasks.removeValue(forKey: id)
         lastHookEventTime.removeValue(forKey: id)
         sessionChanges.removeValue(forKey: id)
         sessionFileTree.removeValue(forKey: id)
@@ -1237,7 +1246,9 @@ public final class RunwayStore {
         // Provision worktree in background, then start tmux
         provisioningWorktreeIDs.insert(session.id)
 
-        Task {
+        let reviewSessionID = session.id
+        provisioningTasks[reviewSessionID] = Task {
+            defer { provisioningTasks.removeValue(forKey: reviewSessionID) }
             let sessionPath: String
             do {
                 sessionPath = try await worktreeManager.checkoutWorktree(

--- a/Sources/GitHubOperations/PRManager.swift
+++ b/Sources/GitHubOperations/PRManager.swift
@@ -72,13 +72,12 @@ public actor PRManager {
     /// Each PR gets an `origin` set indicating which queries returned it.
     /// A failure in one filter does not discard results from the other.
     public func fetchAllPRs() async throws -> [PullRequest] {
-        // Use separate tasks so a failure in one doesn't discard the other's results
-        async let minePRs: [PullRequest] = {
-            (try? await fetchPRs(filter: .mine)) ?? []
-        }()
-        async let reviewPRs: [PullRequest] = {
-            (try? await fetchPRs(filter: .reviewRequested)) ?? []
-        }()
+        // Pre-resolve hosts on the actor so the parallel fetches don't re-enter.
+        // Without this, async let + actor-isolated fetchPRs serializes instead of parallelizing.
+        let hosts = await discoverHosts()
+
+        async let minePRs: [PullRequest] = Self.fetchPRsNonisolated(hosts: hosts, filter: .mine)
+        async let reviewPRs: [PullRequest] = Self.fetchPRsNonisolated(hosts: hosts, filter: .reviewRequested)
 
         let (mine, review) = await (minePRs, reviewPRs)
 
@@ -333,6 +332,32 @@ public actor PRManager {
         return PRFingerprint(latestUpdate: items.first?.updatedAt)
     }
 
+    /// Nonisolated helper for parallel PR fetching — avoids actor re-entrance serialization.
+    /// Hosts are pre-resolved on the actor; shell calls and parsing run off-actor.
+    nonisolated private static func fetchPRsNonisolated(hosts: [String], filter: PRFilter) async -> [PullRequest] {
+        var args = [
+            "search", "prs",
+            "--state", "open",
+            "--archived=false",
+            "--json", "number,title,state,repository,url,isDraft,createdAt,updatedAt,author",
+            "--limit", "50",
+        ]
+        switch filter {
+        case .mine: args += ["--author", "@me"]
+        case .reviewRequested: args += ["--review-requested", "@me"]
+        case .all: break
+        }
+
+        var allPRs: [PullRequest] = []
+        for host in hosts {
+            if let output = try? await ShellRunner.runGH(args: args, host: host) {
+                let prs = (try? parseSearchResultsStatic(output)) ?? []
+                allPRs.append(contentsOf: prs)
+            }
+        }
+        return allPRs
+    }
+
     // MARK: - Private
 
     @discardableResult
@@ -393,6 +418,12 @@ public actor PRManager {
 
         args += ["--limit", "50"]
         return args
+    }
+
+    nonisolated private static func parseSearchResultsStatic(_ json: String) throws -> [PullRequest] {
+        guard let data = json.data(using: .utf8) else { return [] }
+        let items = try JSONDecoder.gh.decode([GHSearchPRItem].self, from: data)
+        return items.map { $0.toPullRequest() }
     }
 
     private func parseSearchResults(_ json: String) throws -> [PullRequest] {

--- a/Sources/GitOperations/WorktreeManager.swift
+++ b/Sources/GitOperations/WorktreeManager.swift
@@ -278,26 +278,41 @@ public actor WorktreeManager {
         return "main"
     }
 
-    /// Get commit history for the current branch since it diverged from a base branch.
+    /// Get commit history for the current branch.
+    /// First tries showing only commits since divergence from the base branch.
+    /// Falls back to showing the last `limit` commits if there are no branch-specific commits
+    /// (e.g., session is on the default branch, or no merge-base exists).
     /// Returns an array of (hash, subject) tuples, most recent first.
     public func commitLog(
         path: String,
         baseBranch: String = "main",
         limit: Int = 50
     ) async -> [(hash: String, subject: String)] {
-        // Find the merge-base to only show commits on this branch
-        let base =
-            (try? await runGit(in: path, args: ["merge-base", baseBranch, "HEAD"]))
-            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) } ?? baseBranch
+        // Try branch-specific commits first (since divergence from base)
+        if let base = try? await runGit(in: path, args: ["merge-base", baseBranch, "HEAD"]) {
+            let trimmedBase = base.trimmingCharacters(in: .whitespacesAndNewlines)
+            if let output = try? await runGit(
+                in: path,
+                args: ["log", "--format=%h\t%s", "-\(limit)", "\(trimmedBase)..HEAD"]
+            ) {
+                let commits = parseCommitLog(output)
+                if !commits.isEmpty { return commits }
+            }
+        }
 
+        // Fallback: show recent commits on the current branch (no range restriction)
         guard
             let output = try? await runGit(
                 in: path,
-                args: ["log", "--oneline", "--format=%h\t%s", "-\(limit)", "\(base)..HEAD"]
+                args: ["log", "--format=%h\t%s", "-\(limit)"]
             )
         else { return [] }
 
-        return output.components(separatedBy: "\n")
+        return parseCommitLog(output)
+    }
+
+    private func parseCommitLog(_ output: String) -> [(hash: String, subject: String)] {
+        output.components(separatedBy: "\n")
             .filter { !$0.isEmpty }
             .compactMap { line in
                 let parts = line.components(separatedBy: "\t")

--- a/Sources/GitOperations/WorktreeManager.swift
+++ b/Sources/GitOperations/WorktreeManager.swift
@@ -149,7 +149,13 @@ public actor WorktreeManager {
         let output = try await runGit(in: repoPath, args: ["branch", "--merged", target])
         return output.components(separatedBy: "\n")
             .map { $0.trimmingCharacters(in: .whitespaces) }
-            .map { $0.hasPrefix("* ") ? String($0.dropFirst(2)) : $0 }
+            .map { line -> String in
+                // Strip prefix markers: "* " = current branch, "+ " = checked out in another worktree
+                if line.hasPrefix("* ") || line.hasPrefix("+ ") {
+                    return String(line.dropFirst(2))
+                }
+                return line
+            }
             .filter { !$0.isEmpty }
             .contains(branch)
     }

--- a/Sources/Models/PullRequest.swift
+++ b/Sources/Models/PullRequest.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// A GitHub pull request with metadata, checks, and review status.
-public struct PullRequest: Identifiable, Codable, Sendable {
+public struct PullRequest: Identifiable, Codable, Sendable, Equatable {
     public let id: String
     public let number: Int
     public var title: String
@@ -147,7 +147,7 @@ public enum ReviewDecision: String, Codable, Sendable {
 
 // MARK: - Check Summary
 
-public struct CheckSummary: Codable, Sendable {
+public struct CheckSummary: Codable, Sendable, Equatable {
     public var passed: Int
     public var failed: Int
     public var pending: Int

--- a/Sources/Models/ShellRunner.swift
+++ b/Sources/Models/ShellRunner.swift
@@ -47,14 +47,14 @@ public enum ShellRunner {
             return
         }
 
-        // Timeout after 3 seconds — complex shell configs (nvm, rbenv, pyenv)
-        // can take a long time and this blocks the main thread at launch.
-        let deadline = DispatchTime.now() + .seconds(3)
+        // Timeout after 1 second — most login shells resolve PATH in <500ms.
+        // This blocks the main thread at launch, so keep it tight.
+        let deadline = DispatchTime.now() + .seconds(1)
         let semaphore = DispatchSemaphore(value: 0)
         process.terminationHandler = { _ in semaphore.signal() }
         if semaphore.wait(timeout: deadline) == .timedOut {
             process.terminate()
-            print("[Runway] Login shell timed out after 3s, applying fallback PATH")
+            print("[Runway] Login shell timed out after 1s, applying fallback PATH")
             applyFallbackPath(current)
             return
         }

--- a/Sources/Persistence/Database.swift
+++ b/Sources/Persistence/Database.swift
@@ -2,11 +2,14 @@ import Foundation
 import GRDB
 import Models
 
-/// SQLite database manager using GRDB with WAL mode.
+/// SQLite database manager using GRDB.
+/// Production uses DatabasePool (WAL, concurrent reads during writes).
+/// Tests use DatabaseQueue (in-memory, serial).
 public final class Database: Sendable {
-    private let dbQueue: DatabaseQueue
+    private let db: any DatabaseWriter
 
     /// Open or create the database at the given path.
+    /// Uses DatabasePool for concurrent reads during writes.
     public init(path: String? = nil) throws {
         let dbPath = path ?? Database.defaultPath()
 
@@ -16,8 +19,6 @@ public final class Database: Sendable {
 
         var config = Configuration()
         config.prepareDatabase { db in
-            // WAL mode for concurrent readers
-            try db.execute(sql: "PRAGMA journal_mode = WAL")
             // NORMAL is safe with WAL — only risks data loss on power failure, not OS crash.
             // Reduces write latency by ~1ms per write (hot path: every hook status update).
             try db.execute(sql: "PRAGMA synchronous = NORMAL")
@@ -25,18 +26,19 @@ public final class Database: Sendable {
             try db.execute(sql: "PRAGMA busy_timeout = 5000")
         }
 
-        dbQueue = try DatabaseQueue(path: dbPath, configuration: config)
+        // DatabasePool enables concurrent reads during writes via WAL mode
+        db = try DatabasePool(path: dbPath, configuration: config)
         try migrate()
     }
 
     /// In-memory database for testing.
+    /// Uses DatabaseQueue since DatabasePool requires a file path for WAL.
     public init(inMemory: Bool) throws {
-        precondition(inMemory)
         var config = Configuration()
         config.prepareDatabase { db in
             try db.execute(sql: "PRAGMA busy_timeout = 5000")
         }
-        dbQueue = try DatabaseQueue(configuration: config)
+        db = try DatabaseQueue(configuration: config)
         try migrate()
     }
 
@@ -268,7 +270,7 @@ public final class Database: Sendable {
             }
         }
 
-        try migrator.migrate(dbQueue)
+        try migrator.migrate(db)
     }
 
     // MARK: - Default Path
@@ -281,32 +283,32 @@ public final class Database: Sendable {
     // MARK: - Session CRUD
 
     public func allSessions() throws -> [Session] {
-        try dbQueue.read { db in
+        try db.read { db in
             try SessionRecord.order(Column("sortOrder"), Column("createdAt")).fetchAll(db).map { $0.toSession() }
         }
     }
 
     public func session(id: String) throws -> Session? {
-        try dbQueue.read { db in
+        try db.read { db in
             try SessionRecord.fetchOne(db, key: id)?.toSession()
         }
     }
 
     public func saveSession(_ session: Session) throws {
-        try dbQueue.write { db in
+        try db.write { db in
             var record = SessionRecord(session)
             try record.save(db)
         }
     }
 
     public func deleteSession(id: String) throws {
-        try dbQueue.write { db in
+        try db.write { db in
             _ = try SessionRecord.deleteOne(db, key: id)
         }
     }
 
     public func updateSessionStatus(id: String, status: SessionStatus) throws {
-        try dbQueue.write { db in
+        try db.write { db in
             try db.execute(
                 sql: "UPDATE sessions SET status = ?, lastAccessedAt = ? WHERE id = ?",
                 arguments: [status.rawValue, Date(), id]
@@ -315,7 +317,7 @@ public final class Database: Sendable {
     }
 
     public func updateSessionPath(id: String, path: String) throws {
-        try dbQueue.write { db in
+        try db.write { db in
             try db.execute(
                 sql: "UPDATE sessions SET path = ?, lastAccessedAt = ? WHERE id = ?",
                 arguments: [path, Date(), id]
@@ -324,7 +326,7 @@ public final class Database: Sendable {
     }
 
     public func updateSessionBranch(id: String, branch: String) throws {
-        try dbQueue.write { db in
+        try db.write { db in
             try db.execute(
                 sql: "UPDATE sessions SET worktreeBranch = ?, lastAccessedAt = ? WHERE id = ?",
                 arguments: [branch, Date(), id]
@@ -333,7 +335,7 @@ public final class Database: Sendable {
     }
 
     public func updateSessionSortOrder(id: String, sortOrder: Int) throws {
-        try dbQueue.write { db in
+        try db.write { db in
             try db.execute(
                 sql: "UPDATE sessions SET sortOrder = ? WHERE id = ?",
                 arguments: [sortOrder, id]
@@ -342,7 +344,7 @@ public final class Database: Sendable {
     }
 
     public func updateProjectSortOrder(id: String, sortOrder: Int) throws {
-        try dbQueue.write { db in
+        try db.write { db in
             try db.execute(
                 sql: "UPDATE projects SET sortOrder = ? WHERE id = ?",
                 arguments: [sortOrder, id]
@@ -353,7 +355,7 @@ public final class Database: Sendable {
     // MARK: - Session Event CRUD
 
     public func saveEvent(_ event: SessionEvent) throws {
-        try dbQueue.write { db in
+        try db.write { db in
             var record = SessionEventRecord(event)
             try record.insert(db)
 
@@ -374,7 +376,7 @@ public final class Database: Sendable {
     }
 
     public func events(forSessionID sessionID: String, limit: Int = 100) throws -> [SessionEvent] {
-        try dbQueue.read { db in
+        try db.read { db in
             try SessionEventRecord
                 .filter(Column("sessionID") == sessionID)
                 .order(Column("createdAt").desc)
@@ -385,7 +387,7 @@ public final class Database: Sendable {
     }
 
     public func updateSessionIssueNumber(id: String, issueNumber: Int?) throws {
-        try dbQueue.write { db in
+        try db.write { db in
             try db.execute(
                 sql: "UPDATE sessions SET issueNumber = ? WHERE id = ?",
                 arguments: [issueNumber, id]
@@ -396,26 +398,26 @@ public final class Database: Sendable {
     // MARK: - Project CRUD
 
     public func allProjects() throws -> [Project] {
-        try dbQueue.read { db in
+        try db.read { db in
             try ProjectRecord.order(Column("sortOrder")).fetchAll(db).map { $0.toProject() }
         }
     }
 
     public func saveProject(_ project: Project) throws {
-        try dbQueue.write { db in
+        try db.write { db in
             var record = ProjectRecord(project)
             try record.save(db)
         }
     }
 
     public func deleteProject(id: String) throws {
-        try dbQueue.write { db in
+        try db.write { db in
             _ = try ProjectRecord.deleteOne(db, key: id)
         }
     }
 
     public func updateProject(_ project: Project) throws {
-        try dbQueue.write { db in
+        try db.write { db in
             let record = ProjectRecord(project)
             try record.update(db)
         }
@@ -426,7 +428,7 @@ public final class Database: Sendable {
     /// Load all cached PRs that haven't expired.
     public func cachedPRs(maxAge: TimeInterval = 300) throws -> [PullRequest] {
         let cutoff = Date().addingTimeInterval(-maxAge)
-        return try dbQueue.read { db in
+        return try db.read { db in
             let rows = try Row.fetchAll(
                 db,
                 sql: "SELECT json FROM pr_cache WHERE fetchedAt > ?",
@@ -445,7 +447,7 @@ public final class Database: Sendable {
     public func cachePR(_ pr: PullRequest) throws {
         let data = try JSONEncoder().encode(pr)
         let json = String(data: data, encoding: .utf8) ?? ""
-        try dbQueue.write { db in
+        try db.write { db in
             try db.execute(
                 sql: "INSERT OR REPLACE INTO pr_cache (id, json, fetchedAt) VALUES (?, ?, ?)",
                 arguments: [pr.id, json, Date()]
@@ -457,7 +459,7 @@ public final class Database: Sendable {
     public func cachePRs(_ prs: [PullRequest]) throws {
         let encoder = JSONEncoder()
         let now = Date()
-        try dbQueue.write { db in
+        try db.write { db in
             for pr in prs {
                 let data = try encoder.encode(pr)
                 let json = String(data: data, encoding: .utf8) ?? ""
@@ -472,7 +474,7 @@ public final class Database: Sendable {
     /// Clear expired PR cache entries.
     public func cleanPRCache(maxAge: TimeInterval = 86400) throws {
         let cutoff = Date().addingTimeInterval(-maxAge)
-        try dbQueue.write { db in
+        try db.write { db in
             try db.execute(sql: "DELETE FROM pr_cache WHERE fetchedAt < ?", arguments: [cutoff])
         }
     }
@@ -483,7 +485,7 @@ public final class Database: Sendable {
     public func cachedIssues(repo: String, maxAge: TimeInterval = 300) throws -> [GitHubIssue] {
         let cutoff = Date().addingTimeInterval(-maxAge)
         let pattern = "\(repo)#%"
-        return try dbQueue.read { db in
+        return try db.read { db in
             let rows = try Row.fetchAll(
                 db,
                 sql: "SELECT json FROM issue_cache WHERE id LIKE ? AND fetchedAt > ?",
@@ -502,7 +504,7 @@ public final class Database: Sendable {
     public func cacheIssues(_ issues: [GitHubIssue]) throws {
         let encoder = JSONEncoder()
         let now = Date()
-        try dbQueue.write { db in
+        try db.write { db in
             for issue in issues {
                 let data = try encoder.encode(issue)
                 let json = String(data: data, encoding: .utf8) ?? ""
@@ -517,7 +519,7 @@ public final class Database: Sendable {
     /// Clear expired issue cache entries.
     public func cleanIssueCache(maxAge: TimeInterval = 86400) throws {
         let cutoff = Date().addingTimeInterval(-maxAge)
-        try dbQueue.write { db in
+        try db.write { db in
             try db.execute(sql: "DELETE FROM issue_cache WHERE fetchedAt < ?", arguments: [cutoff])
         }
     }
@@ -525,7 +527,7 @@ public final class Database: Sendable {
     // MARK: - Session Template CRUD
 
     public func allTemplates() throws -> [SessionTemplate] {
-        try dbQueue.read { db in
+        try db.read { db in
             try SessionTemplateRecord
                 .order(Column("sortOrder"), Column("createdAt"))
                 .fetchAll(db)
@@ -534,7 +536,7 @@ public final class Database: Sendable {
     }
 
     public func templates(forProjectID projectID: String?) throws -> [SessionTemplate] {
-        try dbQueue.read { db in
+        try db.read { db in
             try SessionTemplateRecord
                 .filter(Column("projectID") == projectID)
                 .order(Column("sortOrder"), Column("createdAt"))
@@ -544,14 +546,14 @@ public final class Database: Sendable {
     }
 
     public func saveTemplate(_ template: SessionTemplate) throws {
-        try dbQueue.write { db in
+        try db.write { db in
             var record = SessionTemplateRecord(template)
             try record.save(db)
         }
     }
 
     public func deleteTemplate(id: String) throws {
-        try dbQueue.write { db in
+        try db.write { db in
             _ = try SessionTemplateRecord.deleteOne(db, key: id)
         }
     }
@@ -559,7 +561,7 @@ public final class Database: Sendable {
     // MARK: - Saved Prompt CRUD
 
     public func allPrompts() throws -> [SavedPrompt] {
-        try dbQueue.read { db in
+        try db.read { db in
             try SavedPromptRecord
                 .order(Column("sortOrder"), Column("createdAt"))
                 .fetchAll(db)
@@ -568,7 +570,7 @@ public final class Database: Sendable {
     }
 
     public func prompts(forProjectID projectID: String?) throws -> [SavedPrompt] {
-        try dbQueue.read { db in
+        try db.read { db in
             try SavedPromptRecord
                 .filter(Column("projectID") == projectID)
                 .order(Column("sortOrder"), Column("createdAt"))
@@ -578,14 +580,14 @@ public final class Database: Sendable {
     }
 
     public func savePrompt(_ prompt: SavedPrompt) throws {
-        try dbQueue.write { db in
+        try db.write { db in
             var record = SavedPromptRecord(prompt)
             try record.save(db)
         }
     }
 
     public func deletePrompt(id: String) throws {
-        try dbQueue.write { db in
+        try db.write { db in
             _ = try SavedPromptRecord.deleteOne(db, key: id)
         }
     }
@@ -597,7 +599,7 @@ public final class Database: Sendable {
     @discardableResult
     public func cleanStoppedSessions(maxAge: TimeInterval = 7 * 86400) throws -> Int {
         let cutoff = Date().addingTimeInterval(-maxAge)
-        return try dbQueue.write { db in
+        return try db.write { db in
             try db.execute(
                 sql: "DELETE FROM sessions WHERE status = 'stopped' AND lastAccessedAt < ?",
                 arguments: [cutoff]
@@ -611,7 +613,7 @@ public final class Database: Sendable {
     @discardableResult
     public func cleanOldEvents(maxAge: TimeInterval = 7 * 86400) throws -> Int {
         let cutoff = Date().addingTimeInterval(-maxAge)
-        return try dbQueue.write { db in
+        return try db.write { db in
             try db.execute(
                 sql: "DELETE FROM session_events WHERE createdAt < ?",
                 arguments: [cutoff]
@@ -623,7 +625,7 @@ public final class Database: Sendable {
     /// Run SQLite VACUUM to reclaim disk space after bulk deletions.
     /// Must run outside a transaction — SQLite prohibits VACUUM within transactions.
     public func vacuum() throws {
-        try dbQueue.writeWithoutTransaction { db in
+        try db.writeWithoutTransaction { db in
             try db.execute(sql: "VACUUM")
         }
     }

--- a/Sources/StatusDetection/HookServer.swift
+++ b/Sources/StatusDetection/HookServer.swift
@@ -16,6 +16,8 @@ public actor HookServer {
     private var listener: NWListener?
     private var handlers: [EventHandler] = []
     private let connectionQueue = DispatchQueue(label: "runway.hookserver.conn")
+    /// Active connections tracked for cancellation on stop().
+    private var activeConnections: [NWConnection] = []
 
     /// The actual port the server is listening on (available after `start()` returns).
     public private(set) var actualPort: UInt16?
@@ -100,8 +102,12 @@ public actor HookServer {
         }
     }
 
-    /// Stop the hook server.
+    /// Stop the hook server and cancel all in-flight connections.
     public func stop() {
+        for connection in activeConnections {
+            connection.cancel()
+        }
+        activeConnections.removeAll()
         listener?.cancel()
         listener = nil
         actualPort = nil
@@ -113,6 +119,7 @@ public actor HookServer {
     private static let connectionTimeout: TimeInterval = 30
 
     private func handleConnection(_ connection: NWConnection) {
+        activeConnections.append(connection)
         connection.start(queue: connectionQueue)
 
         // Schedule a timeout to prevent slow/idle connections from leaking resources
@@ -181,6 +188,9 @@ public actor HookServer {
     }
 
     private func processRequest(data: Data, connection: NWConnection) {
+        // Remove from active connections list
+        activeConnections.removeAll { $0 === connection }
+
         // Send 200 OK response immediately — don't block the agent waiting for
         // handler dispatch, which may await MainActor and exceed the hook timeout.
         let response = "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n"

--- a/Sources/TerminalView/TerminalSessionCache.swift
+++ b/Sources/TerminalView/TerminalSessionCache.swift
@@ -17,14 +17,21 @@ public final class TerminalSessionCache {
     /// re-attaching later simply creates a new SwiftTerm view.
     /// Sized generously because re-attach causes a visible "replay" as tmux
     /// dumps the pane buffer through the new PTY.
-    public let maxSize: Int = 30
+    public let maxSize: Int
 
     private var views: [String: LocalProcessTerminalView] = [:]
 
     /// Tracks the last-access time for each cache key.
     private var lastAccess: [String: Date] = [:]
 
-    private init() {}
+    private init() {
+        self.maxSize = 30
+    }
+
+    /// Internal initializer for testing with a custom cache size.
+    init(maxSize: Int) {
+        self.maxSize = maxSize
+    }
 
     /// Get or create a terminal view for the given session ID.
     /// If a view already exists, it's returned as-is (preserving the running PTY).

--- a/Sources/Theme/ThemeFile.swift
+++ b/Sources/Theme/ThemeFile.swift
@@ -72,7 +72,7 @@ public struct ThemeFile: Codable {
 
 extension Color {
     /// Initialize Color from a hex string like "#1a1b26", "1a1b26", or "F00" (3-digit shorthand).
-    init(hexString: String) {
+    public init(hexString: String) {
         var hex = hexString.trimmingCharacters(in: CharacterSet(charactersIn: "#"))
         // Expand 3-digit CSS shorthand (e.g., "F00" → "FF0000")
         if hex.count == 3 {
@@ -81,5 +81,14 @@ extension Color {
         var value: UInt64 = 0
         Scanner(string: hex).scanHexInt64(&value)
         self.init(hex: UInt32(value))
+    }
+
+    /// Failable hex string initializer — returns nil for malformed strings.
+    /// Used by GitHub label colors that may contain unexpected values.
+    public init?(hex: String) {
+        var hex = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+        if hex.hasPrefix("#") { hex.removeFirst() }
+        guard hex.count == 6, let int = UInt64(hex, radix: 16) else { return nil }
+        self.init(hex: UInt32(int))
     }
 }

--- a/Sources/Views/PRDashboard/PRDashboardView.swift
+++ b/Sources/Views/PRDashboard/PRDashboardView.swift
@@ -318,6 +318,10 @@ public struct PRDashboardView: View {
                     .help(
                         showSessionPRsOnly ? "Showing session PRs only" : "Show only session PRs"
                     )
+                    .accessibilityLabel(
+                        showSessionPRsOnly
+                            ? "Showing session PRs only" : "Show only session PRs"
+                    )
                     .padding(.trailing, 4)
 
                     Button {
@@ -328,6 +332,7 @@ public struct PRDashboardView: View {
                     }
                     .buttonStyle(IconButtonStyle())
                     .help(hideDrafts ? "Show drafts" : "Hide drafts")
+                    .accessibilityLabel(hideDrafts ? "Show drafts" : "Hide drafts")
                     .padding(.trailing, 4)
 
                     Button(action: onRefresh) {
@@ -335,6 +340,7 @@ public struct PRDashboardView: View {
                             .font(.callout)
                     }
                     .buttonStyle(IconButtonStyle())
+                    .accessibilityLabel("Refresh pull requests")
                     .padding(.trailing, 8)
                 }
                 .padding(.horizontal)

--- a/Sources/Views/PRDashboard/PRDashboardView.swift
+++ b/Sources/Views/PRDashboard/PRDashboardView.swift
@@ -419,19 +419,13 @@ public struct PRDashboardView: View {
     // MARK: - Tab Button
 
     private func tabButton(_ tab: PRTab) -> some View {
-        let count = tabCounts[tab] ?? 0
-        return Button(action: {
+        TabBarButton(
+            title: tab.rawValue,
+            count: tabCounts[tab] ?? 0,
+            isActive: selectedTab == tab
+        ) {
             selectedTab = tab
-        }) {
-            Text("\(tab.rawValue) (\(count))")
-                .font(.callout)
-                .fontWeight(selectedTab == tab ? .semibold : .regular)
-                .foregroundColor(selectedTab == tab ? theme.chrome.accent : theme.chrome.textDim)
-                .padding(.horizontal, 12)
-                .padding(.vertical, 6)
         }
-        .buttonStyle(.plain)
-        .accessibilityAddTraits(selectedTab == tab ? .isSelected : [])
     }
 
 }

--- a/Sources/Views/PRDashboard/PRFilterBar.swift
+++ b/Sources/Views/PRDashboard/PRFilterBar.swift
@@ -87,6 +87,7 @@ struct PRFilterBar: View {
                     .font(.caption)
                     .foregroundColor(theme.chrome.accent)
                     .buttonStyle(.plain)
+                    .accessibilityLabel("Clear all filters")
             }
 
             Spacer()

--- a/Sources/Views/ProjectPage/NewIssueSheet.swift
+++ b/Sources/Views/ProjectPage/NewIssueSheet.swift
@@ -2,20 +2,6 @@ import GitHubOperations
 import SwiftUI
 import Theme
 
-// MARK: - Color Hex Init
-
-extension Color {
-    init?(hex: String) {
-        var hex = hex.trimmingCharacters(in: .whitespacesAndNewlines)
-        if hex.hasPrefix("#") { hex.removeFirst() }
-        guard hex.count == 6, let int = UInt64(hex, radix: 16) else { return nil }
-        let r = Double((int >> 16) & 0xFF) / 255.0
-        let g = Double((int >> 8) & 0xFF) / 255.0
-        let b = Double(int & 0xFF) / 255.0
-        self.init(red: r, green: g, blue: b)
-    }
-}
-
 // MARK: - Flow Layout
 
 struct FlowLayout: Layout {

--- a/Sources/Views/ProjectPage/ProjectPageView.swift
+++ b/Sources/Views/ProjectPage/ProjectPageView.swift
@@ -182,7 +182,7 @@ public struct ProjectPageView: View {
 
             // Tab bar
             HStack(spacing: 0) {
-                TabButton(
+                TabBarButton(
                     title: "Issues",
                     count: openIssueCount,
                     isActive: selectedTab == .issues
@@ -190,7 +190,7 @@ public struct ProjectPageView: View {
                     selectedTab = .issues
                 }
 
-                TabButton(
+                TabBarButton(
                     title: "Pull Requests",
                     count: openPRCount,
                     isActive: selectedTab == .prs
@@ -271,46 +271,5 @@ public struct ProjectPageView: View {
                 onRefreshIssues()
             }
         }
-    }
-}
-
-// MARK: - Tab Button
-
-private struct TabButton: View {
-    let title: String
-    let count: Int
-    let isActive: Bool
-    let action: () -> Void
-
-    @Environment(\.theme) private var theme
-
-    var body: some View {
-        Button(action: action) {
-            VStack(spacing: 4) {
-                HStack(spacing: 4) {
-                    Text(title)
-                        .font(.body)
-                        .foregroundColor(isActive ? theme.chrome.text : theme.chrome.textDim)
-
-                    Text("\(count)")
-                        .font(.caption)
-                        .foregroundColor(isActive ? theme.chrome.text : theme.chrome.textDim)
-                        .padding(.horizontal, 5)
-                        .padding(.vertical, 1)
-                        .background(
-                            Capsule()
-                                .fill(theme.chrome.surface.opacity(0.6))
-                        )
-                }
-
-                // Underline indicator
-                Rectangle()
-                    .fill(isActive ? theme.chrome.accent : Color.clear)
-                    .frame(height: 2)
-                    .clipShape(RoundedRectangle(cornerRadius: 1))
-            }
-        }
-        .buttonStyle(.plain)
-        .padding(.trailing, 16)
     }
 }

--- a/Sources/Views/ProjectPage/ProjectPageView.swift
+++ b/Sources/Views/ProjectPage/ProjectPageView.swift
@@ -173,6 +173,7 @@ public struct ProjectPageView: View {
                 }
                 .buttonStyle(IconButtonStyle())
                 .help("Project Settings")
+                .accessibilityLabel("Project settings")
             }
             .padding(.horizontal, 16)
             .padding(.vertical, 12)

--- a/Sources/Views/SessionDetail/ChangesSidebarView.swift
+++ b/Sources/Views/SessionDetail/ChangesSidebarView.swift
@@ -33,7 +33,7 @@ struct ChangesSidebarView: View {
 
             Spacer()
 
-            Picker("", selection: $mode) {
+            Picker("Changes compared to", selection: $mode) {
                 Text("vs Main").tag(ChangesMode.branch)
                 Text("Uncommitted").tag(ChangesMode.working)
             }

--- a/Sources/Views/SessionDetail/CommitHistoryView.swift
+++ b/Sources/Views/SessionDetail/CommitHistoryView.swift
@@ -1,0 +1,150 @@
+import GitOperations
+import Models
+import SwiftUI
+import Theme
+
+/// Shows commit history for a session's worktree branch with rollback capability.
+/// Displayed as a popover from the session header's branch name area.
+public struct CommitHistoryView: View {
+    let session: Session
+    let worktreeManager: WorktreeManager
+    let defaultBranch: String
+    var onRollback: ((String) -> Void)?
+
+    @State private var commits: [(hash: String, subject: String)] = []
+    @State private var isLoading = true
+    @State private var confirmRollbackHash: String?
+
+    @Environment(\.theme) private var theme
+
+    public init(
+        session: Session,
+        worktreeManager: WorktreeManager,
+        defaultBranch: String = "main",
+        onRollback: ((String) -> Void)? = nil
+    ) {
+        self.session = session
+        self.worktreeManager = worktreeManager
+        self.defaultBranch = defaultBranch
+        self.onRollback = onRollback
+    }
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Header
+            HStack {
+                Text("Commits")
+                    .font(.callout)
+                    .fontWeight(.semibold)
+                    .foregroundColor(theme.chrome.text)
+                Spacer()
+                if isLoading {
+                    ProgressView()
+                        .controlSize(.small)
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+
+            Divider()
+
+            if commits.isEmpty && !isLoading {
+                Text("No commits on this branch yet")
+                    .font(.callout)
+                    .foregroundColor(theme.chrome.textDim)
+                    .padding(16)
+                    .frame(maxWidth: .infinity)
+            } else {
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 0) {
+                        ForEach(Array(commits.enumerated()), id: \.offset) { index, commit in
+                            commitRow(commit, isLatest: index == 0)
+                        }
+                    }
+                }
+                .frame(maxHeight: 300)
+            }
+        }
+        .frame(width: 360)
+        .background(theme.chrome.background)
+        .task {
+            await loadCommits()
+        }
+        .alert(
+            "Roll back to this commit?",
+            isPresented: Binding(
+                get: { confirmRollbackHash != nil },
+                set: { if !$0 { confirmRollbackHash = nil } }
+            )
+        ) {
+            Button("Cancel", role: .cancel) { confirmRollbackHash = nil }
+            Button("Roll Back", role: .destructive) {
+                if let hash = confirmRollbackHash {
+                    onRollback?(hash)
+                    confirmRollbackHash = nil
+                }
+            }
+        } message: {
+            if let hash = confirmRollbackHash,
+                let commit = commits.first(where: { $0.hash == hash })
+            {
+                Text(
+                    "This will reset the working tree to \(commit.hash). Uncommitted changes will be lost."
+                )
+            }
+        }
+    }
+
+    private func commitRow(
+        _ commit: (hash: String, subject: String), isLatest: Bool
+    ) -> some View {
+        HStack(spacing: 8) {
+            // Commit hash
+            Text(commit.hash)
+                .font(.system(.caption, design: .monospaced))
+                .foregroundColor(theme.chrome.accent)
+                .frame(width: 60, alignment: .leading)
+
+            // Commit message
+            Text(commit.subject)
+                .font(.callout)
+                .foregroundColor(theme.chrome.text)
+                .lineLimit(1)
+
+            Spacer()
+
+            if isLatest {
+                Text("HEAD")
+                    .font(.caption2)
+                    .fontWeight(.bold)
+                    .foregroundColor(theme.chrome.green)
+                    .padding(.horizontal, 5)
+                    .padding(.vertical, 1)
+                    .background(theme.chrome.green.opacity(0.12))
+                    .clipShape(Capsule())
+            } else if onRollback != nil {
+                Button {
+                    confirmRollbackHash = commit.hash
+                } label: {
+                    Text("Roll back")
+                        .font(.caption)
+                        .foregroundColor(theme.chrome.red)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Roll back to commit \(commit.hash)")
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+        .background(isLatest ? theme.chrome.accent.opacity(0.05) : .clear)
+    }
+
+    private func loadCommits() async {
+        isLoading = true
+        commits = await worktreeManager.commitLog(
+            path: session.path,
+            baseBranch: defaultBranch
+        )
+        isLoading = false
+    }
+}

--- a/Sources/Views/SessionDetail/FileTreeView.swift
+++ b/Sources/Views/SessionDetail/FileTreeView.swift
@@ -102,6 +102,7 @@ private struct DirectoryRow: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .accessibilityLabel(expanded ? "Collapse folder \(name)" : "Expand folder \(name)")
 
         if expanded {
             ForEach(children) { child in
@@ -161,6 +162,7 @@ private struct FileRow: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .accessibilityLabel("\(filename), \(change.status.rawValue), +\(change.additions) -\(change.deletions)")
     }
 
     private var filename: String {

--- a/Sources/Views/SessionDetail/SessionDetailView.swift
+++ b/Sources/Views/SessionDetail/SessionDetailView.swift
@@ -1,3 +1,4 @@
+import GitOperations
 import Models
 import SwiftUI
 import Terminal
@@ -29,6 +30,9 @@ public struct SessionDetailView: View {
     var onActiveDiffPathChanged: ((String?) -> Void)?
     var onToggleChanges: (() -> Void)?
     var onRestart: (() -> Void)?
+    var worktreeManager: WorktreeManager?
+    var defaultBranch: String = "main"
+    var onRollback: ((String) -> Void)?
     var savedPrompts: [SavedPrompt] = []
     @AppStorage("changesSidebarWidth") private var sidebarWidth: Double = 260
     @Environment(\.theme) private var theme
@@ -58,6 +62,9 @@ public struct SessionDetailView: View {
         onActiveDiffPathChanged: ((String?) -> Void)? = nil,
         onToggleChanges: (() -> Void)? = nil,
         onRestart: (() -> Void)? = nil,
+        worktreeManager: WorktreeManager? = nil,
+        defaultBranch: String = "main",
+        onRollback: ((String) -> Void)? = nil,
         savedPrompts: [SavedPrompt] = []
     ) {
         self.session = session
@@ -84,6 +91,9 @@ public struct SessionDetailView: View {
         self.onActiveDiffPathChanged = onActiveDiffPathChanged
         self.onToggleChanges = onToggleChanges
         self.onRestart = onRestart
+        self.worktreeManager = worktreeManager
+        self.defaultBranch = defaultBranch
+        self.onRollback = onRollback
         self.savedPrompts = savedPrompts
     }
 
@@ -97,7 +107,10 @@ public struct SessionDetailView: View {
                 onSelectPR: onSelectPR,
                 onSelectSession: onSelectSession,
                 changesVisible: changesVisible,
-                onToggleChanges: onToggleChanges
+                onToggleChanges: onToggleChanges,
+                worktreeManager: worktreeManager,
+                defaultBranch: defaultBranch,
+                onRollback: onRollback
             )
             HStack(spacing: 0) {
                 // Main content: terminal or diff view

--- a/Sources/Views/SessionDetail/SessionHeaderView.swift
+++ b/Sources/Views/SessionDetail/SessionHeaderView.swift
@@ -1,3 +1,4 @@
+import GitOperations
 import Models
 import SwiftUI
 import Theme
@@ -12,6 +13,10 @@ public struct SessionHeaderView: View {
     var onSelectSession: ((String) -> Void)? = nil
     var changesVisible: Bool = false
     var onToggleChanges: (() -> Void)? = nil
+    var worktreeManager: WorktreeManager?
+    var defaultBranch: String = "main"
+    var onRollback: ((String) -> Void)?
+    @State private var showCommitHistory = false
     @Environment(\.theme) private var theme
 
     public init(
@@ -22,7 +27,10 @@ public struct SessionHeaderView: View {
         onSelectPR: ((PullRequest) -> Void)? = nil,
         onSelectSession: ((String) -> Void)? = nil,
         changesVisible: Bool = false,
-        onToggleChanges: (() -> Void)? = nil
+        onToggleChanges: (() -> Void)? = nil,
+        worktreeManager: WorktreeManager? = nil,
+        defaultBranch: String = "main",
+        onRollback: ((String) -> Void)? = nil
     ) {
         self.session = session
         self.linkedPR = linkedPR
@@ -32,6 +40,9 @@ public struct SessionHeaderView: View {
         self.onSelectSession = onSelectSession
         self.changesVisible = changesVisible
         self.onToggleChanges = onToggleChanges
+        self.worktreeManager = worktreeManager
+        self.defaultBranch = defaultBranch
+        self.onRollback = onRollback
     }
 
     public var body: some View {
@@ -119,6 +130,27 @@ public struct SessionHeaderView: View {
                                 Text(pr.baseBranch)
                                     .font(.system(.callout, design: .monospaced))
                                     .foregroundStyle(.secondary)
+                            }
+
+                            if let worktreeManager {
+                                Button {
+                                    showCommitHistory.toggle()
+                                } label: {
+                                    Image(systemName: "clock.arrow.circlepath")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+                                .buttonStyle(.plain)
+                                .help("Commit history")
+                                .accessibilityLabel("Show commit history")
+                                .popover(isPresented: $showCommitHistory) {
+                                    CommitHistoryView(
+                                        session: session,
+                                        worktreeManager: worktreeManager,
+                                        defaultBranch: defaultBranch,
+                                        onRollback: onRollback
+                                    )
+                                }
                             }
                         }
 

--- a/Sources/Views/SessionDetail/SessionHeaderView.swift
+++ b/Sources/Views/SessionDetail/SessionHeaderView.swift
@@ -97,6 +97,7 @@ public struct SessionHeaderView: View {
                                 .foregroundStyle(theme.chrome.accent)
                         }
                         .buttonStyle(.plain)
+                        .accessibilityLabel("View parent session: \(parent.title)")
                     }
                 }
 
@@ -140,6 +141,7 @@ public struct SessionHeaderView: View {
                                 }
                                 .buttonStyle(LinkButtonStyle())
                                 .help(onSelectPR != nil ? "View PR details" : "Open PR in browser")
+                                .accessibilityLabel("Pull request #\(pr.number)")
 
                                 // Check summary
                                 CheckSummaryBadge(checks: pr.checks, style: .inline)
@@ -162,6 +164,9 @@ public struct SessionHeaderView: View {
                                         .padding(.vertical, 2)
                                         .background(theme.chrome.accent.opacity(0.12))
                                         .clipShape(Capsule())
+                                        .accessibilityLabel(
+                                            "\(inlineCount) inline comment\(inlineCount == 1 ? "" : "s")"
+                                        )
                                     }
                                 }
 

--- a/Sources/Views/Settings/ProjectSettingsSheet.swift
+++ b/Sources/Views/Settings/ProjectSettingsSheet.swift
@@ -166,7 +166,7 @@ public struct ProjectSettingsSheet: View {
             .padding(.horizontal, 20)
             .padding(.vertical, 14)
         }
-        .frame(width: 400)
+        .frame(minWidth: 360, idealWidth: 400, maxWidth: 480)
         .frame(minHeight: 480, idealHeight: 480, maxHeight: 640)
         .onAppear {
             themeID = project.themeID

--- a/Sources/Views/Shared/DiffView.swift
+++ b/Sources/Views/Shared/DiffView.swift
@@ -72,6 +72,10 @@ public struct DiffView: View {
                     }
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel(
+                    isExpanded
+                        ? "Collapse \(file.path)" : "Expand \(file.path)"
+                )
             }
 
             if isExpanded {

--- a/Sources/Views/Shared/NewProjectDialog.swift
+++ b/Sources/Views/Shared/NewProjectDialog.swift
@@ -56,7 +56,7 @@ public struct NewProjectDialog: View {
             }
         }
         .padding(24)
-        .frame(width: 420)
+        .frame(minWidth: 380, idealWidth: 420, maxWidth: 500)
         .fixedSize(horizontal: false, vertical: true)
         .onChange(of: path) { _, newPath in
             detectBranch(at: newPath)

--- a/Sources/Views/Shared/NewSessionDialog.swift
+++ b/Sources/Views/Shared/NewSessionDialog.swift
@@ -157,7 +157,7 @@ public struct NewSessionDialog: View {
             }
         }
         .padding(24)
-        .frame(width: 420)
+        .frame(minWidth: 380, idealWidth: 420, maxWidth: 500)
         .fixedSize(horizontal: false, vertical: true)
         .onAppear {
             permissionMode = defaultPermissionMode

--- a/Sources/Views/Shared/ReviewPRSheet.swift
+++ b/Sources/Views/Shared/ReviewPRSheet.swift
@@ -90,7 +90,7 @@ public struct ReviewPRSheet: View {
             }
         }
         .padding(24)
-        .frame(width: 480)
+        .frame(minWidth: 420, idealWidth: 480, maxWidth: 560)
     }
 
     private var prBanner: some View {
@@ -239,7 +239,7 @@ public struct ReviewPRNumberDialog: View {
             }
         }
         .padding(20)
-        .frame(width: 340)
+        .frame(minWidth: 300, idealWidth: 340, maxWidth: 420)
     }
 
     private func resolve() {

--- a/Sources/Views/Shared/TabBarButton.swift
+++ b/Sources/Views/Shared/TabBarButton.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+import Theme
+
+/// Reusable tab bar button for section navigation (project page, PR dashboard).
+/// Shows title + optional count badge with an underline indicator for the active tab.
+public struct TabBarButton: View {
+    let title: String
+    let count: Int?
+    let isActive: Bool
+    let action: () -> Void
+
+    @Environment(\.theme) private var theme
+
+    public init(title: String, count: Int? = nil, isActive: Bool, action: @escaping () -> Void) {
+        self.title = title
+        self.count = count
+        self.isActive = isActive
+        self.action = action
+    }
+
+    public var body: some View {
+        Button(action: action) {
+            VStack(spacing: 4) {
+                HStack(spacing: 4) {
+                    Text(title)
+                        .font(.callout)
+                        .fontWeight(isActive ? .semibold : .regular)
+                        .foregroundColor(isActive ? theme.chrome.text : theme.chrome.textDim)
+
+                    if let count {
+                        Text("\(count)")
+                            .font(.caption)
+                            .foregroundColor(isActive ? theme.chrome.text : theme.chrome.textDim)
+                            .padding(.horizontal, 5)
+                            .padding(.vertical, 1)
+                            .background(
+                                Capsule()
+                                    .fill(theme.chrome.surface.opacity(0.6))
+                            )
+                    }
+                }
+
+                Rectangle()
+                    .fill(isActive ? theme.chrome.accent : Color.clear)
+                    .frame(height: 2)
+                    .clipShape(RoundedRectangle(cornerRadius: 1))
+            }
+        }
+        .buttonStyle(.plain)
+        .accessibilityAddTraits(isActive ? .isSelected : [])
+    }
+}

--- a/Tests/GitOperationsTests/WorktreeManagerTests.swift
+++ b/Tests/GitOperationsTests/WorktreeManagerTests.swift
@@ -578,11 +578,13 @@ private func withTempGitRepo(_ body: (String) async throws -> Void) async throws
     }
 }
 
-@Test func commitLogReturnsEmptyForNoNewCommits() async throws {
+@Test func commitLogFallsBackToRecentCommitsWhenNoBranchDivergence() async throws {
     try await withTempGitRepo { repoPath in
         let manager = WorktreeManager()
         let currentBranch = await manager.currentBranch(path: repoPath) ?? "main"
+        // No branch divergence — commitLog falls back to showing recent commits
         let log = await manager.commitLog(path: repoPath, baseBranch: currentBranch)
-        #expect(log.isEmpty)
+        #expect(!log.isEmpty)
+        #expect(log.first?.subject == "Initial commit")
     }
 }

--- a/Tests/GitOperationsTests/WorktreeManagerTests.swift
+++ b/Tests/GitOperationsTests/WorktreeManagerTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Models
 import Testing
 
 @testable import GitOperations
@@ -365,6 +366,215 @@ private func withTempGitRepo(_ body: (String) async throws -> Void) async throws
         )
 
         #expect(!FileManager.default.fileExists(atPath: worktreePath))
+    }
+}
+
+// MARK: - deleteSession Worktree Protection (Roadmap: deleteSession(deleteWorktree: true))
+
+@Test func removeWorktreeProtectsUnmergedBranch() async throws {
+    // This is the dangerous path in RunwayStore.deleteSession(deleteWorktree: true):
+    // removeWorktree is called with deleteBranch: true, which uses `git branch -d` (safe delete).
+    // If the branch has unmerged commits, -d refuses and the branch survives.
+    try await withTempGitRepo { repoPath in
+        let manager = WorktreeManager()
+        let currentBranch = await manager.currentBranch(path: repoPath) ?? "main"
+
+        try FileManager.default.createDirectory(
+            atPath: "\(repoPath)/.worktrees",
+            withIntermediateDirectories: true
+        )
+
+        // Create a worktree with a new branch
+        let (worktreePath, actualBranch) = try await manager.createWorktree(
+            repoPath: repoPath,
+            branchName: "unmerged-work",
+            baseBranch: currentBranch
+        )
+
+        // Add an unmerged commit to the worktree branch
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = [
+            "-c",
+            """
+            echo 'important work' > work.txt && \
+            git add work.txt && \
+            git commit -m 'unmerged commit'
+            """,
+        ]
+        process.currentDirectoryURL = URL(fileURLWithPath: worktreePath)
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        try process.run()
+        process.waitUntilExit()
+
+        // Now delete the worktree with deleteBranch: true
+        // This is what RunwayStore.deleteSession does for deleteWorktree=true
+        try await manager.removeWorktree(
+            repoPath: repoPath,
+            worktreePath: worktreePath,
+            deleteBranch: true,
+            branchName: actualBranch
+        )
+
+        // The worktree directory should be gone
+        #expect(!FileManager.default.fileExists(atPath: worktreePath))
+
+        // But the branch should survive — git branch -d refuses to delete unmerged branches
+        let branchOutput = try await ShellRunner.runGit(in: repoPath, args: ["branch"])
+        let branches = branchOutput.components(separatedBy: "\n")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .map { $0.hasPrefix("* ") ? String($0.dropFirst(2)) : $0 }
+            .filter { !$0.isEmpty }
+        #expect(branches.contains(actualBranch))
+    }
+}
+
+@Test func removeWorktreeDeletesMergedBranch() async throws {
+    // Complement to the above: when the branch is fully merged, -d succeeds
+    try await withTempGitRepo { repoPath in
+        let manager = WorktreeManager()
+        let currentBranch = await manager.currentBranch(path: repoPath) ?? "main"
+
+        try FileManager.default.createDirectory(
+            atPath: "\(repoPath)/.worktrees",
+            withIntermediateDirectories: true
+        )
+
+        // Create a worktree with no extra commits (branch is at same commit as main)
+        let (worktreePath, actualBranch) = try await manager.createWorktree(
+            repoPath: repoPath,
+            branchName: "merged-work",
+            baseBranch: currentBranch
+        )
+
+        // Remove with deleteBranch: true — branch is already merged (same commit)
+        try await manager.removeWorktree(
+            repoPath: repoPath,
+            worktreePath: worktreePath,
+            deleteBranch: true,
+            branchName: actualBranch
+        )
+
+        // The worktree directory should be gone
+        #expect(!FileManager.default.fileExists(atPath: worktreePath))
+
+        // The branch should also be gone — it was fully merged
+        let branchOutput = try await ShellRunner.runGit(in: repoPath, args: ["branch"])
+        let branches = branchOutput.components(separatedBy: "\n")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .map { $0.hasPrefix("* ") ? String($0.dropFirst(2)) : $0 }
+            .filter { !$0.isEmpty }
+        #expect(!branches.contains(actualBranch))
+    }
+}
+
+// MARK: - Orphaned Worktree Cleanup (Roadmap: cleanOrphanedWorktrees)
+
+@Test func orphanedWorktreeCleanupPreservesOwnedAndProtectsUnmerged() async throws {
+    // Exercises the same WorktreeManager call sequence as RunwayStore.cleanOrphanedWorktrees():
+    // 1. pruneWorktrees  2. listWorktrees  3. identify orphans  4. isBranchMerged  5. removeWorktree
+    try await withTempGitRepo { repoPath in
+        let manager = WorktreeManager()
+        let currentBranch = await manager.currentBranch(path: repoPath) ?? "main"
+        let worktreePrefix = "\(repoPath)/.worktrees/"
+
+        try FileManager.default.createDirectory(
+            atPath: "\(repoPath)/.worktrees",
+            withIntermediateDirectories: true
+        )
+
+        // Create 3 worktrees:
+        // - "owned-session" — simulates a worktree linked to a live session
+        // - "orphan-merged" — orphaned worktree with no unmerged commits (should be fully deleted)
+        // - "orphan-unmerged" — orphaned worktree with unmerged commits (branch preserved)
+        let (ownedPath, _) = try await manager.createWorktree(
+            repoPath: repoPath, branchName: "owned-session", baseBranch: currentBranch)
+        let (orphanMergedPath, orphanMergedBranch) = try await manager.createWorktree(
+            repoPath: repoPath, branchName: "orphan-merged", baseBranch: currentBranch)
+        let (orphanUnmergedPath, orphanUnmergedBranch) = try await manager.createWorktree(
+            repoPath: repoPath, branchName: "orphan-unmerged", baseBranch: currentBranch)
+
+        // Add unmerged commit to the orphan-unmerged worktree
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = [
+            "-c",
+            """
+            echo 'data' > unmerged.txt && \
+            git add unmerged.txt && \
+            git commit -m 'unmerged work'
+            """,
+        ]
+        process.currentDirectoryURL = URL(fileURLWithPath: orphanUnmergedPath)
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        try process.run()
+        process.waitUntilExit()
+
+        // --- Simulate cleanOrphanedWorktrees logic ---
+
+        // Step 1: Build owned paths (only "owned-session" is in our set)
+        let ownedPaths = Set([
+            ownedPath,
+            URL(fileURLWithPath: ownedPath).resolvingSymlinksInPath().path,
+        ])
+
+        // Step 2: Prune + list
+        try await manager.pruneWorktrees(repoPath: repoPath)
+        let worktrees = try await manager.listWorktrees(repoPath: repoPath)
+
+        // Step 3: Identify orphans (managed by Runway + not owned by a session)
+        let orphans = worktrees.filter { wt in
+            let resolved = URL(fileURLWithPath: wt.path).resolvingSymlinksInPath().path
+            let isManaged = resolved.hasPrefix(worktreePrefix) || wt.path.hasPrefix(worktreePrefix)
+            let isOwned = ownedPaths.contains(wt.path) || ownedPaths.contains(resolved)
+            return isManaged && !isOwned
+        }
+
+        #expect(orphans.count == 2)
+
+        // Step 4+5: For each orphan, check merged status, remove accordingly
+        // Pass branchName explicitly (same data cleanOrphanedWorktrees has from the WorktreeInfo)
+        for orphan in orphans {
+            let branchName =
+                orphan.branch.isEmpty
+                ? URL(fileURLWithPath: orphan.path).lastPathComponent
+                : orphan.branch
+            let merged =
+                (try? await manager.isBranchMerged(
+                    repoPath: repoPath, branch: branchName, into: currentBranch)) ?? false
+
+            try await manager.removeWorktree(
+                repoPath: repoPath,
+                worktreePath: orphan.path,
+                deleteBranch: merged,
+                branchName: branchName
+            )
+        }
+
+        // --- Verify results ---
+
+        // Owned worktree should still exist
+        let resolvedOwned = URL(fileURLWithPath: ownedPath).resolvingSymlinksInPath().path
+        #expect(FileManager.default.fileExists(atPath: resolvedOwned))
+
+        // Both orphan directories should be gone
+        let resolvedMerged = URL(fileURLWithPath: orphanMergedPath).resolvingSymlinksInPath().path
+        let resolvedUnmerged = URL(fileURLWithPath: orphanUnmergedPath).resolvingSymlinksInPath().path
+        #expect(!FileManager.default.fileExists(atPath: resolvedMerged))
+        #expect(!FileManager.default.fileExists(atPath: resolvedUnmerged))
+
+        // Merged orphan's branch should be deleted
+        let branchOutput = try await ShellRunner.runGit(in: repoPath, args: ["branch"])
+        let branches = branchOutput.components(separatedBy: "\n")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .map { $0.hasPrefix("* ") ? String($0.dropFirst(2)) : $0 }
+            .filter { !$0.isEmpty }
+        #expect(!branches.contains(orphanMergedBranch))
+
+        // Unmerged orphan's branch should be PRESERVED
+        #expect(branches.contains(orphanUnmergedBranch))
     }
 }
 

--- a/Tests/ModelsTests/ShellRunnerTests.swift
+++ b/Tests/ModelsTests/ShellRunnerTests.swift
@@ -1,0 +1,70 @@
+import Foundation
+import Testing
+
+@testable import Models
+
+@Test func shellRunnerTimesOutLongProcess() async throws {
+    // `sleep 60` will never finish in 1 second — should throw .timeout
+    do {
+        _ = try await ShellRunner.run(
+            executable: "/bin/sleep",
+            args: ["60"],
+            timeout: .seconds(1)
+        )
+        Issue.record("Expected ShellError.timeout but run() succeeded")
+    } catch let error as ShellError {
+        guard case .timeout(let executable, let args) = error else {
+            Issue.record("Expected .timeout but got \(error)")
+            return
+        }
+        #expect(executable == "/bin/sleep")
+        #expect(args == ["60"])
+    }
+}
+
+@Test func shellRunnerSucceedsWithinTimeout() async throws {
+    let output = try await ShellRunner.run(
+        executable: "/bin/echo",
+        args: ["hello"],
+        timeout: .seconds(10)
+    )
+    #expect(output.trimmingCharacters(in: .whitespacesAndNewlines) == "hello")
+}
+
+@Test func shellRunnerReportsNonZeroExitAsCommandFailed() async throws {
+    // /usr/bin/false always exits with status 1
+    do {
+        _ = try await ShellRunner.run(
+            executable: "/usr/bin/false",
+            args: [],
+            timeout: .seconds(5)
+        )
+        Issue.record("Expected ShellError.commandFailed but run() succeeded")
+    } catch let error as ShellError {
+        guard case .commandFailed(_, _, let exitCode, _) = error else {
+            Issue.record("Expected .commandFailed but got \(error)")
+            return
+        }
+        #expect(exitCode == 1)
+    }
+}
+
+@Test func shellRunnerTimeoutErrorDescription() throws {
+    let error = ShellError.timeout(executable: "/usr/bin/git", args: ["fetch"])
+    let description = try #require(error.errorDescription)
+    #expect(description.contains("git"))
+    #expect(description.contains("timed out"))
+}
+
+@Test func shellRunnerCommandFailedErrorDescription() throws {
+    let error = ShellError.commandFailed(
+        executable: "/usr/bin/git",
+        args: ["checkout", "missing"],
+        exitCode: 128,
+        stderr: "pathspec 'missing' did not match"
+    )
+    let description = try #require(error.errorDescription)
+    #expect(description.contains("git"))
+    #expect(description.contains("exit 128"))
+    #expect(description.contains("pathspec"))
+}

--- a/Tests/StatusDetectionTests/HookServerTests.swift
+++ b/Tests/StatusDetectionTests/HookServerTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Models
 import Testing
 
 @testable import StatusDetection
@@ -36,6 +37,88 @@ import Testing
     let (_, response) = try await URLSession.shared.data(for: request)
     let httpResponse = try #require(response as? HTTPURLResponse)
     #expect(httpResponse.statusCode == 200)
+}
+
+@Test func hookServerDispatchesDecodedEventToHandler() async throws {
+    let server = HookServer(port: 0)
+
+    // Register handler BEFORE start — same pattern as RunwayStore.startHookServer()
+    let receivedEvent = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<HookEvent, Error>) in
+        Task {
+            await server.onEvent { event in
+                continuation.resume(returning: event)
+            }
+
+            try await server.start()
+            let portValue = try #require(await server.actualPort)
+
+            // Build a proper JSON body using HookEvent's snake_case CodingKeys
+            let body: [String: Any] = [
+                "session_id": "original-session-id",
+                "hook_event_name": "Stop",
+                "cwd": "/tmp/test",
+                "total_cost_usd": 0.42,
+                "total_input_tokens": 1000,
+                "total_output_tokens": 500,
+            ]
+
+            let url = try #require(URL(string: "http://127.0.0.1:\(portValue)/hooks"))
+            var request = URLRequest(url: url)
+            request.httpMethod = "POST"
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            // X-Runway-Session-Id overrides session_id in the body
+            request.setValue("runway-session-abc", forHTTPHeaderField: "X-Runway-Session-Id")
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+            let (_, response) = try await URLSession.shared.data(for: request)
+            let httpResponse = try #require(response as? HTTPURLResponse)
+            #expect(httpResponse.statusCode == 200)
+        }
+    }
+    defer { Task { await server.stop() } }
+
+    // Verify the handler received the correctly decoded event
+    // sessionID should be overridden by the X-Runway-Session-Id header
+    #expect(receivedEvent.sessionID == "runway-session-abc")
+    #expect(receivedEvent.event == .stop)
+    #expect(receivedEvent.cwd == "/tmp/test")
+    #expect(receivedEvent.totalCostUSD == 0.42)
+    #expect(receivedEvent.totalInputTokens == 1000)
+    #expect(receivedEvent.totalOutputTokens == 500)
+}
+
+@Test func hookServerDispatchesEventWithOriginalSessionID() async throws {
+    let server = HookServer(port: 0)
+
+    let receivedEvent = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<HookEvent, Error>) in
+        Task {
+            await server.onEvent { event in
+                continuation.resume(returning: event)
+            }
+
+            try await server.start()
+            let portValue = try #require(await server.actualPort)
+
+            // No X-Runway-Session-Id header — should use session_id from body
+            let body: [String: Any] = [
+                "session_id": "body-session-id",
+                "hook_event_name": "SessionStart",
+            ]
+
+            let url = try #require(URL(string: "http://127.0.0.1:\(portValue)/hooks"))
+            var request = URLRequest(url: url)
+            request.httpMethod = "POST"
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+            _ = try await URLSession.shared.data(for: request)
+        }
+    }
+    defer { Task { await server.stop() } }
+
+    // Without the header override, sessionID comes from the JSON body
+    #expect(receivedEvent.sessionID == "body-session-id")
+    #expect(receivedEvent.event == .sessionStart)
 }
 
 @Test func twoHookServersRunSimultaneously() async throws {

--- a/Tests/TerminalViewTests/TerminalSessionCacheTests.swift
+++ b/Tests/TerminalViewTests/TerminalSessionCacheTests.swift
@@ -1,0 +1,133 @@
+import AppKit
+import SwiftTerm
+import Testing
+
+@testable import TerminalView
+
+// MARK: - LRU Eviction
+
+@MainActor @Test func cacheEvictsLeastRecentlyUsedEntry() {
+    let cache = TerminalSessionCache(maxSize: 2)
+
+    // Insert two entries — cache at capacity
+    let view1 = cache.terminalView(forSessionID: "s1", tabID: "t1") {
+        LocalProcessTerminalView(frame: .zero)
+    }
+    let view2 = cache.terminalView(forSessionID: "s2", tabID: "t2") {
+        LocalProcessTerminalView(frame: .zero)
+    }
+
+    #expect(cache.has(sessionID: "s1", tabID: "t1"))
+    #expect(cache.has(sessionID: "s2", tabID: "t2"))
+
+    // Insert a third — oldest (s1) should be evicted
+    let view3 = cache.terminalView(forSessionID: "s3", tabID: "t3") {
+        LocalProcessTerminalView(frame: .zero)
+    }
+
+    #expect(!cache.has(sessionID: "s1", tabID: "t1"))  // evicted
+    #expect(cache.has(sessionID: "s2", tabID: "t2"))  // kept
+    #expect(cache.has(sessionID: "s3", tabID: "t3"))  // new
+}
+
+@MainActor @Test func accessRefreshesLRUOrder() {
+    let cache = TerminalSessionCache(maxSize: 2)
+
+    // Insert s1 first, then s2
+    _ = cache.terminalView(forSessionID: "s1", tabID: "t1") {
+        LocalProcessTerminalView(frame: .zero)
+    }
+    _ = cache.terminalView(forSessionID: "s2", tabID: "t2") {
+        LocalProcessTerminalView(frame: .zero)
+    }
+
+    // Access s1 again — this should refresh its timestamp
+    _ = cache.terminalView(forSessionID: "s1", tabID: "t1") {
+        LocalProcessTerminalView(frame: .zero)  // factory won't be called (cache hit)
+    }
+
+    // Insert s3 — s2 should now be evicted (it's the oldest)
+    _ = cache.terminalView(forSessionID: "s3", tabID: "t3") {
+        LocalProcessTerminalView(frame: .zero)
+    }
+
+    #expect(cache.has(sessionID: "s1", tabID: "t1"))  // refreshed, kept
+    #expect(!cache.has(sessionID: "s2", tabID: "t2"))  // evicted
+    #expect(cache.has(sessionID: "s3", tabID: "t3"))  // new
+}
+
+// MARK: - Get-or-Create
+
+@MainActor @Test func cacheReturnsSameViewOnHit() {
+    let cache = TerminalSessionCache(maxSize: 5)
+
+    let view1 = cache.terminalView(forSessionID: "s1", tabID: "t1") {
+        LocalProcessTerminalView(frame: .zero)
+    }
+
+    var factoryCalled = false
+    let view2 = cache.terminalView(forSessionID: "s1", tabID: "t1") {
+        factoryCalled = true
+        return LocalProcessTerminalView(frame: .zero)
+    }
+
+    #expect(view1 === view2)
+    #expect(!factoryCalled)
+}
+
+// MARK: - Removal
+
+@MainActor @Test func removeAllClearsAllTabsForSession() {
+    let cache = TerminalSessionCache(maxSize: 10)
+
+    _ = cache.terminalView(forSessionID: "s1", tabID: "tab-a") {
+        LocalProcessTerminalView(frame: .zero)
+    }
+    _ = cache.terminalView(forSessionID: "s1", tabID: "tab-b") {
+        LocalProcessTerminalView(frame: .zero)
+    }
+    _ = cache.terminalView(forSessionID: "s2", tabID: "tab-a") {
+        LocalProcessTerminalView(frame: .zero)
+    }
+
+    cache.removeAll(forSessionID: "s1")
+
+    #expect(!cache.has(sessionID: "s1", tabID: "tab-a"))
+    #expect(!cache.has(sessionID: "s1", tabID: "tab-b"))
+    #expect(cache.has(sessionID: "s2", tabID: "tab-a"))  // unaffected
+}
+
+@MainActor @Test func removeSingleEntry() {
+    let cache = TerminalSessionCache(maxSize: 10)
+
+    _ = cache.terminalView(forSessionID: "s1", tabID: "tab-a") {
+        LocalProcessTerminalView(frame: .zero)
+    }
+    _ = cache.terminalView(forSessionID: "s1", tabID: "tab-b") {
+        LocalProcessTerminalView(frame: .zero)
+    }
+
+    cache.remove(sessionID: "s1", tabID: "tab-a")
+
+    #expect(!cache.has(sessionID: "s1", tabID: "tab-a"))
+    #expect(cache.has(sessionID: "s1", tabID: "tab-b"))
+}
+
+// MARK: - Read-only Accessors
+
+@MainActor @Test func mainTerminalUsesExpectedKeyFormat() {
+    let cache = TerminalSessionCache(maxSize: 10)
+
+    // mainTerminal looks for key "id_id_main"
+    _ = cache.terminalView(forSessionID: "sess-1", tabID: "sess-1_main") {
+        LocalProcessTerminalView(frame: .zero)
+    }
+
+    let terminal = cache.mainTerminal(forSessionID: "sess-1")
+    #expect(terminal != nil)
+}
+
+@MainActor @Test func existingReturnsNilForMissingEntry() {
+    let cache = TerminalSessionCache(maxSize: 10)
+    #expect(cache.existing(sessionID: "nonexistent", tabID: "t1") == nil)
+}


### PR DESCRIPTION
## Summary

Completes the entire v1.0 roadmap from the 10-agent audit. 7 commits, 56 files changed, +3217/-1000 lines, 312 → 329 tests.

**High Priority**
- **17 tests** covering ShellRunner timeout, TerminalSessionCache LRU eviction, HookServer e2e event dispatch, deleteSession worktree protection, orphaned worktree cleanup flow
- **PRCoordinator extraction** — 496 LOC moved to separate `@Observable` class, RunwayStore 1818 → 1391 LOC. PR poll ticks no longer invalidate terminal/sidebar/session views
- **VoiceOver accessibility** — 14 `.accessibilityLabel()` additions across 8 view files (DiffView, FileTreeView, PRDashboardView, SessionHeaderView, etc.)
- **Bug fix**: `isBranchMerged` didn't strip `+ ` prefix from `git branch --merged` output, causing `cleanOrphanedWorktrees` to never delete merged orphan branches

**Medium Priority**
- **CommitHistoryView** with rollback — popover from session header showing branch commits with confirmation dialog
- **TabBarButton** shared component replacing 2 duplicate tab bar implementations
- **ActiveSheet enum** replacing 4 independent sheet booleans with `.sheet(item:)`
- **Adaptive sheet widths** — 5 sheets switched from hardcoded `frame(width:)` to `minWidth`/`idealWidth`/`maxWidth`

**Low Priority (9 items)**
- DatabaseQueue → DatabasePool (concurrent reads via WAL)
- Color(hex:) deduplication (3 → 1 in Theme module)
- startSessionFromIssue uses project's most recent session tool
- async let actor serialization fix (nonisolated static helper)
- enrichPath timeout 3s → 1s
- PullRequest + CheckSummary Equatable conformance
- Database test init precondition removed
- HookServer tracks + cancels in-flight connections on stop()
- Provisioning Tasks tracked and cancelled on session delete

## Test plan
- [x] `swift build` passes
- [x] `swift test` — 329 tests pass (all existing + 17 new)
- [x] Pre-commit hooks (swiftlint + swift-format) pass on all commits
- [x] Manual: verify PRCoordinator wiring — PR dashboard loads, poll works, approve/merge/close actions
- [ ] Manual: verify CommitHistoryView popover appears from clock icon next to branch name
- [ ] Manual: verify ActiveSheet — only one sheet can be open at a time
- [ ] Manual: verify VoiceOver reads labels on icon-only buttons