### PR TITLE
feat: session status counts in toolbar

### DIFF
--- a/Sources/App/RunwayApp.swift
+++ b/Sources/App/RunwayApp.swift
@@ -575,9 +575,26 @@ struct ContentView: View {
             }
         }
 
-        // Status counts — always visible when there are active sessions
-        ToolbarItem(placement: .automatic) {
-            toolbarSessionCounts
+        // Title + status counts in the principal (centered) position
+        ToolbarItem(placement: .principal) {
+            principalTitleWithCounts
+        }
+    }
+
+    @ViewBuilder
+    private var principalTitleWithCounts: some View {
+        let counts = store.sessions.statusCounts
+        HStack(spacing: 10) {
+            Text(windowTitle)
+                .font(.headline)
+                .foregroundStyle(theme.chrome.text)
+                .lineLimit(1)
+                .truncationMode(.tail)
+            if counts.hasAny {
+                Divider()
+                    .frame(height: 14)
+                toolbarSessionCounts
+            }
         }
     }
 

--- a/Sources/App/RunwayApp.swift
+++ b/Sources/App/RunwayApp.swift
@@ -575,26 +575,11 @@ struct ContentView: View {
             }
         }
 
-        // Title + status counts in the principal (centered) position
+        // Status counts — centered in the toolbar's principal slot. The window
+        // title renders in its native leading slot via .navigationTitle, so we
+        // don't duplicate it here.
         ToolbarItem(placement: .principal) {
-            principalTitleWithCounts
-        }
-    }
-
-    @ViewBuilder
-    private var principalTitleWithCounts: some View {
-        let counts = store.sessions.statusCounts
-        HStack(spacing: 10) {
-            Text(windowTitle)
-                .font(.headline)
-                .foregroundStyle(theme.chrome.text)
-                .lineLimit(1)
-                .truncationMode(.tail)
-            if counts.hasAny {
-                Divider()
-                    .frame(height: 14)
-                toolbarSessionCounts
-            }
+            toolbarSessionCounts
         }
     }
 
@@ -602,7 +587,7 @@ struct ContentView: View {
     private var toolbarSessionCounts: some View {
         let counts = store.sessions.statusCounts
         if counts.hasAny {
-            HStack(spacing: 8) {
+            HStack(spacing: 14) {
                 if counts.running > 0 {
                     statusChip(status: .running, count: counts.running, label: "running")
                 }
@@ -616,15 +601,18 @@ struct ContentView: View {
                     statusChip(status: .error, count: counts.error, label: "error")
                 }
             }
+            .padding(.horizontal, 4)
             .help(toolbarCountsHelpText(counts))
         }
     }
 
     private func statusChip(status: SessionStatus, count: Int, label: String) -> some View {
-        HStack(spacing: 3) {
-            SessionStatusIndicator(status: status, size: 7)
+        HStack(spacing: 5) {
+            SessionStatusIndicator(status: status, size: 9)
             Text("\(count)")
-                .font(.caption)
+                .font(.subheadline)
+                .fontWeight(.medium)
+                .monospacedDigit()
                 .foregroundStyle(theme.chrome.text)
         }
         .accessibilityElement(children: .combine)

--- a/Sources/App/RunwayApp.swift
+++ b/Sources/App/RunwayApp.swift
@@ -583,23 +583,44 @@ struct ContentView: View {
 
     @ViewBuilder
     private var toolbarSessionCounts: some View {
-        let running = store.sessions.filter { $0.status == .running }.count
-        let waiting = store.sessions.filter { $0.status == .waiting }.count
-        if running > 0 || waiting > 0 {
-            HStack(spacing: 6) {
-                if running > 0 {
-                    Label("\(running)", systemImage: "bolt.fill")
-                        .font(.caption)
-                        .foregroundStyle(.green)
+        let counts = store.sessions.statusCounts
+        if counts.hasAny {
+            HStack(spacing: 8) {
+                if counts.running > 0 {
+                    statusChip(status: .running, count: counts.running, label: "running")
                 }
-                if waiting > 0 {
-                    Label("\(waiting)", systemImage: "hand.raised.fill")
-                        .font(.caption)
-                        .foregroundStyle(.orange)
+                if counts.waiting > 0 {
+                    statusChip(status: .waiting, count: counts.waiting, label: "waiting")
+                }
+                if counts.idle > 0 {
+                    statusChip(status: .idle, count: counts.idle, label: "idle")
+                }
+                if counts.error > 0 {
+                    statusChip(status: .error, count: counts.error, label: "error")
                 }
             }
-            .help("\(running) running, \(waiting) waiting")
+            .help(toolbarCountsHelpText(counts))
         }
+    }
+
+    private func statusChip(status: SessionStatus, count: Int, label: String) -> some View {
+        HStack(spacing: 3) {
+            SessionStatusIndicator(status: status, size: 7)
+            Text("\(count)")
+                .font(.caption)
+                .foregroundStyle(theme.chrome.text)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(count) \(label) \(count == 1 ? "session" : "sessions")")
+    }
+
+    private func toolbarCountsHelpText(_ counts: SessionStatusCounts) -> String {
+        var parts: [String] = []
+        if counts.running > 0 { parts.append("\(counts.running) running") }
+        if counts.waiting > 0 { parts.append("\(counts.waiting) waiting") }
+        if counts.idle > 0 { parts.append("\(counts.idle) idle") }
+        if counts.error > 0 { parts.append("\(counts.error) error") }
+        return parts.joined(separator: ", ")
     }
 }
 

--- a/Sources/Models/SessionStatusCounts.swift
+++ b/Sources/Models/SessionStatusCounts.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// Aggregated session status counts for the four statuses surfaced in the toolbar.
+/// `starting` and `stopped` are intentionally excluded — see design spec
+/// `docs/superpowers/specs/2026-04-16-menu-bar-status-counts-design.md`.
+public struct SessionStatusCounts: Sendable, Equatable {
+    public let running: Int
+    public let waiting: Int
+    public let idle: Int
+    public let error: Int
+
+    public init(running: Int = 0, waiting: Int = 0, idle: Int = 0, error: Int = 0) {
+        self.running = running
+        self.waiting = waiting
+        self.idle = idle
+        self.error = error
+    }
+
+    /// True if any of the four tracked statuses has a non-zero count.
+    public var hasAny: Bool {
+        running > 0 || waiting > 0 || idle > 0 || error > 0
+    }
+}
+
+extension Array where Element == Session {
+    /// Single-pass aggregation of session statuses into toolbar-relevant buckets.
+    public var statusCounts: SessionStatusCounts {
+        var running = 0
+        var waiting = 0
+        var idle = 0
+        var error = 0
+        for session in self {
+            switch session.status {
+            case .running: running += 1
+            case .waiting: waiting += 1
+            case .idle: idle += 1
+            case .error: error += 1
+            case .starting, .stopped: break
+            }
+        }
+        return SessionStatusCounts(
+            running: running,
+            waiting: waiting,
+            idle: idle,
+            error: error
+        )
+    }
+}

--- a/Tests/ModelsTests/SessionStatusCountsTests.swift
+++ b/Tests/ModelsTests/SessionStatusCountsTests.swift
@@ -1,0 +1,66 @@
+import Foundation
+import Testing
+
+@testable import Models
+
+@Test func statusCountsEmpty() {
+    let counts = [Session]().statusCounts
+    #expect(counts.running == 0)
+    #expect(counts.waiting == 0)
+    #expect(counts.idle == 0)
+    #expect(counts.error == 0)
+}
+
+@Test func statusCountsOneOfEach() {
+    let sessions = [
+        Session(title: "a", path: "/tmp", status: .running),
+        Session(title: "b", path: "/tmp", status: .waiting),
+        Session(title: "c", path: "/tmp", status: .idle),
+        Session(title: "d", path: "/tmp", status: .error),
+    ]
+    let counts = sessions.statusCounts
+    #expect(counts.running == 1)
+    #expect(counts.waiting == 1)
+    #expect(counts.idle == 1)
+    #expect(counts.error == 1)
+}
+
+@Test func statusCountsIgnoresStartingAndStopped() {
+    let sessions = [
+        Session(title: "a", path: "/tmp", status: .starting),
+        Session(title: "b", path: "/tmp", status: .stopped),
+        Session(title: "c", path: "/tmp", status: .running),
+    ]
+    let counts = sessions.statusCounts
+    #expect(counts.running == 1)
+    #expect(counts.waiting == 0)
+    #expect(counts.idle == 0)
+    #expect(counts.error == 0)
+}
+
+@Test func statusCountsAggregates() {
+    let sessions = [
+        Session(title: "a", path: "/tmp", status: .running),
+        Session(title: "b", path: "/tmp", status: .running),
+        Session(title: "c", path: "/tmp", status: .running),
+        Session(title: "d", path: "/tmp", status: .idle),
+        Session(title: "e", path: "/tmp", status: .idle),
+        Session(title: "f", path: "/tmp", status: .error),
+    ]
+    let counts = sessions.statusCounts
+    #expect(counts.running == 3)
+    #expect(counts.waiting == 0)
+    #expect(counts.idle == 2)
+    #expect(counts.error == 1)
+}
+
+@Test func statusCountsHasAnyActive() {
+    let none = [Session]().statusCounts
+    #expect(none.hasAny == false)
+
+    let some = [Session(title: "a", path: "/tmp", status: .idle)].statusCounts
+    #expect(some.hasAny == true)
+
+    let onlyStopped = [Session(title: "a", path: "/tmp", status: .stopped)].statusCounts
+    #expect(onlyStopped.hasAny == false)
+}

--- a/docs/superpowers/plans/2026-04-16-menu-bar-status-counts.md
+++ b/docs/superpowers/plans/2026-04-16-menu-bar-status-counts.md
@@ -1,0 +1,363 @@
+# Menu Bar Session Status Counts Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend the app window's toolbar status cluster to show live counts for `running`, `waiting`, `idle`, and `error` sessions, using the existing theme-aware `SessionStatusIndicator` component.
+
+**Architecture:** The counting logic lives as a pure function in the `Models` module (unit-testable). The view in `Sources/App/RunwayApp.swift` consumes it and renders one chip per non-zero status using `SessionStatusIndicator` + a count `Text`. All colors flow through the `Theme` environment — no hardcoded system colors.
+
+**Tech Stack:** Swift 5.9+, SwiftUI, Swift Testing (`@Test` / `#expect`), SwiftPM.
+
+**Spec:** `docs/superpowers/specs/2026-04-16-menu-bar-status-counts-design.md`
+
+---
+
+## File Structure
+
+| File | Role | Action |
+|------|------|--------|
+| `Sources/Models/SessionStatusCounts.swift` | Pure helper: `[Session] → (running, waiting, idle, error)` tuple | **Create** |
+| `Tests/ModelsTests/SessionStatusCountsTests.swift` | Unit tests for the helper | **Create** |
+| `Sources/App/RunwayApp.swift` | `toolbarSessionCounts` view, lines 584-603 | **Modify** |
+
+No changes to `Theme`, `RunwayStore`, `Views`, or any other module. `SessionStatusIndicator` is already `public` in the `Views` module which `App` imports.
+
+---
+
+## Task 1: Add `sessionStatusCounts` helper in Models with tests
+
+**Files:**
+- Create: `Sources/Models/SessionStatusCounts.swift`
+- Create: `Tests/ModelsTests/SessionStatusCountsTests.swift`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Tests/ModelsTests/SessionStatusCountsTests.swift` with this exact content:
+
+```swift
+import Foundation
+import Testing
+
+@testable import Models
+
+@Test func statusCountsEmpty() {
+    let counts = [Session]().statusCounts
+    #expect(counts.running == 0)
+    #expect(counts.waiting == 0)
+    #expect(counts.idle == 0)
+    #expect(counts.error == 0)
+}
+
+@Test func statusCountsOneOfEach() {
+    let sessions = [
+        Session(title: "a", path: "/tmp", status: .running),
+        Session(title: "b", path: "/tmp", status: .waiting),
+        Session(title: "c", path: "/tmp", status: .idle),
+        Session(title: "d", path: "/tmp", status: .error),
+    ]
+    let counts = sessions.statusCounts
+    #expect(counts.running == 1)
+    #expect(counts.waiting == 1)
+    #expect(counts.idle == 1)
+    #expect(counts.error == 1)
+}
+
+@Test func statusCountsIgnoresStartingAndStopped() {
+    let sessions = [
+        Session(title: "a", path: "/tmp", status: .starting),
+        Session(title: "b", path: "/tmp", status: .stopped),
+        Session(title: "c", path: "/tmp", status: .running),
+    ]
+    let counts = sessions.statusCounts
+    #expect(counts.running == 1)
+    #expect(counts.waiting == 0)
+    #expect(counts.idle == 0)
+    #expect(counts.error == 0)
+}
+
+@Test func statusCountsAggregates() {
+    let sessions = [
+        Session(title: "a", path: "/tmp", status: .running),
+        Session(title: "b", path: "/tmp", status: .running),
+        Session(title: "c", path: "/tmp", status: .running),
+        Session(title: "d", path: "/tmp", status: .idle),
+        Session(title: "e", path: "/tmp", status: .idle),
+        Session(title: "f", path: "/tmp", status: .error),
+    ]
+    let counts = sessions.statusCounts
+    #expect(counts.running == 3)
+    #expect(counts.waiting == 0)
+    #expect(counts.idle == 2)
+    #expect(counts.error == 1)
+}
+
+@Test func statusCountsHasAnyActive() {
+    let none = [Session]().statusCounts
+    #expect(none.hasAny == false)
+
+    let some = [Session(title: "a", path: "/tmp", status: .idle)].statusCounts
+    #expect(some.hasAny == true)
+
+    let onlyStopped = [Session(title: "a", path: "/tmp", status: .stopped)].statusCounts
+    #expect(onlyStopped.hasAny == false)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `swift test --filter SessionStatusCountsTests 2>&1 | tail -20`
+
+Expected: build error — `value of type '[Session]' has no member 'statusCounts'` (or similar). The key is that `statusCounts` and `SessionStatusCounts` do not yet exist.
+
+- [ ] **Step 3: Write the helper**
+
+Create `Sources/Models/SessionStatusCounts.swift` with this exact content:
+
+```swift
+import Foundation
+
+/// Aggregated session status counts for the four statuses surfaced in the toolbar.
+/// `starting` and `stopped` are intentionally excluded — see design spec
+/// `docs/superpowers/specs/2026-04-16-menu-bar-status-counts-design.md`.
+public struct SessionStatusCounts: Sendable, Equatable {
+    public let running: Int
+    public let waiting: Int
+    public let idle: Int
+    public let error: Int
+
+    public init(running: Int = 0, waiting: Int = 0, idle: Int = 0, error: Int = 0) {
+        self.running = running
+        self.waiting = waiting
+        self.idle = idle
+        self.error = error
+    }
+
+    /// True if any of the four tracked statuses has a non-zero count.
+    public var hasAny: Bool {
+        running > 0 || waiting > 0 || idle > 0 || error > 0
+    }
+}
+
+extension Array where Element == Session {
+    /// Single-pass aggregation of session statuses into toolbar-relevant buckets.
+    public var statusCounts: SessionStatusCounts {
+        var running = 0
+        var waiting = 0
+        var idle = 0
+        var error = 0
+        for session in self {
+            switch session.status {
+            case .running: running += 1
+            case .waiting: waiting += 1
+            case .idle: idle += 1
+            case .error: error += 1
+            case .starting, .stopped: break
+            }
+        }
+        return SessionStatusCounts(
+            running: running,
+            waiting: waiting,
+            idle: idle,
+            error: error
+        )
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --filter SessionStatusCountsTests 2>&1 | tail -20`
+
+Expected: all 5 tests pass. Output should include a "Test run with N tests passed" line with no failures.
+
+- [ ] **Step 5: Run the full Models test suite to confirm no regressions**
+
+Run: `swift test --filter ModelsTests 2>&1 | tail -10`
+
+Expected: all Models tests pass (existing + the 5 new ones).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/Models/SessionStatusCounts.swift Tests/ModelsTests/SessionStatusCountsTests.swift
+git commit -m "feat(models): add SessionStatusCounts helper for toolbar badges"
+```
+
+---
+
+## Task 2: Rewrite `toolbarSessionCounts` to use the helper and `SessionStatusIndicator`
+
+**Files:**
+- Modify: `Sources/App/RunwayApp.swift:584-603` (the `toolbarSessionCounts` computed view and its single usage at line 579-581).
+
+- [ ] **Step 1: Replace the `toolbarSessionCounts` implementation**
+
+Open `Sources/App/RunwayApp.swift`. Find the existing block (currently lines 584-603):
+
+```swift
+@ViewBuilder
+private var toolbarSessionCounts: some View {
+    let running = store.sessions.filter { $0.status == .running }.count
+    let waiting = store.sessions.filter { $0.status == .waiting }.count
+    if running > 0 || waiting > 0 {
+        HStack(spacing: 6) {
+            if running > 0 {
+                Label("\(running)", systemImage: "bolt.fill")
+                    .font(.caption)
+                    .foregroundStyle(.green)
+            }
+            if waiting > 0 {
+                Label("\(waiting)", systemImage: "hand.raised.fill")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+            }
+        }
+        .help("\(running) running, \(waiting) waiting")
+    }
+}
+```
+
+Replace it with this exact code:
+
+```swift
+@ViewBuilder
+private var toolbarSessionCounts: some View {
+    let counts = store.sessions.statusCounts
+    if counts.hasAny {
+        HStack(spacing: 8) {
+            if counts.running > 0 {
+                statusChip(status: .running, count: counts.running, label: "running")
+            }
+            if counts.waiting > 0 {
+                statusChip(status: .waiting, count: counts.waiting, label: "waiting")
+            }
+            if counts.idle > 0 {
+                statusChip(status: .idle, count: counts.idle, label: "idle")
+            }
+            if counts.error > 0 {
+                statusChip(status: .error, count: counts.error, label: "error")
+            }
+        }
+        .help(toolbarCountsHelpText(counts))
+    }
+}
+
+private func statusChip(status: SessionStatus, count: Int, label: String) -> some View {
+    HStack(spacing: 3) {
+        SessionStatusIndicator(status: status, size: 7)
+        Text("\(count)")
+            .font(.caption)
+            .foregroundStyle(theme.chrome.text)
+    }
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel("\(count) \(label) \(count == 1 ? "session" : "sessions")")
+}
+
+private func toolbarCountsHelpText(_ counts: SessionStatusCounts) -> String {
+    var parts: [String] = []
+    if counts.running > 0 { parts.append("\(counts.running) running") }
+    if counts.waiting > 0 { parts.append("\(counts.waiting) waiting") }
+    if counts.idle > 0 { parts.append("\(counts.idle) idle") }
+    if counts.error > 0 { parts.append("\(counts.error) error") }
+    return parts.joined(separator: ", ")
+}
+```
+
+Note: `statusChip` and `toolbarCountsHelpText` go inside the same `ContentView` struct as `toolbarSessionCounts`. Place them directly below `toolbarSessionCounts` (after line 603 in the original numbering).
+
+- [ ] **Step 2: Verify the project builds**
+
+Run: `swift build 2>&1 | tail -20`
+
+Expected: `Build complete!` with no errors and no new warnings related to the edited lines.
+
+If you get `cannot find 'SessionStatusCounts' in scope` — `Models` is already imported at `Sources/App/RunwayApp.swift:2`, so the helper (and `SessionStatusCounts`) should be visible without further work. If not, confirm the new file was saved under `Sources/Models/`.
+
+If you get `cannot find 'SessionStatusIndicator' in scope` — `Views` is already imported at `Sources/App/RunwayApp.swift:9`, so this should compile. Confirm.
+
+- [ ] **Step 3: Run the full test suite to confirm no regressions**
+
+Run: `swift test 2>&1 | tail -10`
+
+Expected: all 336 tests (331 existing + 5 new) pass.
+
+- [ ] **Step 4: Run the format and lint check**
+
+Run: `make check 2>&1 | tail -20`
+
+Expected: build + test + lint + format all pass. If `swift-format` rewrites anything in the edited block, accept its output — the project's CI enforces this style.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/App/RunwayApp.swift
+git commit -m "feat(app): show running/waiting/idle/error counts in toolbar"
+```
+
+---
+
+## Task 3: Manual verification
+
+**Files:** none (runtime verification only).
+
+- [ ] **Step 1: Launch the app**
+
+Run: `swift run Runway`
+
+Expected: app window opens. If there are sessions in the DB from prior runs, their statuses will drive the toolbar chips immediately.
+
+- [ ] **Step 2: Verify chips appear for each status**
+
+For each of the four statuses, confirm a chip appears with the correct count and a dot colored via `theme.chrome.*`:
+
+| Status | How to trigger | Expected chip |
+|--------|----------------|---------------|
+| `running` | Start a new session via ⌘N; while the agent is producing output | Filled green dot + count |
+| `waiting` | Let an agent reach a permission prompt (or use an agent that emits `UserPromptSubmit` → `Notification`) | Filled yellow dot + count |
+| `idle` | Let a running session finish producing output (agent prints and awaits input) | Open gray circle + count |
+| `error` | Start a session with an invalid command in settings, OR manually mark a session errored via the DB if easier | Filled red dot + count |
+
+Left-to-right order must be: running, waiting, idle, error.
+
+- [ ] **Step 3: Verify zero-count chips are hidden**
+
+Stop all sessions (Command menu → "Stop All Sessions"). With no sessions in any of the four tracked statuses, the entire `HStack` group should disappear from the toolbar.
+
+Delete stopped sessions (Command menu → "Delete Stopped Sessions") and confirm the toolbar group stays hidden when only no-op states (`starting`, `stopped`) or zero sessions exist.
+
+- [ ] **Step 4: Verify theme integration**
+
+Open Settings → switch between several themes (at minimum: one light, one dark, Noctis, Tokyo Night variants). Confirm the chip dot colors change with the theme (green/yellow/red intensity shifts). The count `Text` should remain legible in all themes.
+
+- [ ] **Step 5: Verify accessibility label**
+
+With VoiceOver enabled (⌘F5), focus each chip. Expected spoken label format: `"3 idle sessions"` (or `"1 running session"` — singular when count is 1).
+
+Hover the entire chip group: the `.help` tooltip should read e.g. `"2 running, 1 idle"` — only non-zero statuses, comma-separated.
+
+- [ ] **Step 6: Quit the app**
+
+Close the window or ⌘Q.
+
+- [ ] **Step 7: No commit required for this task**
+
+Task 3 is verification only. If you find a defect, fix it and commit under a new `fix:` message before proceeding. Otherwise move on.
+
+---
+
+## Final: Ready for PR
+
+After all three tasks are complete, the branch should contain two commits:
+
+1. `feat(models): add SessionStatusCounts helper for toolbar badges`
+2. `feat(app): show running/waiting/idle/error counts in toolbar`
+
+Then run the project's standard pre-ship flow:
+
+```bash
+# Simplify pass (catches reuse/quality/efficiency issues)
+# Run /simplify
+
+# Then the pre-ship or ship-it pipeline
+# Run /pre-ship  (or /ship-it for smaller changes)
+```

--- a/docs/superpowers/specs/2026-04-16-menu-bar-status-counts-design.md
+++ b/docs/superpowers/specs/2026-04-16-menu-bar-status-counts-design.md
@@ -1,0 +1,112 @@
+# Menu Bar Session Status Counts — Design
+
+**Date:** 2026-04-16
+**Branch:** `feature-menu-bar-status`
+**Status:** Approved
+
+## Problem
+
+The app window's toolbar (the top bar holding the Sessions/PRs picker, title, and action buttons) already surfaces live counts for two session statuses — `running` (green bolt) and `waiting` (orange raised hand) — via `toolbarSessionCounts` in `Sources/App/RunwayApp.swift:584-603`.
+
+Two gaps today:
+
+1. **Incomplete coverage.** `idle` and `error` sessions are invisible in the top bar even though they are part of the everyday picture (idle = agent waiting for user, error = needs attention).
+2. **Theme drift.** `toolbarSessionCounts` is the only place in the app using hardcoded `.green` / `.orange` system colors. Every other status surface uses `SessionStatusIndicator` (`Sources/Views/Shared/PRBadges.swift:275-348`) which is theme-aware (`theme.chrome.green` / `.yellow` / `.red` / `.textDim`).
+
+## Goal
+
+Extend the toolbar's status cluster to show counts for `running`, `waiting`, `idle`, and `error`, using the existing `SessionStatusIndicator` component so the visual vocabulary matches the sidebar and session rows.
+
+## Non-Goals
+
+- Click-to-filter sidebar from the toolbar chips (deferred).
+- `starting` and `stopped` counts — transient/terminal states, low signal in the top bar.
+- Count-change animation.
+- Extracting `toolbarSessionCounts` into its own file/module.
+
+## Design
+
+### Component Structure
+
+Replace the body of `toolbarSessionCounts` (currently two `Label`s) with a four-chip `HStack`. Each chip is:
+
+```swift
+HStack(spacing: 3) {
+    SessionStatusIndicator(status: .running, size: 7)
+    Text("\(count)")
+        .font(.caption)
+        .foregroundStyle(theme.chrome.text)
+}
+.accessibilityElement(children: .combine)
+.accessibilityLabel("\(count) running sessions")
+```
+
+The outer group is `HStack(spacing: 8)` mounted in the same `ToolbarItem(placement: .automatic)` at `Sources/App/RunwayApp.swift:579-581`.
+
+### Statuses and Order
+
+Left-to-right: `running → waiting → idle → error`. This keeps the most actionable (`running`, items needing input) leftmost and errors rightmost for contrast with the rest of the toolbar.
+
+### Visual Spec
+
+| Status | Indicator (from `SessionStatusIndicator` at size 7) | Count color |
+|--------|-----------------------------------------------------|-------------|
+| running | Filled green circle (`theme.chrome.green`) | `theme.chrome.text` |
+| waiting | Filled yellow circle (`theme.chrome.yellow`) | `theme.chrome.text` |
+| idle | Open circle, stroked (`theme.chrome.textDim`, 1.5pt) | `theme.chrome.text` |
+| error | Filled red circle (`theme.chrome.red`) | `theme.chrome.text` |
+
+At `size: 7` every status renders as a 7×7 shape per the existing `SessionStatusIndicator` logic — no `ProgressView` or SF Symbol paths hit at this size.
+
+### Count Computation
+
+Compute all four counts in a single pass rather than four separate `filter { … }.count` calls:
+
+```swift
+var running = 0, waiting = 0, idle = 0, error = 0
+for session in store.sessions {
+    switch session.status {
+    case .running: running += 1
+    case .waiting: waiting += 1
+    case .idle:    idle += 1
+    case .error:   error += 1
+    default:       break
+    }
+}
+```
+
+### Zero-Count Behavior
+
+- A chip is omitted entirely (not rendered at 0 opacity) when its count is 0.
+- If all four counts are 0, the entire `HStack` group renders as `EmptyView` — matches today's behavior where the toolbar item disappears when there's nothing to show.
+
+### Accessibility
+
+- Each chip's `HStack` gets `.accessibilityElement(children: .combine)` plus `.accessibilityLabel("\(count) \(statusName) sessions")`.
+- The outer group gets `.help(...)` summarising non-zero counts, replacing the current `"\(running) running, \(waiting) waiting"` tooltip. Format: `"2 running, 1 waiting, 3 idle"` (skips zeros).
+- `SessionStatusIndicator` already exposes its own `.help` and `.accessibilityLabel`; setting a parent label on the chip doesn't conflict since the accessibility tree is collapsed via `.combine`.
+
+## Files Affected
+
+| File | Change |
+|------|--------|
+| `Sources/App/RunwayApp.swift` | Rewrite `toolbarSessionCounts` (~20 lines → ~40 lines). No new properties: `ContentView` (which owns this method) already has `@Environment(\.theme) private var theme` at line 130. |
+
+No other files need to change. `SessionStatusIndicator` is already `public` and exported from the `Views` module which `RunwayApp` imports.
+
+## Testing
+
+- **Manual:** Start sessions in each of the four states, confirm each chip appears, disappears when count → 0, and updates live as statuses change. Switch themes (light/dark/Noctis/Tokyo Night variants) and confirm dot colors track the theme.
+- **Automated:** No existing pattern for toolbar snapshot tests in this codebase. A unit test on a helper that returns the four counts from a `[Session]` would be cheap but the computation is trivial enough to skip. Defer to any reviewer preference.
+
+## Risks & Open Questions
+
+- **Toolbar horizontal space.** Four chips plus the existing "New Session" and session-scoped buttons could crowd narrow windows. Each chip is ~20pt wide (dot + 1-digit count + spacing), so worst case ~100pt added. Acceptable at the 1200pt default window size; may need a priority/collapse rule later.
+- **Error visibility.** An `error` count > 0 is important but the chip looks identical in weight to the others. If this proves too subtle, a follow-up could add a subtle badge or pulse. Not in scope now.
+
+## Out of Scope (Future Work)
+
+- Click a chip → filter sidebar to that status.
+- `starting` spinner count (usually 0 or 1 and transient).
+- `stopped` count (usually high and noisy; lives in the sidebar anyway).
+- Animated count transitions.


### PR DESCRIPTION
## Summary

- Extends the app window's toolbar status cluster from 2 statuses (running, waiting) to 4 (adds `idle` and `error`).
- Reuses the existing theme-aware `SessionStatusIndicator` component — no more hardcoded `.green` / `.orange` system colors in the toolbar; chips now track the active theme.
- Extracts counting logic into a pure `SessionStatusCounts` helper in `Models`, unit-tested with 5 Swift Testing cases.

## Test Plan

- [x] `swift test` — all 336 tests pass (331 existing + 5 new).
- [x] `make check` — build + test + swiftlint + swift-format all green.
- [ ] Manual — launch app, trigger sessions in each of running/waiting/idle/error states; confirm chips appear with correct theme-aware dot colors, left-to-right order `running → waiting → idle → error`.
- [ ] Manual — stop all sessions; chip group vanishes entirely.
- [ ] Manual — switch themes (light/dark/Noctis/Tokyo Night); dot colors track the theme.
- [ ] Manual — hover group → tooltip reads e.g. \`"2 running, 1 idle"\`. VoiceOver on a chip reads e.g. \`"3 idle sessions"\` / \`"1 running session"\`.

## Design & Plan

- Design spec: \`docs/superpowers/specs/2026-04-16-menu-bar-status-counts-design.md\`
- Implementation plan: \`docs/superpowers/plans/2026-04-16-menu-bar-status-counts.md\`

_Implemented with assistance from Claude Code (Opus 4.7)._