### PR TITLE
fix: preserve terminal tabs across session navigation

### DIFF
--- a/Sources/App/RunwayStore.swift
+++ b/Sources/App/RunwayStore.swift
@@ -557,8 +557,9 @@ public final class RunwayStore {
             try? await tmuxManager.killSession(name: tmuxName)
         }
 
-        // Clear cached terminal view so TerminalPane creates a fresh one
+        // Clear cached terminal view and tab state so TerminalPane creates a fresh one
         TerminalSessionCache.shared.removeAll(forSessionID: id)
+        TerminalTabStateCache.shared.remove(sessionID: id)
 
         // Recreate tmux session
         if tmuxAvailable {
@@ -610,6 +611,7 @@ public final class RunwayStore {
         sessions.removeAll { $0.id == id }
         try? database?.deleteSession(id: id)
         TerminalSessionCache.shared.removeAll(forSessionID: id)
+        TerminalTabStateCache.shared.remove(sessionID: id)
         prCoordinator.sessionDeleted(id: id)
         provisioningTasks[id]?.cancel()
         provisioningTasks.removeValue(forKey: id)

--- a/Sources/Views/SessionDetail/TerminalTabStateCache.swift
+++ b/Sources/Views/SessionDetail/TerminalTabStateCache.swift
@@ -1,0 +1,38 @@
+/// Persists terminal tab state (tabs, selection, shell counter) across SwiftUI
+/// view lifecycle.
+///
+/// When the user navigates away from a session, SwiftUI destroys
+/// `TerminalTabView` and its `@State` properties reset. The underlying tmux
+/// sessions survive, so `initializeTabs()` can rediscover them — but the async
+/// discovery introduces a visible flash and, under rapid navigation, a race
+/// where the guard rejects the results.
+///
+/// This cache stores the tab state outside the view hierarchy so that
+/// returning to a session instantly restores the exact tab layout without
+/// needing async rediscovery.
+@MainActor
+public final class TerminalTabStateCache {
+    public static let shared = TerminalTabStateCache()
+
+    struct TabState {
+        var tabs: [TerminalTab]
+        var selectedTabID: String?
+        var shellCounter: Int
+    }
+
+    private var states: [String: TabState] = [:]
+
+    private init() {}
+
+    func state(for sessionID: String) -> TabState? {
+        states[sessionID]
+    }
+
+    func save(_ state: TabState, for sessionID: String) {
+        states[sessionID] = state
+    }
+
+    public func remove(sessionID: String) {
+        states.removeValue(forKey: sessionID)
+    }
+}

--- a/Sources/Views/SessionDetail/TerminalTabView.swift
+++ b/Sources/Views/SessionDetail/TerminalTabView.swift
@@ -63,6 +63,7 @@ public struct TerminalTabView: View {
     @State private var tabs: [TerminalTab] = []
     @State private var selectedTabID: String?
     @State private var shellCounter: Int = 0
+    private let tabStateCache = TerminalTabStateCache.shared
     @Environment(\.theme) private var theme
     @AppStorage("terminalFontFamily") private var fontFamily: String = "MesloLGS Nerd Font"
     @AppStorage("terminalFontSize") private var fontSize: Double = 13
@@ -173,21 +174,28 @@ public struct TerminalTabView: View {
                 }
             }
         }
-        .onAppear { initializeTabsIfReady() }
-        .onChange(of: session.id) { _, _ in
-            // Reset tabs when switching to a different session — without this,
-            // @State persists the old session's tabs and the wrong terminal shows.
+        .onAppear { restoreOrInitializeTabs() }
+        .onDisappear { saveTabState() }
+        .onChange(of: session.id) { oldID, _ in
+            // Save outgoing session's tab state, then reset for the new session.
+            tabStateCache.save(
+                .init(tabs: tabs, selectedTabID: selectedTabID, shellCounter: shellCounter),
+                for: oldID
+            )
             tabs = []
             selectedTabID = nil
-            initializeTabsIfReady()
+            shellCounter = 0
+            restoreOrInitializeTabs()
         }
         .onChange(of: splitHorizontalTrigger) { _, _ in splitDown() }
         .onChange(of: splitVerticalTrigger) { _, _ in splitRight() }
         .onChange(of: terminalRestartTrigger) { _, _ in
             // Force reinitialize tabs after restart — the status onChange may not
             // fire if SwiftUI coalesces .running → .starting → .running into no-op.
+            tabStateCache.remove(sessionID: session.id)
             tabs = []
             selectedTabID = nil
+            shellCounter = 0
             initializeTabsIfReady()
         }
         .onChange(of: session.status) { _, newStatus in
@@ -200,7 +208,7 @@ public struct TerminalTabView: View {
             // to force full view recreation, and stale hook events from a killed
             // session could otherwise destroy the freshly created terminal.
             if tabs.isEmpty, newStatus.tmuxSessionExpected {
-                initializeTabs()
+                restoreOrInitializeTabs()
             }
         }
         .onChange(of: diffOpenTrigger) { _, _ in
@@ -209,7 +217,9 @@ public struct TerminalTabView: View {
         }
         .onChange(of: selectedTabID) { _, _ in
             notifyActiveDiffPath()
+            saveTabState()
         }
+        .onChange(of: tabs.count) { _, _ in saveTabState() }
     }
 
     // MARK: - Tab Bar
@@ -316,6 +326,26 @@ public struct TerminalTabView: View {
 
     private var selectedTab: TerminalTab? {
         tabs.first(where: { $0.id == selectedTabID }) ?? tabs.first
+    }
+
+    /// Restore tab state from cache if available, otherwise initialize from scratch.
+    private func restoreOrInitializeTabs() {
+        if let cached = tabStateCache.state(for: session.id) {
+            tabs = cached.tabs
+            selectedTabID = cached.selectedTabID
+            shellCounter = cached.shellCounter
+            return
+        }
+        initializeTabsIfReady()
+    }
+
+    /// Persist current tab state so it survives navigation away and back.
+    private func saveTabState() {
+        guard !tabs.isEmpty else { return }
+        tabStateCache.save(
+            .init(tabs: tabs, selectedTabID: selectedTabID, shellCounter: shellCounter),
+            for: session.id
+        )
     }
 
     /// Only initialize tabs once the tmux session exists.


### PR DESCRIPTION
## Summary

- **Bug**: Extra shell tabs (Shell 1, Shell 2, etc.) were lost when navigating away from a session and back — SwiftUI destroyed the `TerminalTabView` `@State` on view teardown, and the async tmux rediscovery was racy under rapid navigation
- **Fix**: Add `TerminalTabStateCache` (same pattern as `TerminalSessionCache`) to persist tab state outside the view lifecycle — tabs restore instantly on re-navigation without async tmux queries
- Cache is cleared on session restart and deletion to prevent stale state

## Test plan

- [ ] Open a session, add 1-2 extra shell tabs
- [ ] Navigate to another session or the PR dashboard, then back — tabs should be preserved
- [ ] Rapid-click between sessions — no tab loss or duplication
- [ ] Restart a session — tabs should reinitialize fresh (cache cleared)
- [ ] Delete a session — no stale cache entries (verify no memory growth over time)
- [ ] `swift test` — all 331 tests pass