### PR TITLE
feat: restart session dialog with Happy toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to Runway are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.9.5] — 2026-04-16
+
+### Added
+
+- **Restart session dialog** — clicking the hover-row or stopped-session restart button now opens a confirmation dialog with a "Launch with Happy" toggle, letting you flip Happy on/off at restart time regardless of the session's original launch configuration
+
+[0.9.5]: https://github.com/sjoeboo/runway/compare/v0.9.4...v0.9.5
+
 ## [0.9.4] — 2026-04-15
 
 ### Fixed

--- a/Sources/App/RunwayApp.swift
+++ b/Sources/App/RunwayApp.swift
@@ -214,6 +214,15 @@ struct ContentView: View {
                         }
                     )
                     .theme(theme)
+
+                case .restartSession(let sessionID):
+                    if let session = store.sessions.first(where: { $0.id == sessionID }) {
+                        RestartSessionDialog(session: session) { useHappy in
+                            Task { await store.restartSession(id: sessionID, withHappy: useHappy) }
+                            store.activeSheet = nil
+                        }
+                        .theme(theme)
+                    }
                 }
             }
 
@@ -465,7 +474,7 @@ struct ContentView: View {
                     diffOpenTrigger: store.diffOpenTrigger,
                     onActiveDiffPathChanged: { path in store.activeDiffPath = path },
                     onToggleChanges: { store.toggleChangesSidebar() },
-                    onRestart: { Task { await store.restartSession(id: sessionID) } },
+                    onRestart: { store.presentRestartDialog(id: sessionID) },
                     worktreeManager: session.worktreeBranch != nil ? store.worktreeManager : nil,
                     defaultBranch: store.projects.first(where: { $0.id == session.projectID })?.defaultBranch ?? "main",
                     onRollback: { hash in

--- a/Sources/App/RunwayStore.swift
+++ b/Sources/App/RunwayStore.swift
@@ -542,6 +542,27 @@ public final class RunwayStore {
     }
 
     public func restartSession(id: String) async {
+        await restartSession(id: id, withHappy: nil)
+    }
+
+    /// Restart a session, optionally flipping the Happy wrapper.
+    /// Pass `nil` to preserve the session's current `useHappy` value.
+    public func restartSession(id: String, withHappy: Bool?) async {
+        guard sessions.contains(where: { $0.id == id }) else { return }
+
+        // Persist the new Happy preference before restart so buildAgentCommand picks it up.
+        if let withHappy, let idx = sessions.firstIndex(where: { $0.id == id }),
+            withHappy != sessions[idx].useHappy
+        {
+            sessions[idx].useHappy = withHappy
+            do {
+                try database?.updateSessionUseHappy(id: id, useHappy: withHappy)
+            } catch {
+                print("[Runway] Failed to persist useHappy change: \(error)")
+            }
+        }
+
+        // Re-read session *after* the potential mutation so buildAgentCommand sees the new flag.
         guard let session = sessions.first(where: { $0.id == id }) else { return }
 
         // Transition to .starting so TerminalTabView clears its tabs
@@ -1311,6 +1332,11 @@ extension RunwayStore: SidebarActions {
         activeSheet = .newSession
     }
 
+    public func presentRestartDialog(id: String) {
+        guard sessions.contains(where: { $0.id == id }) else { return }
+        activeSheet = .restartSession(sessionID: id)
+    }
+
     public func newProject() {
         activeSheet = .newProject
     }
@@ -1396,6 +1422,7 @@ enum ActiveSheet: Identifiable {
     case newProject
     case reviewPRSheet
     case reviewPRDialog
+    case restartSession(sessionID: String)
 
     var id: String {
         switch self {
@@ -1403,6 +1430,7 @@ enum ActiveSheet: Identifiable {
         case .newProject: "newProject"
         case .reviewPRSheet: "reviewPRSheet"
         case .reviewPRDialog: "reviewPRDialog"
+        case .restartSession(let sid): "restartSession:\(sid)"
         }
     }
 }

--- a/Sources/Persistence/Database.swift
+++ b/Sources/Persistence/Database.swift
@@ -343,6 +343,15 @@ public final class Database: Sendable {
         }
     }
 
+    public func updateSessionUseHappy(id: String, useHappy: Bool) throws {
+        try db.write { db in
+            try db.execute(
+                sql: "UPDATE sessions SET useHappy = ? WHERE id = ?",
+                arguments: [useHappy, id]
+            )
+        }
+    }
+
     public func updateProjectSortOrder(id: String, sortOrder: Int) throws {
         try db.write { db in
             try db.execute(

--- a/Sources/Views/Shared/RestartSessionDialog.swift
+++ b/Sources/Views/Shared/RestartSessionDialog.swift
@@ -1,0 +1,65 @@
+import Models
+import SwiftUI
+import Theme
+
+/// Confirmation dialog shown before restarting a session, with an optional
+/// Happy-toggle for agents that support it.
+public struct RestartSessionDialog: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.theme) private var theme
+
+    let session: Session
+    let onConfirm: (_ useHappy: Bool) -> Void
+
+    @State private var useHappy: Bool
+
+    public init(session: Session, onConfirm: @escaping (_ useHappy: Bool) -> Void) {
+        self.session = session
+        self.onConfirm = onConfirm
+        self._useHappy = State(initialValue: session.useHappy)
+    }
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Restart session?")
+                    .font(.headline)
+                Text(session.title)
+                    .font(.callout)
+                    .foregroundColor(theme.chrome.textDim)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+
+            Text("The current terminal will be closed and the agent relaunched with its resume flag.")
+                .font(.callout)
+                .foregroundColor(theme.chrome.textDim)
+                .fixedSize(horizontal: false, vertical: true)
+
+            if session.tool.supportsHappy {
+                VStack(alignment: .leading, spacing: 6) {
+                    Toggle("Launch with Happy", isOn: $useHappy)
+                    if useHappy {
+                        Text("Wraps \(session.tool.displayName) in the Happy mobile companion.")
+                            .font(.caption)
+                            .foregroundColor(theme.chrome.textDim)
+                    }
+                }
+            }
+
+            HStack {
+                Button("Cancel") { dismiss() }
+                    .keyboardShortcut(.cancelAction)
+                Spacer()
+                Button("Restart") {
+                    onConfirm(useHappy)
+                    dismiss()
+                }
+                .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(24)
+        .frame(minWidth: 380, idealWidth: 420, maxWidth: 500)
+        .fixedSize(horizontal: false, vertical: true)
+    }
+}

--- a/Sources/Views/Sidebar/ProjectTreeView.swift
+++ b/Sources/Views/Sidebar/ProjectTreeView.swift
@@ -10,6 +10,7 @@ import Theme
 @MainActor
 public protocol SidebarActions {
     func restartSession(id: String) async
+    func presentRestartDialog(id: String)
     func forkSession(id: String)
     func deleteSession(id: String, deleteWorktree: Bool)
     func newSession(projectID: String?, parentID: String?)
@@ -483,7 +484,7 @@ struct SessionRowView: View {
 
             HStack(spacing: 4) {
                 Button {
-                    Task { await actions.restartSession(id: session.id) }
+                    actions.presentRestartDialog(id: session.id)
                 } label: {
                     Image(systemName: "arrow.counterclockwise")
                         .font(.callout)
@@ -491,7 +492,7 @@ struct SessionRowView: View {
                         .frame(width: 26, height: 26)
                 }
                 .buttonStyle(.plain)
-                .help("Restart session")
+                .help("Restart session\u{2026}")
                 .accessibilityLabel("Restart session")
 
                 Button {

--- a/Tests/PersistenceTests/DatabaseTests.swift
+++ b/Tests/PersistenceTests/DatabaseTests.swift
@@ -212,6 +212,18 @@ import Testing
     #expect(fetched?.useHappy == false)
 }
 
+@Test func updateSessionUseHappyFlipsFlag() throws {
+    let db = try Database(inMemory: true)
+    let session = Session(title: "toggle-happy", path: "/tmp", useHappy: false)
+    try db.saveSession(session)
+
+    try db.updateSessionUseHappy(id: session.id, useHappy: true)
+    #expect(try db.session(id: session.id)?.useHappy == true)
+
+    try db.updateSessionUseHappy(id: session.id, useHappy: false)
+    #expect(try db.session(id: session.id)?.useHappy == false)
+}
+
 @Test func sessionToolGeminiPersistence() throws {
     let db = try Database(inMemory: true)
     let session = Session(title: "gemini-test", path: "/tmp", tool: .gemini)


### PR DESCRIPTION
## Summary

Restarting a session now goes through a confirmation dialog with a "Launch with Happy" toggle, so you can flip Happy on/off at restart time regardless of how the session was originally launched. Two entry points open the same dialog: the sidebar hover-row restart button, and the stopped-session restart button inside the session detail view.

## Changes

- Add `RestartSessionDialog` (new file in `Sources/Views/Shared/`) — sheet with a Happy toggle that only appears for tools where `supportsHappy == true` (Claude/Gemini/Codex).
- Overload `RunwayStore.restartSession(id:withHappy:)` — the new variant persists the flag flip before calling the existing restart logic. Original `restartSession(id:)` becomes a thin wrapper so batch restart and the context-menu "Restart Session" item are unchanged (one-click affordances stay one-click).
- Add `ActiveSheet.restartSession(sessionID:)` — the dialog rides the existing `.sheet(item:)` plumbing in `RunwayApp`, with the session ID carried inside the case so the presentation is atomic.
- Add `SidebarActions.presentRestartDialog(id:)` — the sidebar hover button and the stopped-session restart button both route through this.
- Add `Database.updateSessionUseHappy(id:useHappy:)` — targeted updater mirroring the existing `updateSessionStatus`/`updateSessionPath` helpers.
- CHANGELOG entry for 0.9.5.

## Test Plan

- [x] `swift build` passes
- [x] `swift test` passes (333 tests, including new `updateSessionUseHappyFlipsFlag` round-trip)
- [x] Pre-commit hook (SwiftLint + swift-format) passes
- [x] Tested manually in the app — restart dialog opens from both entry points, toggle flips state, Cancel dismisses cleanly
- [ ] Screenshots (optional)

## Review Guidance

Start with `Sources/App/RunwayStore.swift` — the new overload at line 550 is the crux. Note the re-fetch of `session` *after* the mutation (line 565) — required so `buildAgentCommand` sees the new `useHappy` value.

## Notes

- Context-menu "Restart Session" and the batch `restartSessions(_:)` path intentionally still do direct restart without the dialog — the dialog is scoped to the primary click affordances.
- Version bumped as patch (0.9.5) to match the project's existing cadence for feature-sized changes (e.g., 0.9.3 was a new feature and also bumped patch). Happy to re-tag as minor if preferred.