### PR TITLE
fix: diff sidebar over-reports files when local master is stale

### DIFF
--- a/Sources/GitOperations/WorktreeManager.swift
+++ b/Sources/GitOperations/WorktreeManager.swift
@@ -232,8 +232,9 @@ public actor WorktreeManager {
                 base = "HEAD"
             case .branch:
                 let defaultBranch = await detectDefaultBranch(repoPath: path)
+                let baseRef = await preferredMergeBaseRef(repoPath: path, branch: defaultBranch)
                 base =
-                    (try? await runGit(in: path, args: ["merge-base", defaultBranch, "HEAD"]))
+                    (try? await runGit(in: path, args: ["merge-base", baseRef, "HEAD"]))
                     .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) } ?? "HEAD"
             }
 
@@ -257,8 +258,9 @@ public actor WorktreeManager {
             base = "HEAD"
         case .branch:
             let defaultBranch = await detectDefaultBranch(repoPath: path)
+            let baseRef = await preferredMergeBaseRef(repoPath: path, branch: defaultBranch)
             base =
-                (try? await runGit(in: path, args: ["merge-base", defaultBranch, "HEAD"]))
+                (try? await runGit(in: path, args: ["merge-base", baseRef, "HEAD"]))
                 .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) } ?? "HEAD"
         }
 
@@ -288,6 +290,24 @@ public actor WorktreeManager {
         return "main"
     }
 
+    /// Returns the best ref to use when computing `merge-base` against `HEAD`.
+    ///
+    /// Prefers the remote-tracking ref `origin/<branch>` (updated by `git fetch`) over the
+    /// local branch ref, which can drift far behind origin in worktree-heavy workflows where
+    /// the default branch is rarely checked out. A stale local ref makes `merge-base` return
+    /// an older commit, which causes `git diff` to report unrelated upstream changes as if
+    /// they belonged to the user's branch.
+    ///
+    /// Falls back to the local branch name when origin isn't configured or the branch hasn't
+    /// been pushed.
+    func preferredMergeBaseRef(repoPath: String, branch: String) async -> String {
+        let remoteRef = "origin/\(branch)"
+        if (try? await runGit(in: repoPath, args: ["rev-parse", "--verify", remoteRef])) != nil {
+            return remoteRef
+        }
+        return branch
+    }
+
     /// Get commit history for the current branch.
     /// First tries showing only commits since divergence from the base branch.
     /// Falls back to showing the last `limit` commits if there are no branch-specific commits
@@ -299,7 +319,8 @@ public actor WorktreeManager {
         limit: Int = 50
     ) async -> [(hash: String, subject: String)] {
         // Try branch-specific commits first (since divergence from base)
-        if let base = try? await runGit(in: path, args: ["merge-base", baseBranch, "HEAD"]) {
+        let baseRef = await preferredMergeBaseRef(repoPath: path, branch: baseBranch)
+        if let base = try? await runGit(in: path, args: ["merge-base", baseRef, "HEAD"]) {
             let trimmedBase = base.trimmingCharacters(in: .whitespacesAndNewlines)
             if let output = try? await runGit(
                 in: path,

--- a/Tests/GitOperationsTests/ChangedFilesTests.swift
+++ b/Tests/GitOperationsTests/ChangedFilesTests.swift
@@ -154,3 +154,66 @@ private func sh(_ cmd: String, in dir: String) throws {
         #expect(!diffText.isEmpty)
     }
 }
+
+// MARK: - Regression: stale local default branch
+
+/// When a local tracking branch (e.g. `master`) is behind `origin/master`, computing
+/// `merge-base master HEAD` returns an old commit and the diff inflates to include
+/// unrelated upstream commits. The fix is to prefer `origin/<branch>` for merge-base.
+///
+/// Scenario:
+///   - origin/master has commits M1..M4
+///   - local master is stale at M1 (never pulled)
+///   - feature branch was created off origin/master (M4) + adds F1, F2
+///   - changedFiles(.branch) should report only F1/F2's files, not M2..M4's.
+@Test func changedFilesUsesOriginBranchNotStaleLocal() async throws {
+    let tmpURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("runway-stale-master-\(UUID().uuidString)")
+        .resolvingSymlinksInPath()
+    let tmpDir = tmpURL.path
+    defer { try? FileManager.default.removeItem(atPath: tmpDir) }
+    try FileManager.default.createDirectory(atPath: tmpDir, withIntermediateDirectories: true)
+
+    let remoteDir = "\(tmpDir)/origin.git"
+    let localDir = "\(tmpDir)/local"
+
+    // 1. Create a bare "remote" repo with an initial commit on master.
+    try FileManager.default.createDirectory(atPath: remoteDir, withIntermediateDirectories: true)
+    try sh("git init --bare -b master", in: remoteDir)
+
+    // 2. Seed origin/master with commit M1 (containing initial.txt), then clone.
+    let seedDir = "\(tmpDir)/seed"
+    try FileManager.default.createDirectory(atPath: seedDir, withIntermediateDirectories: true)
+    try sh("git init -b master", in: seedDir)
+    try sh("git config user.email 'test@test.com' && git config user.name 'Test'", in: seedDir)
+    try sh("echo initial > initial.txt && git add . && git commit -m M1", in: seedDir)
+    try sh("git remote add origin \(remoteDir) && git push origin master", in: seedDir)
+
+    // 3. Clone the remote — now local master == origin/master == M1.
+    try sh("git clone \(remoteDir) \(localDir)", in: tmpDir)
+    try sh("git config user.email 'test@test.com' && git config user.name 'Test'", in: localDir)
+
+    // 4. Push M2..M4 to origin directly (these are "upstream" commits the user
+    //    hasn't pulled into their local master).
+    for (i, file) in ["upstream-a.txt", "upstream-b.txt", "upstream-c.txt"].enumerated() {
+        try sh("echo up > \(file) && git add . && git commit -m M\(i + 2)", in: seedDir)
+    }
+    try sh("git push origin master", in: seedDir)
+
+    // 5. In the local clone, fetch (so origin/master updates) but DO NOT pull
+    //    (so local master stays stale at M1).
+    try sh("git fetch origin", in: localDir)
+
+    // 6. Create a feature branch from origin/master (fresh), add two files.
+    try sh("git checkout -b feature origin/master", in: localDir)
+    try sh("echo feat1 > feat1.txt && git add . && git commit -m F1", in: localDir)
+    try sh("echo feat2 > feat2.txt && git add . && git commit -m F2", in: localDir)
+
+    // 7. The fix: changedFiles(.branch) should compare against origin/master (M4),
+    //    not stale local master (M1), so only feat1.txt + feat2.txt show up.
+    let manager = WorktreeManager()
+    let changes = await manager.changedFiles(path: localDir, mode: .branch)
+    let paths = Set(changes.map(\.path))
+
+    #expect(paths == ["feat1.txt", "feat2.txt"], "Expected only the feature branch's files, got \(paths)")
+}


### PR DESCRIPTION
## Summary

The **Changes** sidebar (and the commit history view) sometimes reported far more changed files than the branch actually touched. Root cause traced to `WorktreeManager`: `changedFiles`, `fileDiff`, and `commitLog` all compute `merge-base <branch> HEAD` using the local tracking branch name (e.g. `master`). In worktree-heavy workflows the local `master` ref drifts behind `origin/master` because users rarely check it out — so `merge-base` returns an old commit and `git diff` picks up unrelated upstream commits.

### Why intermittent

- Runway's `createWorktree` already fetches `origin/<baseBranch>` and bases the worktree off it, so sessions start from the correct tip.
- But `detectDefaultBranch` stripped `refs/remotes/origin/master` down to `"master"`, which is fine for UI display but incorrect for `merge-base`.
- The bigger the delta between local `master` and `origin/master`, the more phantom files the sidebar shows.

## Fix

- New `preferredMergeBaseRef(repoPath:branch:)` helper on `WorktreeManager` returns `origin/<branch>` when the remote-tracking ref exists, otherwise falls back to the local ref.
- `changedFiles`, `fileDiff`, and `commitLog` now route through it.
- `detectDefaultBranch` is unchanged — it still returns the plain name for display callers (`NewProjectDialog`, `Project.defaultBranch`, `createWorktree`'s `baseBranch` param which already prefixes `origin/` itself).

## Test plan

- [x] Added `changedFilesUsesOriginBranchNotStaleLocal` regression test: sets up a local clone with a stale `master`, 3 upstream commits on `origin/master`, and 2 feature commits on a branch based off `origin/master`.
- [x] Verified test catches the bug: before the fix it reports 5 files (`upstream-a/b/c.txt` + `feat1/feat2.txt`); after the fix it reports 2 (`feat1/feat2.txt`).
- [x] `swift test` — all 332 tests pass
- [x] `swift build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)