### PR TITLE
feat: sidebar comment indicators for PR feedback

### DIFF
--- a/Sources/App/PRCoordinator.swift
+++ b/Sources/App/PRCoordinator.swift
@@ -149,7 +149,7 @@ public final class PRCoordinator {
                 let host = prManager.hostFromURL(pr.url)
                 group.addTask { [prManager] in
                     let result = try? await prManager.enrichChecks(
-                        repo: pr.repo, number: pr.number, host: host
+                        repo: pr.repo, number: pr.number, author: pr.author, host: host
                     )
                     return (pr.id, result)
                 }
@@ -182,7 +182,7 @@ public final class PRCoordinator {
         let host = prManager.hostFromURL(pr.url)
         guard
             let result = try? await prManager.enrichChecks(
-                repo: pr.repo, number: pr.number, host: host
+                repo: pr.repo, number: pr.number, author: pr.author, host: host
             )
         else { return }
 
@@ -205,6 +205,8 @@ public final class PRCoordinator {
         pr.mergeable = result.mergeable
         pr.mergeStateStatus = result.mergeStateStatus
         pr.autoMergeEnabled = result.autoMergeEnabled
+        pr.commentsSinceLastCommit = result.commentsSinceLastCommit
+        pr.lastCommitDate = result.lastCommitDate
         pr.enrichedAt = Date()
     }
 

--- a/Sources/GitHubOperations/PRManager.swift
+++ b/Sources/GitHubOperations/PRManager.swift
@@ -657,7 +657,12 @@ private struct GHPRDetailResponse: Decodable {
             PRReview(id: r.id ?? "0", author: r.author?.login ?? "", state: r.state ?? "", body: r.body ?? "")
         }
         let mappedComments: [PRComment] = (comments ?? []).map { comment in
-            PRComment(id: comment.id ?? "0", author: comment.author?.login ?? "", body: comment.body ?? "")
+            PRComment(
+                id: comment.id ?? "0",
+                author: comment.author?.login ?? "",
+                body: comment.body ?? "",
+                createdAt: comment.createdAt ?? Date()
+            )
         }
         let mappedFiles: [PRFileChange] = (files ?? []).map { file in
             PRFileChange(path: file.path ?? "", additions: file.additions ?? 0, deletions: file.deletions ?? 0, patch: file.patch)
@@ -728,23 +733,29 @@ private struct GHReview: Decodable {
 private struct GHComment: Decodable {
     let author: GHAuthor?
     let body: String?
+    let createdAt: Date?
 
     let id: String?
 
     enum CodingKeys: String, CodingKey {
-        case id, author, body
+        case id, author, body, createdAt
     }
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         author = try container.decodeIfPresent(GHAuthor.self, forKey: .author)
         body = try container.decodeIfPresent(String.self, forKey: .body)
+        createdAt = try container.decodeIfPresent(Date.self, forKey: .createdAt)
         if let intID = try? container.decodeIfPresent(Int.self, forKey: .id) {
             id = "\(intID)"
         } else {
             id = try container.decodeIfPresent(String.self, forKey: .id)
         }
     }
+}
+
+private struct GHCommit: Decodable {
+    let committedDate: Date?
 }
 
 /// Lightweight response for enrichChecks — only the fields needed for list display.

--- a/Sources/GitHubOperations/PRManager.swift
+++ b/Sources/GitHubOperations/PRManager.swift
@@ -13,13 +13,17 @@ public struct PREnrichResult: Sendable {
     public var mergeable: MergeableState?
     public var mergeStateStatus: MergeStateStatus?
     public var autoMergeEnabled: Bool
+    public var commentsSinceLastCommit: Int
+    public var lastCommitDate: Date?
 
     public init(
         checks: CheckSummary = CheckSummary(), reviewDecision: ReviewDecision = .none,
         headBranch: String = "", baseBranch: String = "",
         additions: Int = 0, deletions: Int = 0, changedFiles: Int = 0,
         mergeable: MergeableState? = nil, mergeStateStatus: MergeStateStatus? = nil,
-        autoMergeEnabled: Bool = false
+        autoMergeEnabled: Bool = false,
+        commentsSinceLastCommit: Int = 0,
+        lastCommitDate: Date? = nil
     ) {
         self.checks = checks
         self.reviewDecision = reviewDecision
@@ -31,6 +35,8 @@ public struct PREnrichResult: Sendable {
         self.mergeable = mergeable
         self.mergeStateStatus = mergeStateStatus
         self.autoMergeEnabled = autoMergeEnabled
+        self.commentsSinceLastCommit = commentsSinceLastCommit
+        self.lastCommitDate = lastCommitDate
     }
 }
 
@@ -119,19 +125,19 @@ public actor PRManager {
 
     /// Lightweight enrichment — fetch only checks and review decision for list display.
     /// Single subprocess per PR (vs fetchDetail's 2).
-    public func enrichChecks(repo: String, number: Int, host: String? = nil) async throws -> PREnrichResult {
+    public func enrichChecks(repo: String, number: Int, author: String? = nil, host: String? = nil) async throws -> PREnrichResult {
         let output = try await runGH(
             args: [
                 "pr", "view", "\(number)",
                 "--repo", repo,
                 "--json",
-                "statusCheckRollup,reviewDecision,headRefName,baseRefName,additions,deletions,changedFiles,mergeable,mergeStateStatus,autoMergeRequest",
+                "statusCheckRollup,reviewDecision,headRefName,baseRefName,additions,deletions,changedFiles,mergeable,mergeStateStatus,autoMergeRequest,comments,commits",
             ], host: host)
         guard let data = output.data(using: .utf8) else {
             return PREnrichResult()
         }
         let resp = try JSONDecoder.gh.decode(GHEnrichResponse.self, from: data)
-        return resp.toEnrichResult()
+        return resp.toEnrichResult(excludeAuthor: author)
     }
 
     /// Fetch detailed PR information including per-file diffs.
@@ -770,8 +776,10 @@ private struct GHEnrichResponse: Decodable {
     let mergeable: String?
     let mergeStateStatus: String?
     let autoMergeRequest: GHAutoMergeRequest?
+    let comments: [GHComment]?
+    let commits: [GHCommit]?
 
-    func toEnrichResult() -> PREnrichResult {
+    func toEnrichResult(excludeAuthor: String? = nil) -> PREnrichResult {
         let checks = parseChecks(statusCheckRollup ?? [])
         let review: ReviewDecision
         switch reviewDecision?.uppercased() {
@@ -780,14 +788,36 @@ private struct GHEnrichResponse: Decodable {
         case "REVIEW_REQUIRED": review = .pending
         default: review = .none
         }
+
+        let lastCommitDate = commits?.last?.committedDate
+        let commentsSinceLastCommit = Self.countCommentsSinceCommit(
+            comments: comments, lastCommitDate: lastCommitDate, excludeAuthor: excludeAuthor
+        )
+
         return PREnrichResult(
             checks: checks, reviewDecision: review,
             headBranch: headRefName ?? "", baseBranch: baseRefName ?? "",
             additions: additions ?? 0, deletions: deletions ?? 0, changedFiles: changedFiles ?? 0,
             mergeable: MergeableState(rawValue: mergeable ?? ""),
             mergeStateStatus: MergeStateStatus(rawValue: mergeStateStatus ?? ""),
-            autoMergeEnabled: autoMergeRequest != nil
+            autoMergeEnabled: autoMergeRequest != nil,
+            commentsSinceLastCommit: commentsSinceLastCommit,
+            lastCommitDate: lastCommitDate
         )
+    }
+
+    private static func countCommentsSinceCommit(
+        comments: [GHComment]?,
+        lastCommitDate: Date?,
+        excludeAuthor: String?
+    ) -> Int {
+        guard let comments, let commitDate = lastCommitDate else { return 0 }
+        return comments.filter { comment in
+            guard let createdAt = comment.createdAt else { return false }
+            if createdAt <= commitDate { return false }
+            if let exclude = excludeAuthor, comment.author?.login == exclude { return false }
+            return true
+        }.count
     }
 }
 

--- a/Sources/Models/PullRequest.swift
+++ b/Sources/Models/PullRequest.swift
@@ -24,6 +24,8 @@ public struct PullRequest: Identifiable, Codable, Sendable, Equatable {
     public var mergeable: MergeableState?
     public var mergeStateStatus: MergeStateStatus?
     public var autoMergeEnabled: Bool
+    public var commentsSinceLastCommit: Int
+    public var lastCommitDate: Date?
 
     public init(
         number: Int,
@@ -46,7 +48,9 @@ public struct PullRequest: Identifiable, Codable, Sendable, Equatable {
         origin: Set<PROrigin> = [],
         mergeable: MergeableState? = nil,
         mergeStateStatus: MergeStateStatus? = nil,
-        autoMergeEnabled: Bool = false
+        autoMergeEnabled: Bool = false,
+        commentsSinceLastCommit: Int = 0,
+        lastCommitDate: Date? = nil
     ) {
         self.id = "\(repo)#\(number)"
         self.number = number
@@ -70,6 +74,8 @@ public struct PullRequest: Identifiable, Codable, Sendable, Equatable {
         self.mergeable = mergeable
         self.mergeStateStatus = mergeStateStatus
         self.autoMergeEnabled = autoMergeEnabled
+        self.commentsSinceLastCommit = commentsSinceLastCommit
+        self.lastCommitDate = lastCommitDate
     }
 
     public var needsEnrichment: Bool {

--- a/Sources/Views/Shared/PRBadges.swift
+++ b/Sources/Views/Shared/PRBadges.swift
@@ -159,6 +159,31 @@ public struct ReviewDecisionBadge: View {
     }
 }
 
+// MARK: - CommentCountBadge
+
+/// Accent-colored badge showing the count of PR comments from others since the last commit.
+///
+/// Hidden when count is zero. Used in sidebar session rows as an "action needed" signal.
+public struct CommentCountBadge: View {
+    let count: Int
+    @Environment(\.theme) private var theme
+
+    public init(count: Int) {
+        self.count = count
+    }
+
+    public var body: some View {
+        if count > 0 {  // swiftlint:disable:this empty_count
+            HStack(spacing: 2) {
+                Image(systemName: "bubble.left.fill")
+                Text("\(count)")
+            }
+            .font(.caption2)
+            .foregroundColor(theme.chrome.accent)
+        }
+    }
+}
+
 // MARK: - MergeStatusBadge
 
 /// Capsule badge showing PR merge status (Clean, Conflicts, Behind, Blocked, etc.).

--- a/Sources/Views/Sidebar/ProjectTreeView.swift
+++ b/Sources/Views/Sidebar/ProjectTreeView.swift
@@ -461,6 +461,7 @@ struct SessionRowView: View {
                         .help("View PR #\(pr.number) details")
                         CheckSummaryBadge(checks: pr.checks)
                         ReviewDecisionBadge(decision: pr.reviewDecision, style: .iconOnly)
+                        CommentCountBadge(count: pr.commentsSinceLastCommit)
                         if pr.additions > 0 || pr.deletions > 0 {
                             HStack(spacing: 1) {
                                 Text("+\(pr.additions)")

--- a/Tests/GitHubOperationsTests/PRManagerTests.swift
+++ b/Tests/GitHubOperationsTests/PRManagerTests.swift
@@ -91,6 +91,14 @@ import Testing
     _ = manager
 }
 
+// MARK: - PREnrichResult
+
+@Test func prEnrichResultCommentDefaults() {
+    let result = PREnrichResult()
+    #expect(result.commentsSinceLastCommit == 0)
+    #expect(result.lastCommitDate == nil)
+}
+
 // MARK: - PROrigin Integration
 
 @Test func prOriginSetOperations() {

--- a/Tests/ModelsTests/PullRequestTests.swift
+++ b/Tests/ModelsTests/PullRequestTests.swift
@@ -133,3 +133,11 @@ import Testing
     pr.enrichedAt = Date().addingTimeInterval(-60)  // 1 minute ago
     #expect(pr.needsEnrichment == false)
 }
+
+@Test func pullRequestCommentFieldDefaults() {
+    let pr = PullRequest(
+        number: 1, title: "Test", state: .open, headBranch: "f",
+        baseBranch: "main", author: "me", repo: "r")
+    #expect(pr.commentsSinceLastCommit == 0)
+    #expect(pr.lastCommitDate == nil)
+}

--- a/docs/superpowers/plans/2026-04-14-sidebar-comment-indicators.md
+++ b/docs/superpowers/plans/2026-04-14-sidebar-comment-indicators.md
@@ -1,0 +1,440 @@
+# Sidebar Comment Indicators Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show an accent-colored badge in the sidebar session row indicating the count of PR comments from others since the last commit, so users can see at a glance when feedback needs attention.
+
+**Architecture:** Add `commentsSinceLastCommit` and `lastCommitDate` fields to `PullRequest` and `PREnrichResult`. Expand the existing `enrichChecks()` gh query to also fetch `comments` and `commits`, compute the filtered count in `PRManager`, and display it via a new `CommentCountBadge` view in the sidebar row. Also fix the existing `GHComment` struct to decode `createdAt` (currently missing, affecting detail view comment timestamps).
+
+**Tech Stack:** Swift, SwiftUI, gh CLI (JSON output), Swift Testing framework
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `Sources/Models/PullRequest.swift` | Modify | Add `commentsSinceLastCommit` and `lastCommitDate` fields to `PullRequest` |
+| `Sources/GitHubOperations/PRManager.swift` | Modify | Add `createdAt` to `GHComment`, add `GHCommit` struct, expand `GHEnrichResponse` and `enrichChecks()`, update `GHPRDetailResponse.toPRDetail()` comment mapping |
+| `Sources/App/PRCoordinator.swift` | Modify | Apply new fields in `applyEnrichment()` |
+| `Sources/Views/Shared/PRBadges.swift` | Modify | Add `CommentCountBadge` view |
+| `Sources/Views/Sidebar/ProjectTreeView.swift` | Modify | Insert `CommentCountBadge` in `SessionRowView` |
+| `Tests/ModelsTests/PullRequestTests.swift` | Modify | Test new field defaults |
+| `Tests/GitHubOperationsTests/PRManagerTests.swift` | Modify | Test `PREnrichResult` new field defaults |
+
+---
+
+### Task 1: Add model fields to PullRequest
+
+**Files:**
+- Modify: `Sources/Models/PullRequest.swift:4-73`
+- Test: `Tests/ModelsTests/PullRequestTests.swift`
+
+- [ ] **Step 1: Write failing test for new PullRequest defaults**
+
+Add to `Tests/ModelsTests/PullRequestTests.swift`:
+
+```swift
+@Test func pullRequestCommentFieldDefaults() {
+    let pr = PullRequest(
+        number: 1, title: "Test", state: .open, headBranch: "f",
+        baseBranch: "main", author: "me", repo: "r")
+    #expect(pr.commentsSinceLastCommit == 0)
+    #expect(pr.lastCommitDate == nil)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `swift test --filter PullRequestTests/pullRequestCommentFieldDefaults`
+Expected: FAIL — `PullRequest` has no member `commentsSinceLastCommit`
+
+- [ ] **Step 3: Add fields to PullRequest struct**
+
+In `Sources/Models/PullRequest.swift`, add two new properties after `autoMergeEnabled` (line 26):
+
+```swift
+public var commentsSinceLastCommit: Int
+public var lastCommitDate: Date?
+```
+
+Add matching parameters to the `init` (after `autoMergeEnabled: Bool = false` on line 49), with defaults:
+
+```swift
+commentsSinceLastCommit: Int = 0,
+lastCommitDate: Date? = nil
+```
+
+And the assignments in the init body (after `self.autoMergeEnabled = autoMergeEnabled` on line 72):
+
+```swift
+self.commentsSinceLastCommit = commentsSinceLastCommit
+self.lastCommitDate = lastCommitDate
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `swift test --filter PullRequestTests/pullRequestCommentFieldDefaults`
+Expected: PASS
+
+- [ ] **Step 5: Run full model tests to check for regressions**
+
+Run: `swift test --filter ModelsTests`
+Expected: All tests pass — existing callers use defaults
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/Models/PullRequest.swift Tests/ModelsTests/PullRequestTests.swift
+git commit -m "feat: add commentsSinceLastCommit and lastCommitDate to PullRequest model"
+```
+
+---
+
+### Task 2: Fix GHComment to decode createdAt and add GHCommit struct
+
+**Files:**
+- Modify: `Sources/GitHubOperations/PRManager.swift:728-748` (GHComment)
+- Modify: `Sources/GitHubOperations/PRManager.swift:659-661` (toPRDetail mapping)
+
+- [ ] **Step 1: Add `createdAt` to GHComment**
+
+In `Sources/GitHubOperations/PRManager.swift`, update the `GHComment` struct (line 728):
+
+```swift
+private struct GHComment: Decodable {
+    let author: GHAuthor?
+    let body: String?
+    let createdAt: Date?
+
+    let id: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id, author, body, createdAt
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        author = try container.decodeIfPresent(GHAuthor.self, forKey: .author)
+        body = try container.decodeIfPresent(String.self, forKey: .body)
+        createdAt = try container.decodeIfPresent(Date.self, forKey: .createdAt)
+        if let intID = try? container.decodeIfPresent(Int.self, forKey: .id) {
+            id = "\(intID)"
+        } else {
+            id = try container.decodeIfPresent(String.self, forKey: .id)
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Update toPRDetail() comment mapping to pass createdAt**
+
+In `Sources/GitHubOperations/PRManager.swift`, update the `mappedComments` mapping (line 659-661):
+
+```swift
+let mappedComments: [PRComment] = (comments ?? []).map { comment in
+    PRComment(
+        id: comment.id ?? "0",
+        author: comment.author?.login ?? "",
+        body: comment.body ?? "",
+        createdAt: comment.createdAt ?? Date()
+    )
+}
+```
+
+- [ ] **Step 3: Add GHCommit struct**
+
+Add this struct after the `GHComment` struct (after line 748):
+
+```swift
+private struct GHCommit: Decodable {
+    let committedDate: Date?
+}
+```
+
+- [ ] **Step 4: Run existing tests to verify no regressions**
+
+Run: `swift test --filter GitHubOperationsTests`
+Expected: All tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/GitHubOperations/PRManager.swift
+git commit -m "fix: decode createdAt in GHComment, add GHCommit struct"
+```
+
+---
+
+### Task 3: Expand enrichChecks() to compute comment count
+
+**Files:**
+- Modify: `Sources/GitHubOperations/PRManager.swift:1-35` (PREnrichResult)
+- Modify: `Sources/GitHubOperations/PRManager.swift:122-135` (enrichChecks method)
+- Modify: `Sources/GitHubOperations/PRManager.swift:751-781` (GHEnrichResponse)
+- Test: `Tests/GitHubOperationsTests/PRManagerTests.swift`
+
+- [ ] **Step 1: Write failing test for PREnrichResult new defaults**
+
+Add to `Tests/GitHubOperationsTests/PRManagerTests.swift`:
+
+```swift
+@Test func prEnrichResultCommentDefaults() {
+    let result = PREnrichResult()
+    #expect(result.commentsSinceLastCommit == 0)
+    #expect(result.lastCommitDate == nil)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `swift test --filter GitHubOperationsTests/prEnrichResultCommentDefaults`
+Expected: FAIL — `PREnrichResult` has no member `commentsSinceLastCommit`
+
+- [ ] **Step 3: Add fields to PREnrichResult**
+
+In `Sources/GitHubOperations/PRManager.swift`, add to the `PREnrichResult` struct (after `autoMergeEnabled` on line 15):
+
+```swift
+public var commentsSinceLastCommit: Int
+public var lastCommitDate: Date?
+```
+
+Update the init (after `autoMergeEnabled: Bool = false` on line 22) to add:
+
+```swift
+commentsSinceLastCommit: Int = 0,
+lastCommitDate: Date? = nil
+```
+
+And the init body (after `self.autoMergeEnabled = autoMergeEnabled` on line 33):
+
+```swift
+self.commentsSinceLastCommit = commentsSinceLastCommit
+self.lastCommitDate = lastCommitDate
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `swift test --filter GitHubOperationsTests/prEnrichResultCommentDefaults`
+Expected: PASS
+
+- [ ] **Step 5: Expand GHEnrichResponse to decode comments and commits**
+
+In `Sources/GitHubOperations/PRManager.swift`, update the `GHEnrichResponse` struct (line 751) to add two new fields:
+
+```swift
+let comments: [GHComment]?
+let commits: [GHCommit]?
+```
+
+Update `toEnrichResult()` to accept an `excludeAuthor` parameter and compute the filtered count. Change the signature and add the computation before the `return`:
+
+```swift
+func toEnrichResult(excludeAuthor: String? = nil) -> PREnrichResult {
+    // ... existing checks/review parsing unchanged ...
+
+    let lastCommitDate = commits?.last?.committedDate
+    let commentsSinceLastCommit = Self.countCommentsSinceCommit(
+        comments: comments, lastCommitDate: lastCommitDate, excludeAuthor: excludeAuthor
+    )
+
+    return PREnrichResult(
+        checks: checks, reviewDecision: review,
+        headBranch: headRefName ?? "", baseBranch: baseRefName ?? "",
+        additions: additions ?? 0, deletions: deletions ?? 0, changedFiles: changedFiles ?? 0,
+        mergeable: MergeableState(rawValue: mergeable ?? ""),
+        mergeStateStatus: MergeStateStatus(rawValue: mergeStateStatus ?? ""),
+        autoMergeEnabled: autoMergeRequest != nil,
+        commentsSinceLastCommit: commentsSinceLastCommit,
+        lastCommitDate: lastCommitDate
+    )
+}
+```
+
+Add a static helper method on `GHEnrichResponse`:
+
+```swift
+private static func countCommentsSinceCommit(
+    comments: [GHComment]?,
+    lastCommitDate: Date?,
+    excludeAuthor: String?
+) -> Int {
+    guard let comments, let commitDate = lastCommitDate else { return 0 }
+    return comments.filter { comment in
+        guard let createdAt = comment.createdAt else { return false }
+        if createdAt <= commitDate { return false }
+        if let exclude = excludeAuthor, comment.author?.login == exclude { return false }
+        return true
+    }.count
+}
+```
+
+- [ ] **Step 6: Update enrichChecks() method to pass author and expand JSON fields**
+
+Update the `enrichChecks()` method (line 122-135) to:
+
+1. Add `author` parameter:
+```swift
+public func enrichChecks(repo: String, number: Int, author: String? = nil, host: String? = nil) async throws -> PREnrichResult
+```
+
+2. Expand the `--json` field list to include `comments,commits`:
+```swift
+"statusCheckRollup,reviewDecision,headRefName,baseRefName,additions,deletions,changedFiles,mergeable,mergeStateStatus,autoMergeRequest,comments,commits",
+```
+
+3. Pass the author through to `toEnrichResult`:
+```swift
+return resp.toEnrichResult(excludeAuthor: author)
+```
+
+- [ ] **Step 7: Run all tests**
+
+Run: `swift test --filter GitHubOperationsTests`
+Expected: All tests pass
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Sources/GitHubOperations/PRManager.swift Tests/GitHubOperationsTests/PRManagerTests.swift
+git commit -m "feat: expand enrichChecks to compute comment count since last commit"
+```
+
+---
+
+### Task 4: Apply enrichment in PRCoordinator
+
+**Files:**
+- Modify: `Sources/App/PRCoordinator.swift:195-209` (applyEnrichment)
+- Modify: `Sources/App/PRCoordinator.swift:148-155` (enrichPRs task group, pass author)
+
+- [ ] **Step 1: Update applyEnrichment to include new fields**
+
+In `Sources/App/PRCoordinator.swift`, add two lines to `applyEnrichment()` (after `pr.autoMergeEnabled = result.autoMergeEnabled` on line 207):
+
+```swift
+pr.commentsSinceLastCommit = result.commentsSinceLastCommit
+pr.lastCommitDate = result.lastCommitDate
+```
+
+- [ ] **Step 2: Pass PR author to enrichChecks call**
+
+In `Sources/App/PRCoordinator.swift`, update the `enrichChecks` call inside the task group in `enrichPRs()` (around line 151) to pass the author:
+
+```swift
+let result = try? await prManager.enrichChecks(
+    repo: pr.repo, number: pr.number, author: pr.author, host: host
+)
+```
+
+Also update the `reEnrichPR` method's `enrichChecks` call (around line 184):
+
+```swift
+let result = try? await prManager.enrichChecks(
+    repo: pr.repo, number: pr.number, author: pr.author, host: host
+)
+```
+
+- [ ] **Step 3: Build to verify compilation**
+
+Run: `swift build`
+Expected: Build succeeds
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/App/PRCoordinator.swift
+git commit -m "feat: apply comment count enrichment in PRCoordinator"
+```
+
+---
+
+### Task 5: Add CommentCountBadge view and wire into sidebar
+
+**Files:**
+- Modify: `Sources/Views/Shared/PRBadges.swift` (add new view after line 160)
+- Modify: `Sources/Views/Sidebar/ProjectTreeView.swift:463` (insert badge)
+
+- [ ] **Step 1: Add CommentCountBadge to PRBadges.swift**
+
+In `Sources/Views/Shared/PRBadges.swift`, add after the `ReviewDecisionBadge` closing brace (after line 160):
+
+```swift
+// MARK: - CommentCountBadge
+
+/// Accent-colored badge showing the count of PR comments from others since the last commit.
+///
+/// Hidden when count is zero. Used in sidebar session rows as an "action needed" signal.
+public struct CommentCountBadge: View {
+    let count: Int
+    @Environment(\.theme) private var theme
+
+    public init(count: Int) {
+        self.count = count
+    }
+
+    public var body: some View {
+        if count > 0 {
+            HStack(spacing: 2) {
+                Image(systemName: "bubble.left.fill")
+                Text("\(count)")
+            }
+            .font(.caption2)
+            .foregroundColor(theme.chrome.accent)
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Insert CommentCountBadge in SessionRowView**
+
+In `Sources/Views/Sidebar/ProjectTreeView.swift`, add after the `ReviewDecisionBadge` line (line 463):
+
+```swift
+CommentCountBadge(count: pr.commentsSinceLastCommit)
+```
+
+So the badge section reads:
+```swift
+CheckSummaryBadge(checks: pr.checks)
+ReviewDecisionBadge(decision: pr.reviewDecision, style: .iconOnly)
+CommentCountBadge(count: pr.commentsSinceLastCommit)
+```
+
+- [ ] **Step 3: Build to verify compilation**
+
+Run: `swift build`
+Expected: Build succeeds
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/Views/Shared/PRBadges.swift Sources/Views/Sidebar/ProjectTreeView.swift
+git commit -m "feat: add CommentCountBadge to sidebar session rows"
+```
+
+---
+
+### Task 6: Final validation
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `swift test`
+Expected: All 329+ tests pass
+
+- [ ] **Step 2: Run lint and format check**
+
+Run: `make check`
+Expected: Build + test + lint + format all pass
+
+- [ ] **Step 3: Fix any lint/format issues**
+
+Run: `make fix` if needed, then re-run `make check`
+
+- [ ] **Step 4: Final commit if any formatting changes**
+
+```bash
+git add -A
+git commit -m "style: format and lint fixes"
+```

--- a/docs/superpowers/specs/2026-04-14-sidebar-comment-indicators-design.md
+++ b/docs/superpowers/specs/2026-04-14-sidebar-comment-indicators-design.md
@@ -1,0 +1,163 @@
+# Sidebar Comment Indicators
+
+Surface new PR comments (since last commit, from others) as an accent-colored badge in the session sidebar row.
+
+## Problem
+
+When reviewers leave comments on a PR, there's no way to see "action needed" without opening the PR detail drawer. Users want a quick visual signal in the sidebar that feedback exists to address.
+
+## Design Decisions
+
+- **"New" = comments since last commit on the PR branch, excluding the PR author's own comments.** This is the natural "do I have feedback to address?" heuristic — after you push, any new comments from others are likely review feedback.
+- **Piggyback on existing `enrichChecks()` polling** rather than adding a new API call. The enrichment cycle already runs for each linked PR and uses `gh pr view --json`. Adding `comments` and `commits` to that query costs almost nothing.
+- **Accent-colored badge** to visually distinguish "action needed" from informational badges (checks use green/red, review uses green/orange). The comment badge uses `theme.chrome.accent`.
+
+## Architecture
+
+### Data Flow
+
+```
+gh pr view --json ...,comments,commits
+    |
+    v
+PRManager.enrichChecks()
+    - Parse lastCommitDate from commits(last)
+    - Filter comments: createdAt > lastCommitDate AND author != prAuthor
+    - Return count in PREnrichResult
+    |
+    v
+PRCoordinator.applyEnrichment()
+    - Sets pr.commentsSinceLastCommit
+    - Sets pr.lastCommitDate
+    |
+    v
+SessionRowView
+    - CommentCountBadge(count: pr.commentsSinceLastCommit)
+    - Shows "bubble.left.fill N" in accent color when count > 0
+```
+
+### Layer Changes
+
+| Layer | File | Change |
+|-------|------|--------|
+| Model | `PullRequest.swift` | Add `commentsSinceLastCommit: Int` (default 0) and `lastCommitDate: Date?` to `PullRequest` |
+| Model | `PullRequest.swift` | Add same fields to `PREnrichResult` |
+| GitHub Ops | `PRManager.swift` | Add `createdAt` to `GHComment`, pass through in `fetchDetail()` mapping |
+| GitHub Ops | `PRManager.swift` | Expand `enrichChecks()` `--json` to include `comments,commits` |
+| GitHub Ops | `PRManager.swift` | Add `GHCommit` struct for decoding commit dates |
+| GitHub Ops | `PRManager.swift` | Compute filtered comment count in `enrichChecks()` |
+| Coordinator | `PRCoordinator.swift` | Apply `commentsSinceLastCommit` and `lastCommitDate` in `applyEnrichment()` |
+| View | `PRBadges.swift` | New `CommentCountBadge` view |
+| View | `ProjectTreeView.swift` | Insert `CommentCountBadge` in `SessionRowView` after `ReviewDecisionBadge` |
+
+### Model Changes
+
+**PullRequest struct** — two new fields:
+```swift
+public var commentsSinceLastCommit: Int = 0
+public var lastCommitDate: Date?
+```
+
+**PREnrichResult** — two new fields:
+```swift
+public var commentsSinceLastCommit: Int = 0
+public var lastCommitDate: Date?
+```
+
+### GHComment.createdAt Fix (Prerequisite)
+
+The existing `GHComment` struct does not decode `createdAt` from the `gh` JSON response. The `PRComment` model has a `createdAt: Date` field but it defaults to `Date()` — meaning all comments currently get the fetch timestamp, not their real creation time. This doesn't affect the detail drawer (comments are displayed in return order), but our feature requires accurate timestamps.
+
+**Fix:** Add `createdAt` to `GHComment`:
+```swift
+private struct GHComment: Decodable {
+    let author: GHAuthor?
+    let body: String?
+    let id: String?
+    let createdAt: Date?  // new — ISO 8601 from gh CLI
+}
+```
+
+And pass it through in the `mappedComments` mapping in `fetchDetail()`:
+```swift
+PRComment(id: comment.id ?? "0", author: comment.author?.login ?? "",
+          body: comment.body ?? "", createdAt: comment.createdAt ?? Date())
+```
+
+This is a small bugfix that benefits both the existing detail view and the new sidebar feature.
+
+### enrichChecks() Query Expansion
+
+Current `--json` fields:
+```
+statusCheckRollup,reviewDecision,headRefName,baseRefName,
+additions,deletions,changedFiles,mergeable,mergeStateStatus,autoMergeRequest
+```
+
+New fields added:
+```
+...,comments,commits
+```
+
+**New decoding struct:**
+```swift
+struct GHCommit: Decodable {
+    let committedDate: String?
+}
+```
+
+**Comment count computation** (inside `enrichChecks()`):
+```swift
+let lastCommitDate = commits?.last.flatMap { ISO8601DateFormatter().date(from: $0.committedDate) }
+let commentsSinceLastCommit = comments?
+    .filter { comment in
+        guard let date = comment.createdAt, let commitDate = lastCommitDate else { return false }
+        return date > commitDate && comment.author?.login != prAuthor
+    }
+    .count ?? 0
+```
+
+### CommentCountBadge View
+
+```swift
+struct CommentCountBadge: View {
+    let count: Int
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        if count > 0 {
+            HStack(spacing: 2) {
+                Image(systemName: "bubble.left.fill")
+                Text("\(count)")
+            }
+            .font(.caption2)
+            .foregroundColor(theme.chrome.accent)
+        }
+    }
+}
+```
+
+**Placement** in `SessionRowView`, after `ReviewDecisionBadge`:
+```swift
+CheckSummaryBadge(checks: pr.checks)
+ReviewDecisionBadge(decision: pr.reviewDecision, style: .iconOnly)
+CommentCountBadge(count: pr.commentsSinceLastCommit)  // new
+```
+
+## Edge Cases
+
+| Case | Behavior |
+|------|----------|
+| PR with no commits | `lastCommitDate` nil, count stays 0, badge hidden |
+| PR author's own comments | Excluded by `author != prAuthor` filter |
+| Review + inline comments | Both included in `gh` `comments` field, both count |
+| Enrichment hasn't run yet | Defaults to 0, badge hidden until first enrichment |
+| Session with no linked PR | Entire PR badge HStack not rendered, no change needed |
+
+## Testing
+
+- **ModelsTests**: Verify `PullRequest` new field defaults
+- **GitHubOperationsTests**: Test comment filtering logic with mixed authors and timestamps
+- **ViewsTests**: Test `CommentCountBadge` renders when count > 0, hidden when 0
+
+No new test targets required.


### PR DESCRIPTION
## Summary

- Surface new PR comments as an accent-colored badge in the session sidebar row
- Badge shows count of comments from others since the last commit — the "do I have feedback to address?" signal
- Piggybacks on existing `enrichChecks()` polling cycle (no new API calls)
- Also fixes `GHComment` to decode `createdAt` (was silently dropping it, defaulting to `Date()`)

## Changes

| Layer | File | Change |
|-------|------|--------|
| Model | `PullRequest.swift` | Add `commentsSinceLastCommit: Int` and `lastCommitDate: Date?` |
| GitHub Ops | `PRManager.swift` | Fix `GHComment.createdAt`, add `GHCommit`, expand `enrichChecks()` JSON fields, add `countCommentsSinceCommit` filtering logic |
| Coordinator | `PRCoordinator.swift` | Wire new fields in `applyEnrichment()`, pass PR author to exclude self-comments |
| View | `PRBadges.swift` | New `CommentCountBadge` — accent-colored `bubble.left.fill` + count |
| View | `ProjectTreeView.swift` | Insert badge in `SessionRowView` after `ReviewDecisionBadge` |

## How it works

1. `enrichChecks()` now fetches `comments` and `commits` alongside existing check/review data
2. Filters comments where `createdAt > lastCommitDate` AND `author != prAuthor`
3. Count flows through `PREnrichResult` → `PRCoordinator.applyEnrichment()` → `PullRequest.commentsSinceLastCommit`
4. `CommentCountBadge` renders in accent color when count > 0, hidden otherwise

## Test plan

- [x] 331 tests pass (2 new: `pullRequestCommentFieldDefaults`, `prEnrichResultCommentDefaults`)
- [x] `make check` clean (build + test + lint + format)
- [ ] Manual: create a PR, push a commit, have someone comment — verify badge appears
- [ ] Manual: push another commit after comments — verify badge resets to 0
- [ ] Manual: comment on own PR — verify own comments don't count