### PR TITLE
feat: PR assignee management — drawer picker + Assigned tab + avatars column

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ Frameworks/GhosttyKit.xcframework/
 # Hangar config
 .hangar/
 .worktrees/
+
+# Superpowers brainstorming artifacts
+.superpowers/

--- a/Sources/App/PRCoordinator.swift
+++ b/Sources/App/PRCoordinator.swift
@@ -154,6 +154,12 @@ public final class PRCoordinator {
 
     // MARK: - Collaborators
 
+    /// Whether a collaborator fetch is currently in flight for this repo.
+    /// Used by the picker to show a ProgressView while the first load runs.
+    func isLoadingCollaborators(for repo: String) -> Bool {
+        loadingCollaboratorsRepos.contains(repo)
+    }
+
     /// Load collaborators for a repo, caching the result. Deduplicates concurrent calls.
     /// Hits the PRManager cache for instant re-reads within the 10-min TTL.
     func loadCollaborators(for repo: String, host: String? = nil) async {
@@ -541,6 +547,11 @@ public final class PRCoordinator {
         }
         whoamiByHost[host ?? ""] = login
         await updateAssignees(pr, adding: [login], removing: [])
+        // Mirror the self-assignment into the PR's origin set so the Assigned tab
+        // reflects the change immediately (rather than waiting for the next poll).
+        if let idx = pullRequests.firstIndex(where: { $0.id == pr.id }) {
+            pullRequests[idx].origin.insert(.assigned)
+        }
     }
 
     /// Unassign the current user from the PR.
@@ -552,6 +563,10 @@ public final class PRCoordinator {
         }
         whoamiByHost[host ?? ""] = login
         await updateAssignees(pr, adding: [], removing: [login])
+        // Remove .assigned locally so the PR disappears from the Assigned tab immediately.
+        if let idx = pullRequests.firstIndex(where: { $0.id == pr.id }) {
+            pullRequests[idx].origin.remove(.assigned)
+        }
     }
 
     /// Apply a set of assignee changes to a PR. Optimistic on success, reverts via re-enrichment

--- a/Sources/App/PRCoordinator.swift
+++ b/Sources/App/PRCoordinator.swift
@@ -35,6 +35,9 @@ public final class PRCoordinator {
     /// Populated lazily on first `warmWhoami(host:)` call per host.
     var whoamiByHost: [String: String] = [:]
 
+    /// Observable mirror of PRManager collaborators cache. Keyed by repo (e.g. "owner/repo").
+    var collaboratorsByRepo: [String: [Collaborator]] = [:]
+
     // MARK: - Private State
 
     private var prPollTask: Task<Void, Never>?
@@ -45,6 +48,9 @@ public final class PRCoordinator {
     private let sessionPRTTL: TimeInterval = 60
     private var detailCache: [String: (detail: PRDetail, fetchedAt: Date)] = [:]
     private let detailTTL: TimeInterval = 300
+
+    /// Tracks which repos have a load in-flight to avoid duplicate fetches.
+    private var loadingCollaboratorsRepos: Set<String> = []
 
     // MARK: - Dependencies
 
@@ -143,6 +149,26 @@ public final class PRCoordinator {
             if let login = try? await prManager.whoami(host: host) {
                 whoamiByHost[key] = login
             }
+        }
+    }
+
+    // MARK: - Collaborators
+
+    /// Load collaborators for a repo, caching the result. Deduplicates concurrent calls.
+    /// Hits the PRManager cache for instant re-reads within the 10-min TTL.
+    func loadCollaborators(for repo: String, host: String? = nil) async {
+        if let cached = await prManager.cachedCollaborators(for: repo) {
+            collaboratorsByRepo[repo] = cached
+            return
+        }
+        guard !loadingCollaboratorsRepos.contains(repo) else { return }
+        loadingCollaboratorsRepos.insert(repo)
+        defer { loadingCollaboratorsRepos.remove(repo) }
+        do {
+            let collabs = try await prManager.collaborators(repo: repo, host: host)
+            collaboratorsByRepo[repo] = collabs
+        } catch {
+            store?.statusMessage = .error("Couldn't load collaborators: \(error.localizedDescription)")
         }
     }
 

--- a/Sources/App/PRCoordinator.swift
+++ b/Sources/App/PRCoordinator.swift
@@ -529,6 +529,72 @@ public final class PRCoordinator {
         }
     }
 
+    // MARK: - Assignee Actions
+
+    /// Assign the current user to the PR. Optimistic UI: mutates pr.assignees before refresh.
+    func assignPRToMe(_ pr: PullRequest) async {
+        let host = prManager.hostFromURL(pr.url)
+        guard let login = try? await prManager.whoami(host: host) else {
+            store?.statusMessage = .error("Couldn't resolve your GitHub login")
+            return
+        }
+        whoamiByHost[host ?? ""] = login
+        await updateAssignees(pr, adding: [login], removing: [])
+    }
+
+    /// Unassign the current user from the PR.
+    func unassignMeFromPR(_ pr: PullRequest) async {
+        let host = prManager.hostFromURL(pr.url)
+        guard let login = try? await prManager.whoami(host: host) else {
+            store?.statusMessage = .error("Couldn't resolve your GitHub login")
+            return
+        }
+        whoamiByHost[host ?? ""] = login
+        await updateAssignees(pr, adding: [], removing: [login])
+    }
+
+    /// Apply a set of assignee changes to a PR. Optimistic on success, reverts via re-enrichment
+    /// on failure. Skips the gh subprocess when both lists are empty.
+    func updateAssignees(_ pr: PullRequest, adding: [String], removing: [String]) async {
+        guard !adding.isEmpty || !removing.isEmpty else { return }
+
+        // Optimistic update
+        let originalAssignees: [String]?
+        if let idx = pullRequests.firstIndex(where: { $0.id == pr.id }) {
+            originalAssignees = pullRequests[idx].assignees
+            var current = pullRequests[idx].assignees
+            for login in adding where !current.contains(login) { current.append(login) }
+            current.removeAll { removing.contains($0) }
+            pullRequests[idx].assignees = current
+        } else {
+            originalAssignees = nil
+        }
+
+        let host = prManager.hostFromURL(pr.url)
+        do {
+            if !adding.isEmpty {
+                try await prManager.assign(repo: pr.repo, number: pr.number, logins: adding, host: host)
+            }
+            if !removing.isEmpty {
+                try await prManager.unassign(repo: pr.repo, number: pr.number, logins: removing, host: host)
+            }
+            let parts: [String] = [
+                adding.isEmpty ? nil : "+\(adding.joined(separator: ","))",
+                removing.isEmpty ? nil : "-\(removing.joined(separator: ","))",
+            ].compactMap { $0 }
+            store?.statusMessage = .success("Updated assignees on #\(pr.number): \(parts.joined(separator: " "))")
+            await refreshPRAfterAction(pr)
+        } catch {
+            // Revert optimistic update
+            if let original = originalAssignees,
+                let idx = pullRequests.firstIndex(where: { $0.id == pr.id })
+            {
+                pullRequests[idx].assignees = original
+            }
+            store?.statusMessage = .error("Assign failed: \(error.localizedDescription)")
+        }
+    }
+
     // MARK: - PR Review Resolution
 
     func resolvePRForReview(number: Int, repo: String, host: String?) async {

--- a/Sources/App/PRCoordinator.swift
+++ b/Sources/App/PRCoordinator.swift
@@ -31,6 +31,10 @@ public final class PRCoordinator {
     var reviewPRCandidate: PullRequest? = nil
     var isResolvingPR: Bool = false
 
+    /// Mirror of PRManager whoami cache, observable to drive UI highlighting.
+    /// Populated lazily on first `warmWhoami(host:)` call per host.
+    var whoamiByHost: [String: String] = [:]
+
     // MARK: - Private State
 
     private var prPollTask: Task<Void, Never>?
@@ -121,6 +125,25 @@ public final class PRCoordinator {
         let staleness: TimeInterval = 60
         if let last = prLastFetched, Date().timeIntervalSince(last) < staleness { return }
         await fetchPRs()
+    }
+
+    // MARK: - Whoami
+
+    /// Synchronous accessor for the current user's login on a given host.
+    /// Returns nil until the first `warmWhoami(host:)` call resolves.
+    func myLogin(forHost host: String?) -> String? {
+        whoamiByHost[host ?? ""]
+    }
+
+    /// Populate the whoami mirror for a host if not already present. Safe to call repeatedly.
+    func warmWhoami(host: String?) {
+        let key = host ?? ""
+        guard whoamiByHost[key] == nil else { return }
+        Task { @MainActor in
+            if let login = try? await prManager.whoami(host: host) {
+                whoamiByHost[key] = login
+            }
+        }
     }
 
     // MARK: - PR Enrichment

--- a/Sources/App/PRCoordinator.swift
+++ b/Sources/App/PRCoordinator.swift
@@ -256,6 +256,7 @@ public final class PRCoordinator {
         pr.autoMergeEnabled = result.autoMergeEnabled
         pr.commentsSinceLastCommit = result.commentsSinceLastCommit
         pr.lastCommitDate = result.lastCommitDate
+        pr.assignees = result.assignees
         pr.enrichedAt = Date()
     }
 

--- a/Sources/App/RunwayApp.swift
+++ b/Sources/App/RunwayApp.swift
@@ -526,7 +526,28 @@ struct ContentView: View {
                 onReviewPR: { pr in store.reviewPR(pr) },
                 onEnableAutoMerge: { pr, strategy in Task { await store.prCoordinator.enableAutoMerge(pr, strategy: strategy) } },
                 onDisableAutoMerge: { pr in Task { await store.prCoordinator.disableAutoMerge(pr) } },
-                onClosePR: { pr in Task { await store.prCoordinator.closePR(pr) } }
+                onClosePR: { pr in Task { await store.prCoordinator.closePR(pr) } },
+                onAssignToMe: { pr in Task { await store.prCoordinator.assignPRToMe(pr) } },
+                onUnassignMe: { pr in Task { await store.prCoordinator.unassignMeFromPR(pr) } },
+                onToggleAssignee: { pr, login in
+                    Task {
+                        if pr.assignees.contains(login) {
+                            await store.prCoordinator.updateAssignees(pr, adding: [], removing: [login])
+                        } else {
+                            await store.prCoordinator.updateAssignees(pr, adding: [login], removing: [])
+                        }
+                    }
+                },
+                onLoadCollaborators: { repo in
+                    Task { await store.prCoordinator.loadCollaborators(for: repo) }
+                },
+                myLoginForHost: { host in
+                    store.prCoordinator.warmWhoami(host: host)
+                    return store.prCoordinator.myLogin(forHost: host)
+                },
+                collaboratorsForRepo: { repo in
+                    store.prCoordinator.collaboratorsByRepo[repo] ?? []
+                }
             )
         }
     }

--- a/Sources/App/RunwayApp.swift
+++ b/Sources/App/RunwayApp.swift
@@ -547,6 +547,9 @@ struct ContentView: View {
                 },
                 collaboratorsForRepo: { repo in
                     store.prCoordinator.collaboratorsByRepo[repo] ?? []
+                },
+                isLoadingCollaboratorsForRepo: { repo in
+                    store.prCoordinator.isLoadingCollaborators(for: repo)
                 }
             )
         }

--- a/Sources/GitHubOperations/PRManager.swift
+++ b/Sources/GitHubOperations/PRManager.swift
@@ -80,9 +80,9 @@ public actor PRManager {
         }
     }
 
-    /// Fetch both "mine" and "review-requested" PRs in parallel, merge and deduplicate.
+    /// Fetch "mine", "review-requested", and "assigned" PRs in parallel, merge and deduplicate.
     /// Each PR gets an `origin` set indicating which queries returned it.
-    /// A failure in one filter does not discard results from the other.
+    /// A failure in one filter does not discard results from the others.
     public func fetchAllPRs() async throws -> [PullRequest] {
         // Pre-resolve hosts on the actor so the parallel fetches don't re-enter.
         // Without this, async let + actor-isolated fetchPRs serializes instead of parallelizing.
@@ -90,16 +90,25 @@ public actor PRManager {
 
         async let minePRs: [PullRequest] = Self.fetchPRsNonisolated(hosts: hosts, filter: .mine)
         async let reviewPRs: [PullRequest] = Self.fetchPRsNonisolated(hosts: hosts, filter: .reviewRequested)
+        async let assignedPRs: [PullRequest] = Self.fetchPRsNonisolated(hosts: hosts, filter: .assigned)
 
-        let (mine, review) = await (minePRs, reviewPRs)
+        let (mine, review, assigned) = await (minePRs, reviewPRs, assignedPRs)
+        return Self.mergePRsByOrigin(mine: mine, reviewRequested: review, assigned: assigned)
+    }
 
-        // Merge: deduplicate by ID, combine origins
+    /// Merge three origin-tagged PR lists by id, combining origins into a single Set per PR.
+    /// Nonisolated + static so it is trivially testable without spinning up the actor.
+    nonisolated static func mergePRsByOrigin(
+        mine: [PullRequest],
+        reviewRequested: [PullRequest],
+        assigned: [PullRequest]
+    ) -> [PullRequest] {
         var merged: [String: PullRequest] = [:]
         for var pr in mine {
             pr.origin = [.mine]
             merged[pr.id] = pr
         }
-        for var pr in review {
+        for var pr in reviewRequested {
             pr.origin = [.reviewRequested]
             if var existing = merged[pr.id] {
                 existing.origin.insert(.reviewRequested)
@@ -108,7 +117,15 @@ public actor PRManager {
                 merged[pr.id] = pr
             }
         }
-
+        for var pr in assigned {
+            pr.origin = [.assigned]
+            if var existing = merged[pr.id] {
+                existing.origin.insert(.assigned)
+                merged[pr.id] = existing
+            } else {
+                merged[pr.id] = pr
+            }
+        }
         return Array(merged.values)
     }
 

--- a/Sources/GitHubOperations/PRManager.swift
+++ b/Sources/GitHubOperations/PRManager.swift
@@ -45,6 +45,7 @@ public actor PRManager {
     /// Cached hosts from `gh auth status` — rarely changes at runtime
     private var cachedHosts: [String]?
     private var hostsCacheTime: Date?
+    private var cachedWhoamiByHost: [String: String] = [:]
 
     public init() {}
 
@@ -353,6 +354,30 @@ public actor PRManager {
         }
         return allPRs
     }
+
+    /// Returns the current user's login for the given host, fetching and caching on first call.
+    /// Per-host because the same user may have different logins on different GHE instances.
+    public func whoami(host: String? = nil) async throws -> String {
+        let key = host ?? ""
+        if let cached = cachedWhoamiByHost[key] { return cached }
+        let output = try await runGH(args: ["api", "user", "-q", ".login"], host: host)
+        let login = output.trimmingCharacters(in: .whitespacesAndNewlines)
+        cachedWhoamiByHost[key] = login
+        return login
+    }
+
+    /// Returns the cached whoami for a host without triggering a fetch. Used by UI
+    /// that needs synchronous access and can tolerate `nil` until the cache warms.
+    public func cachedWhoami(host: String?) -> String? {
+        cachedWhoamiByHost[host ?? ""]
+    }
+
+    #if DEBUG
+        /// Test-only: seed the whoami cache to bypass the gh shellout.
+        public func seedWhoamiForTest(host: String?, login: String) {
+            cachedWhoamiByHost[host ?? ""] = login
+        }
+    #endif
 
     // MARK: - Private
 

--- a/Sources/GitHubOperations/PRManager.swift
+++ b/Sources/GitHubOperations/PRManager.swift
@@ -46,6 +46,8 @@ public actor PRManager {
     private var cachedHosts: [String]?
     private var hostsCacheTime: Date?
     private var cachedWhoamiByHost: [String: String] = [:]
+    private var cachedCollaboratorsByRepo: [String: (data: [Collaborator], fetchedAt: Date)] = [:]
+    private let collaboratorsTTL: TimeInterval = 600
 
     public init() {}
 
@@ -378,6 +380,50 @@ public actor PRManager {
             cachedWhoamiByHost[host ?? ""] = login
         }
     #endif
+
+    /// Fetch the collaborator list for a repo. Cached per-repo with a 10-min TTL.
+    public func collaborators(repo: String, host: String? = nil) async throws -> [Collaborator] {
+        if let entry = cachedCollaboratorsByRepo[repo],
+            Date().timeIntervalSince(entry.fetchedAt) < collaboratorsTTL
+        {
+            return entry.data
+        }
+        let output = try await runGH(
+            args: ["api", "repos/\(repo)/collaborators", "--paginate", "--slurp"],
+            host: host
+        )
+        let collabs = try Self.parseCollaborators(output)
+        cachedCollaboratorsByRepo[repo] = (collabs, Date())
+        return collabs
+    }
+
+    /// Synchronous read of the cached collaborator list (nil if not loaded or stale).
+    public func cachedCollaborators(for repo: String) -> [Collaborator]? {
+        guard let entry = cachedCollaboratorsByRepo[repo],
+            Date().timeIntervalSince(entry.fetchedAt) < collaboratorsTTL
+        else { return nil }
+        return entry.data
+    }
+
+    #if DEBUG
+        /// Test-only seeder for the collaborators cache.
+        public func seedCollaboratorsForTest(repo: String, collabs: [Collaborator]) {
+            cachedCollaboratorsByRepo[repo] = (collabs, Date())
+        }
+    #endif
+
+    /// Parse `gh api repos/.../collaborators --paginate --slurp` output (array of pages).
+    /// Dedup by login, preserve first-occurrence order.
+    nonisolated static func parseCollaborators(_ json: String) throws -> [Collaborator] {
+        guard let data = json.data(using: .utf8) else { return [] }
+        let pages = try JSONDecoder().decode([[GHCollaboratorUser]].self, from: data)
+        var seen = Set<String>()
+        var result: [Collaborator] = []
+        for user in pages.flatMap({ $0 }) where seen.insert(user.login).inserted {
+            result.append(Collaborator(login: user.login, name: user.name))
+        }
+        return result
+    }
 
     // MARK: - Private
 
@@ -942,6 +988,11 @@ public struct PRFingerprint: Equatable, Sendable {
 
 private struct GHFingerprintItem: Decodable {
     let updatedAt: String?
+}
+
+private struct GHCollaboratorUser: Decodable {
+    let login: String
+    let name: String?
 }
 
 // MARK: - JSONDecoder for gh output

--- a/Sources/GitHubOperations/PRManager.swift
+++ b/Sources/GitHubOperations/PRManager.swift
@@ -54,7 +54,7 @@ public actor PRManager {
     /// When `repo` is provided, uses `gh pr list` scoped to that repo.
     public func fetchPRs(repo: String? = nil, filter: PRFilter = .mine) async throws -> [PullRequest] {
         if let repo {
-            let args = buildListArgs(repo: repo, filter: filter)
+            let args = Self.buildListArgs(repo: repo, filter: filter)
             let output = try await runGH(args: args)
             return try parsePRList(output)
         } else {
@@ -63,7 +63,7 @@ public actor PRManager {
             var allPRs: [PullRequest] = []
 
             for host in hosts {
-                let args = buildSearchArgs(filter: filter)
+                let args = Self.buildSearchArgs(filter: filter)
                 if let output = try? await runGH(args: args, host: host) {
                     let prs = (try? parseSearchResults(output)) ?? []
                     allPRs.append(contentsOf: prs)
@@ -327,6 +327,7 @@ public actor PRManager {
         switch filter {
         case .mine: args += ["--author", "@me"]
         case .reviewRequested: args += ["--review-requested", "@me"]
+        case .assigned: args += ["--assignee", "@me"]
         case .all: break
         }
         // gh search --json returns an array; also print total via --jq is fragile,
@@ -341,18 +342,7 @@ public actor PRManager {
     /// Nonisolated helper for parallel PR fetching — avoids actor re-entrance serialization.
     /// Hosts are pre-resolved on the actor; shell calls and parsing run off-actor.
     nonisolated private static func fetchPRsNonisolated(hosts: [String], filter: PRFilter) async -> [PullRequest] {
-        var args = [
-            "search", "prs",
-            "--state", "open",
-            "--archived=false",
-            "--json", "number,title,state,repository,url,isDraft,createdAt,updatedAt,author",
-            "--limit", "50",
-        ]
-        switch filter {
-        case .mine: args += ["--author", "@me"]
-        case .reviewRequested: args += ["--review-requested", "@me"]
-        case .all: break
-        }
+        let args = Self.buildSearchArgs(filter: filter)
 
         var allPRs: [PullRequest] = []
         for host in hosts {
@@ -385,7 +375,7 @@ public actor PRManager {
         return hosts.isEmpty ? ["github.com"] : hosts
     }
 
-    private func buildSearchArgs(filter: PRFilter) -> [String] {
+    nonisolated static func buildSearchArgs(filter: PRFilter) -> [String] {
         var args = [
             "search", "prs",
             "--state", "open",
@@ -399,14 +389,16 @@ public actor PRManager {
             args += ["--author", "@me"]
         case .reviewRequested:
             args += ["--review-requested", "@me"]
+        case .assigned:
+            args += ["--assignee", "@me"]
         case .all:
-            break  // No author filter — show all open PRs
+            break
         }
 
         return args
     }
 
-    private func buildListArgs(repo: String, filter: PRFilter) -> [String] {
+    nonisolated static func buildListArgs(repo: String, filter: PRFilter) -> [String] {
         var args = [
             "pr", "list", "--json",
             "number,title,state,headRefName,baseRefName,author,url,isDraft,additions,deletions,changedFiles,createdAt,updatedAt,reviewDecision",
@@ -418,6 +410,8 @@ public actor PRManager {
             args += ["--author", "@me"]
         case .reviewRequested:
             args += ["--search", "review-requested:@me"]
+        case .assigned:
+            args += ["--assignee", "@me"]
         case .all:
             break
         }
@@ -476,6 +470,7 @@ public struct Collaborator: Identifiable, Sendable, Hashable, Codable {
 public enum PRFilter: Sendable {
     case mine
     case reviewRequested
+    case assigned
     case all
 }
 

--- a/Sources/GitHubOperations/PRManager.swift
+++ b/Sources/GitHubOperations/PRManager.swift
@@ -278,6 +278,25 @@ public actor PRManager {
         )
     }
 
+    /// Assign the given logins to a PR. Single subprocess (gh accepts comma-joined list).
+    public func assign(repo: String, number: Int, logins: [String], host: String? = nil) async throws {
+        guard !logins.isEmpty else { return }
+        let args = Self.buildAssignArgs(repo: repo, number: number, logins: logins, add: true)
+        try await runGH(args: args, host: host)
+    }
+
+    /// Remove assignees from a PR. No-op if logins is empty.
+    public func unassign(repo: String, number: Int, logins: [String], host: String? = nil) async throws {
+        guard !logins.isEmpty else { return }
+        let args = Self.buildAssignArgs(repo: repo, number: number, logins: logins, add: false)
+        try await runGH(args: args, host: host)
+    }
+
+    nonisolated static func buildAssignArgs(repo: String, number: Int, logins: [String], add: Bool) -> [String] {
+        let flag = add ? "--add-assignee" : "--remove-assignee"
+        return ["pr", "edit", "\(number)", "--repo", repo, flag, logins.joined(separator: ",")]
+    }
+
     /// Update a PR branch with the latest base branch (merge or rebase).
     public func updateBranch(repo: String, number: Int, rebase: Bool = false, host: String? = nil) async throws {
         var args = ["pr", "update-branch", "\(number)", "--repo", repo]

--- a/Sources/GitHubOperations/PRManager.swift
+++ b/Sources/GitHubOperations/PRManager.swift
@@ -457,6 +457,20 @@ public actor PRManager {
     }
 }
 
+// MARK: - Collaborator
+
+public struct Collaborator: Identifiable, Sendable, Hashable, Codable {
+    public let login: String
+    public let name: String?
+
+    public init(login: String, name: String? = nil) {
+        self.login = login
+        self.name = name
+    }
+
+    public var id: String { login }
+}
+
 // MARK: - Types
 
 public enum PRFilter: Sendable {

--- a/Sources/GitHubOperations/PRManager.swift
+++ b/Sources/GitHubOperations/PRManager.swift
@@ -15,6 +15,7 @@ public struct PREnrichResult: Sendable {
     public var autoMergeEnabled: Bool
     public var commentsSinceLastCommit: Int
     public var lastCommitDate: Date?
+    public var assignees: [String]
 
     public init(
         checks: CheckSummary = CheckSummary(), reviewDecision: ReviewDecision = .none,
@@ -23,7 +24,8 @@ public struct PREnrichResult: Sendable {
         mergeable: MergeableState? = nil, mergeStateStatus: MergeStateStatus? = nil,
         autoMergeEnabled: Bool = false,
         commentsSinceLastCommit: Int = 0,
-        lastCommitDate: Date? = nil
+        lastCommitDate: Date? = nil,
+        assignees: [String] = []
     ) {
         self.checks = checks
         self.reviewDecision = reviewDecision
@@ -37,6 +39,7 @@ public struct PREnrichResult: Sendable {
         self.autoMergeEnabled = autoMergeEnabled
         self.commentsSinceLastCommit = commentsSinceLastCommit
         self.lastCommitDate = lastCommitDate
+        self.assignees = assignees
     }
 }
 
@@ -134,7 +137,7 @@ public actor PRManager {
                 "pr", "view", "\(number)",
                 "--repo", repo,
                 "--json",
-                "statusCheckRollup,reviewDecision,headRefName,baseRefName,additions,deletions,changedFiles,mergeable,mergeStateStatus,autoMergeRequest,comments,commits",
+                "statusCheckRollup,reviewDecision,headRefName,baseRefName,additions,deletions,changedFiles,mergeable,mergeStateStatus,autoMergeRequest,comments,commits,assignees",
             ], host: host)
         guard let data = output.data(using: .utf8) else {
             return PREnrichResult()
@@ -150,7 +153,7 @@ public actor PRManager {
                 "pr", "view", "\(number)",
                 "--repo", repo,
                 "--json",
-                "body,reviews,comments,files,statusCheckRollup,reviewDecision,headRefName,baseRefName,additions,deletions,changedFiles,mergeable,mergeStateStatus,autoMergeRequest",
+                "body,reviews,comments,files,statusCheckRollup,reviewDecision,headRefName,baseRefName,additions,deletions,changedFiles,mergeable,mergeStateStatus,autoMergeRequest,assignees",
             ], host: host)
         var detail = try parsePRDetail(output)
 
@@ -409,6 +412,16 @@ public actor PRManager {
         /// Test-only seeder for the collaborators cache.
         public func seedCollaboratorsForTest(repo: String, collabs: [Collaborator]) {
             cachedCollaboratorsByRepo[repo] = (collabs, Date())
+        }
+    #endif
+
+    #if DEBUG
+        /// Test-only: parse an enrich response from raw JSON data.
+        nonisolated static func parseEnrichResponseForTest(data: Data, excludeAuthor: String?) throws -> PREnrichResult {
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+            let resp = try decoder.decode(GHEnrichResponse.self, from: data)
+            return resp.toEnrichResult(excludeAuthor: excludeAuthor)
         }
     #endif
 
@@ -725,6 +738,7 @@ private struct GHPRDetailResponse: Decodable {
     let mergeable: String?
     let mergeStateStatus: String?
     let autoMergeRequest: GHAutoMergeRequest?
+    let assignees: [GHAuthor]?
 
     func toPRDetail() -> PRDetail {
         let rollup = statusCheckRollup ?? []
@@ -769,7 +783,8 @@ private struct GHPRDetailResponse: Decodable {
             changedFiles: changedFiles ?? 0,
             mergeable: MergeableState(rawValue: mergeable ?? ""),
             mergeStateStatus: MergeStateStatus(rawValue: mergeStateStatus ?? ""),
-            autoMergeEnabled: autoMergeRequest != nil
+            autoMergeEnabled: autoMergeRequest != nil,
+            assignees: (assignees ?? []).map(\.login)
         )
     }
 
@@ -858,6 +873,7 @@ private struct GHEnrichResponse: Decodable {
     let autoMergeRequest: GHAutoMergeRequest?
     let comments: [GHComment]?
     let commits: [GHCommit]?
+    let assignees: [GHAuthor]?
 
     func toEnrichResult(excludeAuthor: String? = nil) -> PREnrichResult {
         let checks = parseChecks(statusCheckRollup ?? [])
@@ -873,6 +889,7 @@ private struct GHEnrichResponse: Decodable {
         let commentsSinceLastCommit = Self.countCommentsSinceCommit(
             comments: comments, lastCommitDate: lastCommitDate, excludeAuthor: excludeAuthor
         )
+        let assigneeLogins = (assignees ?? []).map(\.login)
 
         return PREnrichResult(
             checks: checks, reviewDecision: review,
@@ -882,7 +899,8 @@ private struct GHEnrichResponse: Decodable {
             mergeStateStatus: MergeStateStatus(rawValue: mergeStateStatus ?? ""),
             autoMergeEnabled: autoMergeRequest != nil,
             commentsSinceLastCommit: commentsSinceLastCommit,
-            lastCommitDate: lastCommitDate
+            lastCommitDate: lastCommitDate,
+            assignees: assigneeLogins
         )
     }
 

--- a/Sources/Models/PullRequest.swift
+++ b/Sources/Models/PullRequest.swift
@@ -223,6 +223,7 @@ public struct PRDetail: Codable, Sendable {
     public var mergeable: MergeableState?
     public var mergeStateStatus: MergeStateStatus?
     public var autoMergeEnabled: Bool
+    public var assignees: [String]
 
     public init(
         body: String = "",
@@ -239,7 +240,8 @@ public struct PRDetail: Codable, Sendable {
         changedFiles: Int = 0,
         mergeable: MergeableState? = nil,
         mergeStateStatus: MergeStateStatus? = nil,
-        autoMergeEnabled: Bool = false
+        autoMergeEnabled: Bool = false,
+        assignees: [String] = []
     ) {
         self.body = body
         self.reviews = reviews
@@ -256,6 +258,7 @@ public struct PRDetail: Codable, Sendable {
         self.mergeable = mergeable
         self.mergeStateStatus = mergeStateStatus
         self.autoMergeEnabled = autoMergeEnabled
+        self.assignees = assignees
     }
 }
 

--- a/Sources/Models/PullRequest.swift
+++ b/Sources/Models/PullRequest.swift
@@ -89,6 +89,7 @@ public struct PullRequest: Identifiable, Codable, Sendable, Equatable {
 public enum PROrigin: String, Codable, Sendable, Hashable {
     case mine
     case reviewRequested
+    case assigned
 }
 
 // MARK: - PR State

--- a/Sources/Models/PullRequest.swift
+++ b/Sources/Models/PullRequest.swift
@@ -26,6 +26,7 @@ public struct PullRequest: Identifiable, Codable, Sendable, Equatable {
     public var autoMergeEnabled: Bool
     public var commentsSinceLastCommit: Int
     public var lastCommitDate: Date?
+    public var assignees: [String]
 
     public init(
         number: Int,
@@ -50,7 +51,8 @@ public struct PullRequest: Identifiable, Codable, Sendable, Equatable {
         mergeStateStatus: MergeStateStatus? = nil,
         autoMergeEnabled: Bool = false,
         commentsSinceLastCommit: Int = 0,
-        lastCommitDate: Date? = nil
+        lastCommitDate: Date? = nil,
+        assignees: [String] = []
     ) {
         self.id = "\(repo)#\(number)"
         self.number = number
@@ -76,6 +78,7 @@ public struct PullRequest: Identifiable, Codable, Sendable, Equatable {
         self.autoMergeEnabled = autoMergeEnabled
         self.commentsSinceLastCommit = commentsSinceLastCommit
         self.lastCommitDate = lastCommitDate
+        self.assignees = assignees
     }
 
     public var needsEnrichment: Bool {

--- a/Sources/Views/PRDashboard/AssigneePicker.swift
+++ b/Sources/Views/PRDashboard/AssigneePicker.swift
@@ -1,0 +1,171 @@
+import GitHubOperations
+import Models
+import SwiftUI
+import Theme
+
+/// Popover-hosted picker for PR assignees. Shows a top "Assign to me" pill,
+/// a search field, and a scrollable list of repo collaborators with
+/// check indicators for currently-assigned logins.
+public struct AssigneePickerView: View {
+    let pr: PullRequest
+    let myLogin: String?
+    let collaborators: [Collaborator]
+    let isLoading: Bool
+    let onAssignToMe: () -> Void
+    let onUnassignMe: () -> Void
+    let onToggle: (String) -> Void
+
+    @State private var query: String = ""
+    @Environment(\.theme) private var theme
+
+    public init(
+        pr: PullRequest,
+        myLogin: String?,
+        collaborators: [Collaborator],
+        isLoading: Bool,
+        onAssignToMe: @escaping () -> Void,
+        onUnassignMe: @escaping () -> Void,
+        onToggle: @escaping (String) -> Void
+    ) {
+        self.pr = pr
+        self.myLogin = myLogin
+        self.collaborators = collaborators
+        self.isLoading = isLoading
+        self.onAssignToMe = onAssignToMe
+        self.onUnassignMe = onUnassignMe
+        self.onToggle = onToggle
+    }
+
+    public var body: some View {
+        VStack(spacing: 8) {
+            mePill
+            Divider()
+            searchField
+            Divider()
+            listContent
+        }
+        .padding(12)
+        .frame(width: 360, height: 420)
+        .background(theme.chrome.surface)
+    }
+
+    // MARK: - Pill
+
+    @ViewBuilder
+    private var mePill: some View {
+        if let myLogin {
+            let isAssigned = pr.assignees.contains(myLogin)
+            Button {
+                if isAssigned { onUnassignMe() } else { onAssignToMe() }
+            } label: {
+                HStack {
+                    Image(
+                        systemName: isAssigned
+                            ? "person.crop.circle.badge.minus" : "person.crop.circle.badge.plus"
+                    )
+                    Text(isAssigned ? "Unassign me" : "Assign to me")
+                        .fontWeight(.medium)
+                    Spacer()
+                }
+                .padding(.vertical, 6)
+                .padding(.horizontal, 10)
+                .frame(maxWidth: .infinity)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(theme.chrome.green.opacity(0.15))
+                )
+                .foregroundColor(theme.chrome.green)
+            }
+            .buttonStyle(.plain)
+        } else {
+            Text("Resolving your login…")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    // MARK: - Search
+
+    private var searchField: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "magnifyingglass").foregroundStyle(.secondary)
+            TextField("Filter collaborators…", text: $query)
+                .textFieldStyle(.plain)
+        }
+        .padding(.horizontal, 6)
+        .padding(.vertical, 4)
+        .background(RoundedRectangle(cornerRadius: 6).fill(theme.chrome.background))
+    }
+
+    // MARK: - List
+
+    @ViewBuilder
+    private var listContent: some View {
+        if isLoading && collaborators.isEmpty {
+            VStack {
+                Spacer()
+                ProgressView("Loading collaborators…")
+                Spacer()
+            }
+        } else {
+            let filtered = Self.filter(collaborators: collaborators, query: query)
+            if filtered.isEmpty {
+                VStack {
+                    Spacer()
+                    Text("No matches").foregroundStyle(.secondary)
+                    Spacer()
+                }
+            } else {
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 2) {
+                        ForEach(filtered) { collab in
+                            row(for: collab)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func row(for collab: Collaborator) -> some View {
+        let isAssigned = pr.assignees.contains(collab.login)
+        let isMe = collab.login == myLogin
+        return Button {
+            onToggle(collab.login)
+        } label: {
+            HStack(spacing: 8) {
+                AssigneeAvatar(login: collab.login, isMe: isMe, size: 20)
+                VStack(alignment: .leading, spacing: 0) {
+                    Text(collab.login).font(.callout)
+                    if let name = collab.name, !name.isEmpty {
+                        Text(name).font(.caption).foregroundStyle(.secondary)
+                    }
+                }
+                Spacer()
+                if isAssigned {
+                    Image(systemName: "checkmark").foregroundColor(theme.chrome.green)
+                }
+            }
+            .padding(.vertical, 4)
+            .padding(.horizontal, 6)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Pure helper (testable)
+
+    nonisolated public static func filter(
+        collaborators: [Collaborator], query: String
+    )
+        -> [Collaborator]
+    {
+        let trimmed = query.trimmingCharacters(in: .whitespaces).lowercased()
+        guard !trimmed.isEmpty else { return collaborators }
+        return collaborators.filter { collab in
+            if collab.login.lowercased().contains(trimmed) { return true }
+            if let name = collab.name?.lowercased(), name.contains(trimmed) { return true }
+            return false
+        }
+    }
+}

--- a/Sources/Views/PRDashboard/PRDashboardView.swift
+++ b/Sources/Views/PRDashboard/PRDashboardView.swift
@@ -1,3 +1,4 @@
+import GitHubOperations
 import Models
 import SwiftUI
 import Theme
@@ -23,6 +24,12 @@ public struct PRDashboardView: View {
     var onEnableAutoMerge: ((PullRequest, MergeStrategy) -> Void)?
     var onDisableAutoMerge: ((PullRequest) -> Void)?
     var onClosePR: ((PullRequest) -> Void)?
+    var onAssignToMe: ((PullRequest) -> Void)?
+    var onUnassignMe: ((PullRequest) -> Void)?
+    var onToggleAssignee: ((PullRequest, String) -> Void)?
+    var onLoadCollaborators: ((String) -> Void)?
+    var myLoginForHost: ((String?) -> String?)?
+    var collaboratorsForRepo: ((String) -> [Collaborator])?
 
     @AppStorage("prListWidth") private var prListWidth: Double = 380
     @AppStorage("hideDrafts") private var hideDrafts: Bool = false
@@ -78,7 +85,13 @@ public struct PRDashboardView: View {
         onReviewPR: ((PullRequest) -> Void)? = nil,
         onEnableAutoMerge: ((PullRequest, MergeStrategy) -> Void)? = nil,
         onDisableAutoMerge: ((PullRequest) -> Void)? = nil,
-        onClosePR: ((PullRequest) -> Void)? = nil
+        onClosePR: ((PullRequest) -> Void)? = nil,
+        onAssignToMe: ((PullRequest) -> Void)? = nil,
+        onUnassignMe: ((PullRequest) -> Void)? = nil,
+        onToggleAssignee: ((PullRequest, String) -> Void)? = nil,
+        onLoadCollaborators: ((String) -> Void)? = nil,
+        myLoginForHost: ((String?) -> String?)? = nil,
+        collaboratorsForRepo: ((String) -> [Collaborator])? = nil
     ) {
         self.pullRequests = pullRequests
         self.selectedPRID = selectedPRID
@@ -99,6 +112,12 @@ public struct PRDashboardView: View {
         self.onEnableAutoMerge = onEnableAutoMerge
         self.onDisableAutoMerge = onDisableAutoMerge
         self.onClosePR = onClosePR
+        self.onAssignToMe = onAssignToMe
+        self.onUnassignMe = onUnassignMe
+        self.onToggleAssignee = onToggleAssignee
+        self.onLoadCollaborators = onLoadCollaborators
+        self.myLoginForHost = myLoginForHost
+        self.collaboratorsForRepo = collaboratorsForRepo
     }
 
     private var selectedPR: PullRequest? {
@@ -194,7 +213,21 @@ public struct PRDashboardView: View {
                     },
                     onClosePR: onClosePR.map { callback in
                         { callback(pr) }
-                    }
+                    },
+                    onAssignToMe: onAssignToMe.map { callback in
+                        { callback(pr) }
+                    },
+                    onUnassignMe: onUnassignMe.map { callback in
+                        { callback(pr) }
+                    },
+                    onToggleAssignee: onToggleAssignee.map { callback in
+                        { login in callback(pr, login) }
+                    },
+                    onLoadCollaborators: onLoadCollaborators.map { callback in
+                        { callback(pr.repo) }
+                    },
+                    myLogin: myLoginForHost?(hostFromURL(pr.url)),
+                    collaborators: collaboratorsForRepo?(pr.repo) ?? []
                 )
                 .frame(maxWidth: .infinity)
             }
@@ -367,6 +400,11 @@ public struct PRDashboardView: View {
 
     private func prStateBadge(_ pr: PullRequest) -> some View {
         PRStateDot(state: pr.state)
+    }
+
+    private func hostFromURL(_ url: String) -> String? {
+        guard let parsed = URL(string: url), let host = parsed.host else { return nil }
+        return host == "github.com" ? nil : host
     }
 
     private func prRepoShortName(_ pr: PullRequest) -> String {

--- a/Sources/Views/PRDashboard/PRDashboardView.swift
+++ b/Sources/Views/PRDashboard/PRDashboardView.swift
@@ -30,6 +30,7 @@ public struct PRDashboardView: View {
     var onLoadCollaborators: ((String) -> Void)?
     var myLoginForHost: ((String?) -> String?)?
     var collaboratorsForRepo: ((String) -> [Collaborator])?
+    var isLoadingCollaboratorsForRepo: ((String) -> Bool)?
 
     @AppStorage("prListWidth") private var prListWidth: Double = 380
     @AppStorage("hideDrafts") private var hideDrafts: Bool = false
@@ -91,7 +92,8 @@ public struct PRDashboardView: View {
         onToggleAssignee: ((PullRequest, String) -> Void)? = nil,
         onLoadCollaborators: ((String) -> Void)? = nil,
         myLoginForHost: ((String?) -> String?)? = nil,
-        collaboratorsForRepo: ((String) -> [Collaborator])? = nil
+        collaboratorsForRepo: ((String) -> [Collaborator])? = nil,
+        isLoadingCollaboratorsForRepo: ((String) -> Bool)? = nil
     ) {
         self.pullRequests = pullRequests
         self.selectedPRID = selectedPRID
@@ -118,6 +120,7 @@ public struct PRDashboardView: View {
         self.onLoadCollaborators = onLoadCollaborators
         self.myLoginForHost = myLoginForHost
         self.collaboratorsForRepo = collaboratorsForRepo
+        self.isLoadingCollaboratorsForRepo = isLoadingCollaboratorsForRepo
     }
 
     private var selectedPR: PullRequest? {
@@ -229,7 +232,8 @@ public struct PRDashboardView: View {
                         { callback(pr.repo) }
                     },
                     myLogin: myLoginForHost?(hostFromURL(pr.url)),
-                    collaborators: collaboratorsForRepo?(pr.repo) ?? []
+                    collaborators: collaboratorsForRepo?(pr.repo) ?? [],
+                    isLoadingCollaborators: isLoadingCollaboratorsForRepo?(pr.repo) ?? false
                 )
                 .frame(maxWidth: .infinity)
             }

--- a/Sources/Views/PRDashboard/PRDashboardView.swift
+++ b/Sources/Views/PRDashboard/PRDashboardView.swift
@@ -280,6 +280,25 @@ public struct PRDashboardView: View {
             }
             .width(min: 60, ideal: 90, max: 200)
 
+            TableColumn("Assignees", value: \.assigneeSortKey) { pr in
+                if !pr.assignees.isEmpty {
+                    let me = myLoginForHost?(hostFromURL(pr.url))
+                    HStack(spacing: -4) {
+                        ForEach(pr.assignees.prefix(3), id: \.self) { login in
+                            AssigneeAvatar(login: login, isMe: login == me, size: 14)
+                        }
+                        if pr.assignees.count > 3 {
+                            Text("+\(pr.assignees.count - 3)")
+                                .font(.caption2)
+                                .frame(width: 14, height: 14)
+                                .background(Circle().fill(theme.chrome.surface))
+                                .foregroundColor(theme.chrome.textDim)
+                        }
+                    }
+                }
+            }
+            .width(min: 40, ideal: 80, max: 140)
+
             TableColumn("Age", value: \.createdAt) { pr in
                 Text(pr.ageText)
                     .font(.caption)

--- a/Sources/Views/PRDashboard/PRDashboardView.swift
+++ b/Sources/Views/PRDashboard/PRDashboardView.swift
@@ -136,6 +136,8 @@ public struct PRDashboardView: View {
             result = result.filter { $0.origin.contains(.mine) }
         case .reviewRequested:
             result = result.filter { $0.origin.contains(.reviewRequested) }
+        case .assigned:
+            result = result.filter { $0.origin.contains(.assigned) }
         }
 
         if showSessionPRsOnly {
@@ -517,4 +519,5 @@ public enum PRTab: String, CaseIterable, Sendable {
     case all = "All"
     case mine = "Mine"
     case reviewRequested = "Review Requests"
+    case assigned = "Assigned"
 }

--- a/Sources/Views/PRDashboard/PRDetailDrawer.swift
+++ b/Sources/Views/PRDashboard/PRDetailDrawer.swift
@@ -1,3 +1,4 @@
+import GitHubOperations
 import MarkdownRendering
 import Models
 import SwiftUI
@@ -18,6 +19,13 @@ public struct PRDetailDrawer: View {
     var onEnableAutoMerge: ((MergeStrategy) -> Void)?
     var onDisableAutoMerge: (() -> Void)?
     var onClosePR: (() -> Void)?
+    var onAssignToMe: (() -> Void)?
+    var onUnassignMe: (() -> Void)?
+    var onToggleAssignee: ((String) -> Void)?
+    var onLoadCollaborators: (() -> Void)?
+    var myLogin: String?
+    var collaborators: [Collaborator] = []
+    var isLoadingCollaborators: Bool = false
 
     @State private var selectedTab: PRDetailTab = .overview
     @State private var sheetCommentText: String = ""
@@ -27,6 +35,7 @@ public struct PRDetailDrawer: View {
     @State private var selectedMergeStrategy: MergeStrategy = .squash
     @State private var requestChangesText: String = ""
     @State private var activeSheet: ActiveSheet?
+    @State private var showAssigneePicker: Bool = false
 
     enum ActiveSheet: Identifiable {
         case comment
@@ -49,7 +58,14 @@ public struct PRDetailDrawer: View {
         onSendToSession: ((String) -> Void)? = nil,
         onEnableAutoMerge: ((MergeStrategy) -> Void)? = nil,
         onDisableAutoMerge: (() -> Void)? = nil,
-        onClosePR: (() -> Void)? = nil
+        onClosePR: (() -> Void)? = nil,
+        onAssignToMe: (() -> Void)? = nil,
+        onUnassignMe: (() -> Void)? = nil,
+        onToggleAssignee: ((String) -> Void)? = nil,
+        onLoadCollaborators: (() -> Void)? = nil,
+        myLogin: String? = nil,
+        collaborators: [Collaborator] = [],
+        isLoadingCollaborators: Bool = false
     ) {
         self.pr = pr
         self.detail = detail
@@ -64,6 +80,13 @@ public struct PRDetailDrawer: View {
         self.onEnableAutoMerge = onEnableAutoMerge
         self.onDisableAutoMerge = onDisableAutoMerge
         self.onClosePR = onClosePR
+        self.onAssignToMe = onAssignToMe
+        self.onUnassignMe = onUnassignMe
+        self.onToggleAssignee = onToggleAssignee
+        self.onLoadCollaborators = onLoadCollaborators
+        self.myLogin = myLogin
+        self.collaborators = collaborators
+        self.isLoadingCollaborators = isLoadingCollaborators
     }
 
     public var body: some View {
@@ -133,6 +156,9 @@ public struct PRDetailDrawer: View {
             if reviewStatus != .none {
                 detailReviewBadge(reviewStatus)
             }
+
+            // Assignees
+            assigneesRow
 
             // Merge status
             let mergeable = detail?.mergeable ?? pr.mergeable
@@ -389,6 +415,48 @@ public struct PRDetailDrawer: View {
             case .none:
                 EmptyView()
             }
+        }
+        .font(.callout)
+    }
+
+    @ViewBuilder
+    private var assigneesRow: some View {
+        HStack(spacing: 8) {
+            Text("Assignees")
+                .font(.callout)
+                .foregroundColor(theme.chrome.textDim)
+            ForEach(pr.assignees, id: \.self) { login in
+                AssigneeAvatar(login: login, isMe: login == myLogin, size: 18)
+                    .help(login)
+            }
+            Button {
+                onLoadCollaborators?()
+                showAssigneePicker = true
+            } label: {
+                Image(systemName: "plus.circle")
+                    .font(.callout)
+                    .foregroundColor(theme.chrome.textDim)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Edit assignees")
+            .popover(isPresented: $showAssigneePicker, arrowEdge: .bottom) {
+                AssigneePickerView(
+                    pr: pr,
+                    myLogin: myLogin,
+                    collaborators: collaborators,
+                    isLoading: isLoadingCollaborators,
+                    onAssignToMe: {
+                        onAssignToMe?()
+                        showAssigneePicker = false
+                    },
+                    onUnassignMe: {
+                        onUnassignMe?()
+                        showAssigneePicker = false
+                    },
+                    onToggle: { login in onToggleAssignee?(login) }
+                )
+            }
+            Spacer()
         }
         .font(.callout)
     }

--- a/Sources/Views/PRDashboard/PRSortFilter.swift
+++ b/Sources/Views/PRDashboard/PRSortFilter.swift
@@ -151,6 +151,12 @@ extension PullRequest {
         default: return 6
         }
     }
+
+    /// Sort key for the "Assignees" table column — count of assignees.
+    /// PRs with no assignees sort first when ascending.
+    public var assigneeSortKey: Int {
+        assignees.count
+    }
 }
 
 // MARK: - Column Widths

--- a/Sources/Views/Shared/AssigneeAvatar.swift
+++ b/Sources/Views/Shared/AssigneeAvatar.swift
@@ -1,0 +1,78 @@
+import SwiftUI
+import Theme
+
+/// Small circular avatar rendering two-letter initials.
+/// Color is deterministically hashed from the login so the same user
+/// always gets the same color. The `isMe` variant uses the theme green.
+public struct AssigneeAvatar: View {
+    public let login: String
+    public let isMe: Bool
+    public let size: CGFloat
+
+    @Environment(\.theme) private var theme
+
+    public init(login: String, isMe: Bool = false, size: CGFloat = 18) {
+        self.login = login
+        self.isMe = isMe
+        self.size = size
+    }
+
+    public var body: some View {
+        ZStack {
+            Circle()
+                .fill(backgroundColor)
+            Text(Self.initials(for: login))
+                .font(.system(size: size * 0.5, weight: .semibold))
+                .foregroundColor(.white)
+        }
+        .frame(width: size, height: size)
+        .overlay(
+            Circle().stroke(theme.chrome.background, lineWidth: 1)
+        )
+    }
+
+    private var backgroundColor: Color {
+        if isMe { return theme.chrome.green }
+        let idx = Self.colorIndex(for: login, paletteCount: Self.palette.count)
+        return Self.palette[idx]
+    }
+
+    // MARK: - Pure helpers (testable)
+
+    /// Two-letter initials. Splits on '-' first (alice-bailey → AB), else first two chars.
+    /// Returns "?" for empty strings so the UI never renders a blank circle.
+    nonisolated public static func initials(for login: String) -> String {
+        guard !login.isEmpty else { return "?" }
+        let parts = login.split(separator: "-", maxSplits: 2, omittingEmptySubsequences: true)
+        if parts.count >= 2,
+            let first = parts[0].first, let second = parts[1].first
+        {
+            return "\(first)\(second)".uppercased()
+        }
+        let chars = Array(login)
+        if chars.count >= 2 {
+            return "\(chars[0])\(chars[1])".uppercased()
+        }
+        return String(chars[0]).uppercased()
+    }
+
+    /// Deterministic palette index for a login. Uses a stable UTF-8 FNV-like hash
+    /// so color is consistent across app launches. **Do not use `String.hashValue`**:
+    /// Swift randomizes the seed per process, which would change colors every launch.
+    nonisolated public static func colorIndex(for login: String, paletteCount: Int) -> Int {
+        guard paletteCount > 0 else { return 0 }
+        let hash = login.utf8.reduce(0) { ($0 &* 31 &+ Int($1)) & Int.max }
+        return hash % paletteCount
+    }
+
+    private static let palette: [Color] = [
+        Color(red: 0.48, green: 0.38, blue: 1.00),
+        Color(red: 0.37, green: 0.77, blue: 0.89),
+        Color(red: 0.96, green: 0.56, blue: 0.33),
+        Color(red: 0.87, green: 0.37, blue: 0.54),
+        Color(red: 0.37, green: 0.56, blue: 0.89),
+        Color(red: 0.89, green: 0.72, blue: 0.37),
+        Color(red: 0.56, green: 0.37, blue: 0.78),
+        Color(red: 0.37, green: 0.78, blue: 0.56),
+    ]
+}

--- a/Tests/GitHubOperationsTests/PRManagerTests.swift
+++ b/Tests/GitHubOperationsTests/PRManagerTests.swift
@@ -213,3 +213,29 @@ import Testing
     let cached = await manager.cachedCollaborators(for: "owner/repo")
     #expect(cached?.map(\.login) == ["alice"])
 }
+
+// MARK: - Assignee decoding
+
+@Test func enrichResultHasAssignees() {
+    let result = PREnrichResult()
+    #expect(result.assignees.isEmpty)
+}
+
+@Test func enrichResponseDecodesAssignees() throws {
+    let json = """
+        {
+          "statusCheckRollup": [],
+          "assignees": [{"login":"alice","name":"Alice"}, {"login":"bob","name":null}]
+        }
+        """
+    let data = Data(json.utf8)
+    let result = try PRManager.parseEnrichResponseForTest(data: data, excludeAuthor: nil)
+    #expect(result.assignees == ["alice", "bob"])
+}
+
+@Test func enrichResponseWithNoAssignees() throws {
+    let json = #"{"statusCheckRollup":[]}"#
+    let data = Data(json.utf8)
+    let result = try PRManager.parseEnrichResponseForTest(data: data, excludeAuthor: nil)
+    #expect(result.assignees.isEmpty)
+}

--- a/Tests/GitHubOperationsTests/PRManagerTests.swift
+++ b/Tests/GitHubOperationsTests/PRManagerTests.swift
@@ -109,3 +109,32 @@ import Testing
     #expect(origins.contains(.mine))
     #expect(origins.contains(.reviewRequested))
 }
+
+// MARK: - Collaborator
+
+@Test func collaboratorIdEqualsLogin() {
+    let collab = Collaborator(login: "alice", name: "Alice B")
+    #expect(collab.id == "alice")
+}
+
+@Test func collaboratorHashableByLogin() {
+    let a1 = Collaborator(login: "alice", name: "Alice")
+    let a2 = Collaborator(login: "alice", name: nil)
+    #expect(a1 == a1)
+    // Different names yield different structs — hashable by all fields is fine
+    #expect(a1 != a2)
+}
+
+@Test func collaboratorDecodable() throws {
+    let json = Data(#"{"login":"alice","name":"Alice Bailey"}"#.utf8)
+    let collab = try JSONDecoder().decode(Collaborator.self, from: json)
+    #expect(collab.login == "alice")
+    #expect(collab.name == "Alice Bailey")
+}
+
+@Test func collaboratorDecodableWithNullName() throws {
+    let json = Data(#"{"login":"bob","name":null}"#.utf8)
+    let collab = try JSONDecoder().decode(Collaborator.self, from: json)
+    #expect(collab.login == "bob")
+    #expect(collab.name == nil)
+}

--- a/Tests/GitHubOperationsTests/PRManagerTests.swift
+++ b/Tests/GitHubOperationsTests/PRManagerTests.swift
@@ -117,12 +117,15 @@ import Testing
     #expect(collab.id == "alice")
 }
 
-@Test func collaboratorHashableByLogin() {
+@Test func collaboratorEqualityUsesAllFields() {
+    // Same login + same name — equal and same hash
     let a1 = Collaborator(login: "alice", name: "Alice")
-    let a2 = Collaborator(login: "alice", name: nil)
-    #expect(a1 == a1)
-    // Different names yield different structs — hashable by all fields is fine
-    #expect(a1 != a2)
+    let a2 = Collaborator(login: "alice", name: "Alice")
+    #expect(a1 == a2)
+    #expect(a1.hashValue == a2.hashValue)
+    // Same login, different name — not equal (synthesized Hashable uses all fields)
+    let a3 = Collaborator(login: "alice", name: nil)
+    #expect(a1 != a3)
 }
 
 @Test func collaboratorDecodable() throws {

--- a/Tests/GitHubOperationsTests/PRManagerTests.swift
+++ b/Tests/GitHubOperationsTests/PRManagerTests.swift
@@ -239,3 +239,27 @@ import Testing
     let result = try PRManager.parseEnrichResponseForTest(data: data, excludeAuthor: nil)
     #expect(result.assignees.isEmpty)
 }
+
+// MARK: - assign / unassign args
+
+@Test func buildAssignArgsAdd() {
+    let args = PRManager.buildAssignArgs(
+        repo: "owner/repo", number: 42, logins: ["alice", "bob"], add: true
+    )
+    #expect(args == ["pr", "edit", "42", "--repo", "owner/repo", "--add-assignee", "alice,bob"])
+}
+
+@Test func buildAssignArgsRemove() {
+    let args = PRManager.buildAssignArgs(
+        repo: "owner/repo", number: 42, logins: ["alice"], add: false
+    )
+    #expect(args == ["pr", "edit", "42", "--repo", "owner/repo", "--remove-assignee", "alice"])
+}
+
+@Test func buildAssignArgsSingle() {
+    let args = PRManager.buildAssignArgs(
+        repo: "o/r", number: 1, logins: ["me"], add: true
+    )
+    #expect(args.last == "me")
+    #expect(args.contains("--add-assignee"))
+}

--- a/Tests/GitHubOperationsTests/PRManagerTests.swift
+++ b/Tests/GitHubOperationsTests/PRManagerTests.swift
@@ -160,3 +160,26 @@ import Testing
     #expect(collab.login == "bob")
     #expect(collab.name == nil)
 }
+
+// MARK: - whoami
+
+@Test func whoamiReturnsSeededValue() async {
+    let manager = PRManager()
+    await manager.seedWhoamiForTest(host: "github.com", login: "alice")
+    let result = await manager.cachedWhoami(host: "github.com")
+    #expect(result == "alice")
+}
+
+@Test func whoamiReturnsNilForUnseededHost() async {
+    let manager = PRManager()
+    let result = await manager.cachedWhoami(host: "github.com")
+    #expect(result == nil)
+}
+
+@Test func whoamiDistinctAcrossHosts() async {
+    let manager = PRManager()
+    await manager.seedWhoamiForTest(host: "github.com", login: "alice")
+    await manager.seedWhoamiForTest(host: "ghe.spotify.net", login: "alice-s")
+    #expect(await manager.cachedWhoami(host: "github.com") == "alice")
+    #expect(await manager.cachedWhoami(host: "ghe.spotify.net") == "alice-s")
+}

--- a/Tests/GitHubOperationsTests/PRManagerTests.swift
+++ b/Tests/GitHubOperationsTests/PRManagerTests.swift
@@ -263,3 +263,48 @@ import Testing
     #expect(args.last == "me")
     #expect(args.contains("--add-assignee"))
 }
+
+// MARK: - fetchAllPRs merge
+
+@Test func mergeOriginsSingleList() throws {
+    let pr = PullRequest(
+        number: 1, title: "t", state: .open,
+        headBranch: "h", baseBranch: "m", author: "a", repo: "r"
+    )
+    let merged = PRManager.mergePRsByOrigin(
+        mine: [pr],
+        reviewRequested: [],
+        assigned: []
+    )
+    let out = try #require(merged.first)
+    #expect(out.origin == [.mine])
+}
+
+@Test func mergeOriginsAcrossAllThree() throws {
+    let pr = PullRequest(
+        number: 1, title: "t", state: .open,
+        headBranch: "h", baseBranch: "m", author: "a", repo: "r"
+    )
+    let merged = PRManager.mergePRsByOrigin(
+        mine: [pr],
+        reviewRequested: [pr],
+        assigned: [pr]
+    )
+    #expect(merged.count == 1)
+    let out = try #require(merged.first)
+    #expect(out.origin == [.mine, .reviewRequested, .assigned])
+}
+
+@Test func mergeOriginsAssignedOnly() throws {
+    let pr = PullRequest(
+        number: 2, title: "t", state: .open,
+        headBranch: "h", baseBranch: "m", author: "a", repo: "r"
+    )
+    let merged = PRManager.mergePRsByOrigin(
+        mine: [],
+        reviewRequested: [],
+        assigned: [pr]
+    )
+    let out = try #require(merged.first)
+    #expect(out.origin == [.assigned])
+}

--- a/Tests/GitHubOperationsTests/PRManagerTests.swift
+++ b/Tests/GitHubOperationsTests/PRManagerTests.swift
@@ -13,12 +13,31 @@ import Testing
     #expect(error.errorDescription?.contains("not logged in") == true)
 }
 
-// MARK: - PRFilter
+// MARK: - PRFilter.assigned
 
-@Test func prFilterCases() {
-    // Verify all filter cases exist and are distinct
-    let filters: [PRFilter] = [.mine, .reviewRequested, .all]
-    #expect(filters.count == 3)
+@Test func prFilterAssignedCase() {
+    let filters: [PRFilter] = [.mine, .reviewRequested, .assigned, .all]
+    #expect(filters.count == 4)
+}
+
+@Test func buildSearchArgsForAssigned() {
+    let args = PRManager.buildSearchArgs(filter: .assigned)
+    #expect(args.contains("--assignee"))
+    #expect(args.contains("@me"))
+}
+
+@Test func buildSearchArgsForMine() {
+    let args = PRManager.buildSearchArgs(filter: .mine)
+    #expect(args.contains("--author"))
+    #expect(args.contains("@me"))
+    #expect(!args.contains("--assignee"))
+}
+
+@Test func buildListArgsForAssigned() {
+    let args = PRManager.buildListArgs(repo: "owner/repo", filter: .assigned)
+    #expect(args.contains("owner/repo"))
+    #expect(args.contains("--assignee"))
+    #expect(args.contains("@me"))
 }
 
 // MARK: - PRDetail

--- a/Tests/GitHubOperationsTests/PRManagerTests.swift
+++ b/Tests/GitHubOperationsTests/PRManagerTests.swift
@@ -183,3 +183,33 @@ import Testing
     #expect(await manager.cachedWhoami(host: "github.com") == "alice")
     #expect(await manager.cachedWhoami(host: "ghe.spotify.net") == "alice-s")
 }
+
+// MARK: - collaborators parsing
+
+@Test func parseCollaboratorsPages() throws {
+    // --paginate --slurp returns [[...], [...]]
+    let json = """
+        [
+          [{"login":"alice","name":"Alice Bailey"}, {"login":"bob","name":null}],
+          [{"login":"carol","name":"Carol"}, {"login":"alice","name":"Alice Bailey"}]
+        ]
+        """
+    let collabs = try PRManager.parseCollaborators(json)
+    // Dedup by login; preserve first-occurrence order
+    #expect(collabs.map(\.login) == ["alice", "bob", "carol"])
+    #expect(collabs[0].name == "Alice Bailey")
+    #expect(collabs[1].name == nil)
+}
+
+@Test func parseCollaboratorsEmpty() throws {
+    let collabs = try PRManager.parseCollaborators("[]")
+    #expect(collabs.isEmpty)
+}
+
+@Test func collaboratorsCacheSeeded() async {
+    let manager = PRManager()
+    let seed = [Collaborator(login: "alice", name: "Alice")]
+    await manager.seedCollaboratorsForTest(repo: "owner/repo", collabs: seed)
+    let cached = await manager.cachedCollaborators(for: "owner/repo")
+    #expect(cached?.map(\.login) == ["alice"])
+}

--- a/Tests/ModelsTests/PullRequestTests.swift
+++ b/Tests/ModelsTests/PullRequestTests.swift
@@ -141,3 +141,17 @@ import Testing
     #expect(pr.commentsSinceLastCommit == 0)
     #expect(pr.lastCommitDate == nil)
 }
+
+// MARK: - PROrigin.assigned
+
+@Test func prOriginAssignedCase() {
+    let origin: PROrigin = .assigned
+    #expect(origin.rawValue == "assigned")
+}
+
+@Test func prOriginAssignedEncodable() throws {
+    let origins: Set<PROrigin> = [.mine, .assigned]
+    let data = try JSONEncoder().encode(origins)
+    let decoded = try JSONDecoder().decode(Set<PROrigin>.self, from: data)
+    #expect(decoded == origins)
+}

--- a/Tests/ModelsTests/PullRequestTests.swift
+++ b/Tests/ModelsTests/PullRequestTests.swift
@@ -155,3 +155,24 @@ import Testing
     let decoded = try JSONDecoder().decode(Set<PROrigin>.self, from: data)
     #expect(decoded == origins)
 }
+
+// MARK: - PullRequest.assignees
+
+@Test func pullRequestAssigneesDefault() {
+    let pr = PullRequest(
+        number: 1, title: "t", state: .open,
+        headBranch: "h", baseBranch: "m", author: "a", repo: "r"
+    )
+    #expect(pr.assignees.isEmpty)
+}
+
+@Test func pullRequestAssigneesCodableRoundtrip() throws {
+    var pr = PullRequest(
+        number: 1, title: "t", state: .open,
+        headBranch: "h", baseBranch: "m", author: "a", repo: "r"
+    )
+    pr.assignees = ["alice", "bob-chen"]
+    let data = try JSONEncoder().encode(pr)
+    let decoded = try JSONDecoder().decode(PullRequest.self, from: data)
+    #expect(decoded.assignees == ["alice", "bob-chen"])
+}

--- a/Tests/ViewsTests/AssigneeAvatarTests.swift
+++ b/Tests/ViewsTests/AssigneeAvatarTests.swift
@@ -1,0 +1,52 @@
+import Foundation
+import Testing
+
+@testable import Views
+
+// MARK: - Initials extraction
+
+@Test func initialsHyphenSplit() {
+    #expect(AssigneeAvatar.initials(for: "alice-bailey") == "AB")
+}
+
+@Test func initialsNoHyphenUsesFirstTwo() {
+    #expect(AssigneeAvatar.initials(for: "mnicholson") == "MN")
+}
+
+@Test func initialsShortName() {
+    #expect(AssigneeAvatar.initials(for: "mn") == "MN")
+}
+
+@Test func initialsSingleChar() {
+    #expect(AssigneeAvatar.initials(for: "a") == "A")
+}
+
+@Test func initialsEmpty() {
+    #expect(AssigneeAvatar.initials(for: "") == "?")
+}
+
+@Test func initialsMultipleHyphens() {
+    // Only the first two hyphen-separated parts matter
+    #expect(AssigneeAvatar.initials(for: "a-b-c") == "AB")
+}
+
+// MARK: - Stable color index
+
+@Test func colorIndexDeterministic() {
+    let idxA = AssigneeAvatar.colorIndex(for: "alice", paletteCount: 8)
+    let idxB = AssigneeAvatar.colorIndex(for: "alice", paletteCount: 8)
+    #expect(idxA == idxB)
+}
+
+@Test func colorIndexWithinPalette() {
+    let idx = AssigneeAvatar.colorIndex(for: "alice", paletteCount: 8)
+    #expect(idx >= 0)
+    #expect(idx < 8)
+}
+
+@Test func colorIndexDoesNotUseHashValue() {
+    // Swift's .hashValue is randomized per-launch. Our hash must be stable.
+    let input = "mnicholson"
+    let expected = input.utf8.reduce(0) { ($0 &* 31 &+ Int($1)) & Int.max }
+    #expect(AssigneeAvatar.colorIndex(for: input, paletteCount: 8) == expected % 8)
+}

--- a/Tests/ViewsTests/AssigneeAvatarTests.swift
+++ b/Tests/ViewsTests/AssigneeAvatarTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import GitHubOperations
 import Testing
 
 @testable import Views
@@ -49,4 +50,40 @@ import Testing
     let input = "mnicholson"
     let expected = input.utf8.reduce(0) { ($0 &* 31 &+ Int($1)) & Int.max }
     #expect(AssigneeAvatar.colorIndex(for: input, paletteCount: 8) == expected % 8)
+}
+
+// MARK: - AssigneePicker filter
+
+@Test func pickerFilterMatchesLogin() {
+    let collabs = [
+        Collaborator(login: "alice-bailey", name: "Alice B"),
+        Collaborator(login: "bob-chen", name: "Bob C"),
+    ]
+    let filtered = AssigneePickerView.filter(collaborators: collabs, query: "alice")
+    #expect(filtered.count == 1)
+    #expect(filtered.first?.login == "alice-bailey")
+}
+
+@Test func pickerFilterMatchesName() {
+    let collabs = [
+        Collaborator(login: "ab", name: "Alice B"),
+        Collaborator(login: "bc", name: "Bob C"),
+    ]
+    let filtered = AssigneePickerView.filter(collaborators: collabs, query: "bob")
+    #expect(filtered.first?.login == "bc")
+}
+
+@Test func pickerFilterEmptyQueryReturnsAll() {
+    let collabs = [
+        Collaborator(login: "a1", name: nil),
+        Collaborator(login: "b1", name: nil),
+    ]
+    let filtered = AssigneePickerView.filter(collaborators: collabs, query: "")
+    #expect(filtered.count == 2)
+}
+
+@Test func pickerFilterCaseInsensitive() {
+    let collabs = [Collaborator(login: "Alice", name: "Alice")]
+    let filtered = AssigneePickerView.filter(collaborators: collabs, query: "ALICE")
+    #expect(filtered.count == 1)
 }

--- a/Tests/ViewsTests/PRGroupingTests.swift
+++ b/Tests/ViewsTests/PRGroupingTests.swift
@@ -130,3 +130,15 @@ import Testing
     )
     #expect(prGroup(for: pr) == .ready)
 }
+
+// MARK: - PRTab.assigned
+
+@Test func prTabAssignedCaseExists() {
+    let tabs = PRTab.allCases
+    #expect(tabs.contains(.assigned))
+    #expect(tabs.count == 4)
+}
+
+@Test func prTabAssignedRawValue() {
+    #expect(PRTab.assigned.rawValue == "Assigned")
+}

--- a/Tests/ViewsTests/PRSortFilterTests.swift
+++ b/Tests/ViewsTests/PRSortFilterTests.swift
@@ -310,3 +310,22 @@ import Testing
     #expect(sorted[1].number == 3)  // pending
     #expect(sorted[2].number == 2)  // changes
 }
+
+// MARK: - assigneeSortKey
+
+@Test func assigneeSortKeyEmpty() {
+    let pr = PullRequest(
+        number: 1, title: "t", state: .open,
+        headBranch: "h", baseBranch: "m", author: "a", repo: "r"
+    )
+    #expect(pr.assigneeSortKey == 0)
+}
+
+@Test func assigneeSortKeyCount() {
+    var pr = PullRequest(
+        number: 1, title: "t", state: .open,
+        headBranch: "h", baseBranch: "m", author: "a", repo: "r"
+    )
+    pr.assignees = ["alice", "bob", "carol"]
+    #expect(pr.assigneeSortKey == 3)
+}

--- a/docs/superpowers/plans/2026-04-17-pr-assign-to-self.md
+++ b/docs/superpowers/plans/2026-04-17-pr-assign-to-self.md
@@ -1,0 +1,2241 @@
+# PR Assignee Management Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add assignee management to Runway's PR surface — a dedicated drawer row with a searchable popover picker, an "Assignees" column on the dashboard Table, and a new "Assigned" tab — so users can assign themselves or any repo collaborator without leaving the app.
+
+**Architecture:** Pure additions to the existing three-layer PR stack (`PRManager` actor → `PRCoordinator` @Observable → SwiftUI views). Four new `gh` CLI ops (`assign`, `unassign`, `whoami`, `collaborators`), one new `[String]` field on `PullRequest`, three new enum cases (`PROrigin.assigned`, `PRFilter.assigned`, `PRTab.assigned`). Assignees arrive via the existing enrichment pipeline — no new fetches for list display. Popover-hosted `AssigneePickerView` loads repo collaborators lazily with 10-minute TTL.
+
+**Tech Stack:** Swift 6, SwiftUI, Swift Testing (`@Test` / `#expect`), GRDB (no schema changes — assignees not persisted), `gh` CLI wrapping.
+
+**Spec:** [`docs/superpowers/specs/2026-04-17-pr-assign-to-self-design.md`](../specs/2026-04-17-pr-assign-to-self-design.md)
+
+---
+
+## Task Groups
+
+| # | Task | Files |
+|---|------|-------|
+| 1 | Add `PROrigin.assigned` case | Models, ModelsTests |
+| 2 | Add `PullRequest.assignees` field | Models, ModelsTests |
+| 3 | Add `Collaborator` type | GitHubOperations, GitHubOperationsTests |
+| 4 | Add `PRFilter.assigned` + search args | GitHubOperations, GitHubOperationsTests |
+| 5 | Add `whoami(host:)` with caching | GitHubOperations, GitHubOperationsTests |
+| 6 | Add `collaborators(repo:host:)` with caching | GitHubOperations, GitHubOperationsTests |
+| 7 | Extend `enrichChecks` / `fetchDetail` to decode assignees | GitHubOperations, GitHubOperationsTests |
+| 8 | Add `assign` / `unassign` with static arg builder | GitHubOperations, GitHubOperationsTests |
+| 9 | Extend `fetchAllPRs` with third `.assigned` search | GitHubOperations, GitHubOperationsTests |
+| 10 | Add `PRCoordinator` whoami mirror + `myLogin(forHost:)` | App |
+| 11 | Add `PRCoordinator.loadCollaborators(for:)` | App |
+| 12 | Add `PRCoordinator` write ops (`assignPRToMe`, etc.) | App |
+| 13 | Surface `assignees` through `applyEnrichment` | App |
+| 14 | Create `AssigneeAvatar` view + tests | Views, ViewsTests |
+| 15 | Add `assigneeSortKey` to `PRSortFilter` | Views, ViewsTests |
+| 16 | Create `AssigneePickerView` | Views |
+| 17 | Add assignees row to `PRDetailDrawer` | Views |
+| 18 | Wire drawer callbacks through `RunwayStore` | App, Views |
+| 19 | Add `PRTab.assigned` + filter logic | Views, ViewsTests |
+| 20 | Add "Assignees" `TableColumn` to `PRDashboardView` | Views |
+| 21 | Final verification: full test + manual smoke | — |
+
+---
+
+## Task 1: Add `PROrigin.assigned` enum case
+
+**Files:**
+- Modify: `Sources/Models/PullRequest.swift:89-92`
+- Test: `Tests/ModelsTests/PullRequestTests.swift`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `Tests/ModelsTests/PullRequestTests.swift`:
+
+```swift
+// MARK: - PROrigin.assigned
+
+@Test func prOriginAssignedCase() {
+    let origin: PROrigin = .assigned
+    #expect(origin.rawValue == "assigned")
+}
+
+@Test func prOriginAssignedEncodable() throws {
+    let origins: Set<PROrigin> = [.mine, .assigned]
+    let data = try JSONEncoder().encode(origins)
+    let decoded = try JSONDecoder().decode(Set<PROrigin>.self, from: data)
+    #expect(decoded == origins)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+swift test --filter "ModelsTests.prOriginAssigned"
+```
+Expected: FAIL — `type 'PROrigin' has no member 'assigned'`.
+
+- [ ] **Step 3: Add the case**
+
+In `Sources/Models/PullRequest.swift`, change:
+
+```swift
+public enum PROrigin: String, Codable, Sendable, Hashable {
+    case mine
+    case reviewRequested
+}
+```
+
+to:
+
+```swift
+public enum PROrigin: String, Codable, Sendable, Hashable {
+    case mine
+    case reviewRequested
+    case assigned
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+swift test --filter "ModelsTests.prOriginAssigned"
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/Models/PullRequest.swift Tests/ModelsTests/PullRequestTests.swift
+git commit -m "feat(models): add PROrigin.assigned case"
+```
+
+---
+
+## Task 2: Add `PullRequest.assignees` field
+
+**Files:**
+- Modify: `Sources/Models/PullRequest.swift:4-85`
+- Test: `Tests/ModelsTests/PullRequestTests.swift`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `Tests/ModelsTests/PullRequestTests.swift`:
+
+```swift
+// MARK: - PullRequest.assignees
+
+@Test func pullRequestAssigneesDefault() {
+    let pr = PullRequest(
+        number: 1, title: "t", state: .open,
+        headBranch: "h", baseBranch: "m", author: "a", repo: "r"
+    )
+    #expect(pr.assignees.isEmpty)
+}
+
+@Test func pullRequestAssigneesCodableRoundtrip() throws {
+    var pr = PullRequest(
+        number: 1, title: "t", state: .open,
+        headBranch: "h", baseBranch: "m", author: "a", repo: "r"
+    )
+    pr.assignees = ["alice", "bob-chen"]
+    let data = try JSONEncoder().encode(pr)
+    let decoded = try JSONDecoder().decode(PullRequest.self, from: data)
+    #expect(decoded.assignees == ["alice", "bob-chen"])
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+swift test --filter "ModelsTests.pullRequestAssignees"
+```
+Expected: FAIL — `value of type 'PullRequest' has no member 'assignees'`.
+
+- [ ] **Step 3: Add the field**
+
+In `Sources/Models/PullRequest.swift`, add `assignees` after `lastCommitDate` (line 28):
+
+```swift
+    public var lastCommitDate: Date?
+    public var assignees: [String]
+```
+
+Then add `assignees` to the `init`:
+
+```swift
+        lastCommitDate: Date? = nil,
+        assignees: [String] = []
+    ) {
+```
+
+And assign it at the end of `init`:
+
+```swift
+        self.lastCommitDate = lastCommitDate
+        self.assignees = assignees
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+swift test --filter "ModelsTests.pullRequestAssignees"
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/Models/PullRequest.swift Tests/ModelsTests/PullRequestTests.swift
+git commit -m "feat(models): add PullRequest.assignees field"
+```
+
+---
+
+## Task 3: Add `Collaborator` type
+
+**Files:**
+- Modify: `Sources/GitHubOperations/PRManager.swift` (append near the "Types" section around line 460)
+- Test: `Tests/GitHubOperationsTests/PRManagerTests.swift`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `Tests/GitHubOperationsTests/PRManagerTests.swift`:
+
+```swift
+// MARK: - Collaborator
+
+@Test func collaboratorIdEqualsLogin() {
+    let c = Collaborator(login: "alice", name: "Alice B")
+    #expect(c.id == "alice")
+}
+
+@Test func collaboratorHashableByLogin() {
+    let a1 = Collaborator(login: "alice", name: "Alice")
+    let a2 = Collaborator(login: "alice", name: nil)
+    #expect(a1 == a1)
+    // Different names yield different structs — hashable by all fields is fine
+    #expect(a1 != a2)
+}
+
+@Test func collaboratorDecodable() throws {
+    let json = #"{"login":"alice","name":"Alice Bailey"}"#.data(using: .utf8)!
+    let c = try JSONDecoder().decode(Collaborator.self, from: json)
+    #expect(c.login == "alice")
+    #expect(c.name == "Alice Bailey")
+}
+
+@Test func collaboratorDecodableWithNullName() throws {
+    let json = #"{"login":"bob","name":null}"#.data(using: .utf8)!
+    let c = try JSONDecoder().decode(Collaborator.self, from: json)
+    #expect(c.login == "bob")
+    #expect(c.name == nil)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+swift test --filter "GitHubOperationsTests.collaborator"
+```
+Expected: FAIL — `cannot find 'Collaborator' in scope`.
+
+- [ ] **Step 3: Add the type**
+
+In `Sources/GitHubOperations/PRManager.swift`, add before `// MARK: - Types` (line ~460):
+
+```swift
+// MARK: - Collaborator
+
+public struct Collaborator: Identifiable, Sendable, Hashable, Codable {
+    public let login: String
+    public let name: String?
+
+    public init(login: String, name: String? = nil) {
+        self.login = login
+        self.name = name
+    }
+
+    public var id: String { login }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+swift test --filter "GitHubOperationsTests.collaborator"
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/GitHubOperations/PRManager.swift Tests/GitHubOperationsTests/PRManagerTests.swift
+git commit -m "feat(github): add Collaborator type"
+```
+
+---
+
+## Task 4: Add `PRFilter.assigned` + update search arg builders
+
+**Files:**
+- Modify: `Sources/GitHubOperations/PRManager.swift:462-466` (`PRFilter` enum)
+- Modify: `Sources/GitHubOperations/PRManager.swift:388-407` (`buildSearchArgs`)
+- Modify: `Sources/GitHubOperations/PRManager.swift:409-427` (`buildListArgs`)
+- Test: `Tests/GitHubOperationsTests/PRManagerTests.swift`
+
+- [ ] **Step 1: Extract arg builders into testable static helpers**
+
+`buildSearchArgs` and `buildListArgs` are currently private instance methods. To test them, make `buildSearchArgs` a nonisolated static (`buildListArgs` remains private but becomes static too for symmetry). Replace line 388-407 in `Sources/GitHubOperations/PRManager.swift`:
+
+```swift
+    nonisolated static func buildSearchArgs(filter: PRFilter) -> [String] {
+        var args = [
+            "search", "prs",
+            "--state", "open",
+            "--archived=false",
+            "--json", "number,title,state,repository,url,isDraft,createdAt,updatedAt,author",
+            "--limit", "50",
+        ]
+
+        switch filter {
+        case .mine:
+            args += ["--author", "@me"]
+        case .reviewRequested:
+            args += ["--review-requested", "@me"]
+        case .assigned:
+            args += ["--assignee", "@me"]
+        case .all:
+            break
+        }
+
+        return args
+    }
+```
+
+Update the caller on line 66 to use `Self.buildSearchArgs(filter: filter)`.
+
+And replace `buildListArgs` (line 409-427) similarly:
+
+```swift
+    nonisolated static func buildListArgs(repo: String, filter: PRFilter) -> [String] {
+        var args = [
+            "pr", "list", "--json",
+            "number,title,state,headRefName,baseRefName,author,url,isDraft,additions,deletions,changedFiles,createdAt,updatedAt,reviewDecision",
+            "--repo", repo,
+        ]
+
+        switch filter {
+        case .mine:
+            args += ["--author", "@me"]
+        case .reviewRequested:
+            args += ["--search", "review-requested:@me"]
+        case .assigned:
+            args += ["--assignee", "@me"]
+        case .all:
+            break
+        }
+
+        args += ["--limit", "50"]
+        return args
+    }
+```
+
+Update the caller on line 57 to use `Self.buildListArgs(repo: repo, filter: filter)`.
+
+Also update `fetchPRsNonisolated` (line 343) to use the new static: replace the inline `var args = [...]` switch block with `var args = Self.buildSearchArgs(filter: filter)`.
+
+Finally, add the new case to `PRFilter` (line 462):
+
+```swift
+public enum PRFilter: Sendable {
+    case mine
+    case reviewRequested
+    case assigned
+    case all
+}
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Append to `Tests/GitHubOperationsTests/PRManagerTests.swift`:
+
+```swift
+// MARK: - PRFilter.assigned
+
+@Test func prFilterAssignedCase() {
+    let filters: [PRFilter] = [.mine, .reviewRequested, .assigned, .all]
+    #expect(filters.count == 4)
+}
+
+@Test func buildSearchArgsForAssigned() {
+    let args = PRManager.buildSearchArgs(filter: .assigned)
+    #expect(args.contains("--assignee"))
+    #expect(args.contains("@me"))
+}
+
+@Test func buildSearchArgsForMine() {
+    let args = PRManager.buildSearchArgs(filter: .mine)
+    #expect(args.contains("--author"))
+    #expect(args.contains("@me"))
+    #expect(!args.contains("--assignee"))
+}
+
+@Test func buildListArgsForAssigned() {
+    let args = PRManager.buildListArgs(repo: "owner/repo", filter: .assigned)
+    #expect(args.contains("owner/repo"))
+    #expect(args.contains("--assignee"))
+    #expect(args.contains("@me"))
+}
+```
+
+Also update the existing `prFilterCases` test (line 18-22) — it checks `filters.count == 3` but we now have 4:
+
+Replace:
+```swift
+@Test func prFilterCases() {
+    // Verify all filter cases exist and are distinct
+    let filters: [PRFilter] = [.mine, .reviewRequested, .all]
+    #expect(filters.count == 3)
+}
+```
+
+with (removing the old test — covered by `prFilterAssignedCase` above):
+
+```swift
+// (removed — superseded by prFilterAssignedCase)
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+swift test --filter "GitHubOperationsTests.(prFilter|buildSearchArgs|buildListArgs)"
+```
+Expected: PASS — new case and arg construction both work.
+
+- [ ] **Step 4: Run the full test suite to catch regressions**
+
+```bash
+swift test
+```
+Expected: PASS. Any previously-passing test that broke means the switch-exhaustiveness warnings exposed something — fix the missing case.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/GitHubOperations/PRManager.swift Tests/GitHubOperationsTests/PRManagerTests.swift
+git commit -m "feat(github): add PRFilter.assigned + extract arg builders as testable statics"
+```
+
+---
+
+## Task 5: Add `whoami(host:)` with per-host caching
+
+**Files:**
+- Modify: `Sources/GitHubOperations/PRManager.swift` (add state vars + method)
+- Test: `Tests/GitHubOperationsTests/PRManagerTests.swift`
+
+Testing `whoami` directly requires shelling out — which is not mocked. Instead, test the cache accessor via a testable overload that bypasses the shell call. The real `whoami(host:)` is verified by manual smoke test at the end.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `Tests/GitHubOperationsTests/PRManagerTests.swift`:
+
+```swift
+// MARK: - whoami
+
+@Test func whoamiReturnsSeededValue() async {
+    let manager = PRManager()
+    await manager.seedWhoamiForTest(host: "github.com", login: "alice")
+    let result = await manager.cachedWhoami(host: "github.com")
+    #expect(result == "alice")
+}
+
+@Test func whoamiReturnsNilForUnseededHost() async {
+    let manager = PRManager()
+    let result = await manager.cachedWhoami(host: "github.com")
+    #expect(result == nil)
+}
+
+@Test func whoamiDistinctAcrossHosts() async {
+    let manager = PRManager()
+    await manager.seedWhoamiForTest(host: "github.com", login: "alice")
+    await manager.seedWhoamiForTest(host: "ghe.spotify.net", login: "alice-s")
+    #expect(await manager.cachedWhoami(host: "github.com") == "alice")
+    #expect(await manager.cachedWhoami(host: "ghe.spotify.net") == "alice-s")
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+swift test --filter "GitHubOperationsTests.whoami"
+```
+Expected: FAIL — methods don't exist.
+
+- [ ] **Step 3: Add state + methods**
+
+In `Sources/GitHubOperations/PRManager.swift`, add to the actor state (near line 44, after `cachedHosts`):
+
+```swift
+    private var cachedWhoamiByHost: [String: String] = [:]
+```
+
+The dictionary key treats `nil` host as `""` (canonical form for "default / github.com").
+
+Then add the public and test methods (near the bottom of the actor body, before `// MARK: - Private`):
+
+```swift
+    /// Returns the current user's login for the given host, fetching and caching on first call.
+    /// Per-host because the same user may have different logins on different GHE instances.
+    public func whoami(host: String? = nil) async throws -> String {
+        let key = host ?? ""
+        if let cached = cachedWhoamiByHost[key] { return cached }
+        let output = try await runGH(args: ["api", "user", "-q", ".login"], host: host)
+        let login = output.trimmingCharacters(in: .whitespacesAndNewlines)
+        cachedWhoamiByHost[key] = login
+        return login
+    }
+
+    /// Returns the cached whoami for a host without triggering a fetch. Used by UI
+    /// that needs synchronous access and can tolerate `nil` until the cache warms.
+    public func cachedWhoami(host: String?) -> String? {
+        cachedWhoamiByHost[host ?? ""]
+    }
+
+    #if DEBUG
+    /// Test-only: seed the whoami cache to bypass the gh shellout.
+    public func seedWhoamiForTest(host: String?, login: String) {
+        cachedWhoamiByHost[host ?? ""] = login
+    }
+    #endif
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+swift test --filter "GitHubOperationsTests.whoami"
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/GitHubOperations/PRManager.swift Tests/GitHubOperationsTests/PRManagerTests.swift
+git commit -m "feat(github): add PRManager.whoami with per-host cache"
+```
+
+---
+
+## Task 6: Add `collaborators(repo:host:)` with caching
+
+**Files:**
+- Modify: `Sources/GitHubOperations/PRManager.swift` (add method + parser + cache)
+- Test: `Tests/GitHubOperationsTests/PRManagerTests.swift`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `Tests/GitHubOperationsTests/PRManagerTests.swift`:
+
+```swift
+// MARK: - collaborators parsing
+
+@Test func parseCollaboratorsPages() throws {
+    // --paginate --slurp returns [[...], [...]]
+    let json = """
+    [
+      [{"login":"alice","name":"Alice Bailey"}, {"login":"bob","name":null}],
+      [{"login":"carol","name":"Carol"}, {"login":"alice","name":"Alice Bailey"}]
+    ]
+    """
+    let collabs = try PRManager.parseCollaborators(json)
+    // Dedup by login; preserve first-occurrence order
+    #expect(collabs.map(\.login) == ["alice", "bob", "carol"])
+    #expect(collabs[0].name == "Alice Bailey")
+    #expect(collabs[1].name == nil)
+}
+
+@Test func parseCollaboratorsEmpty() throws {
+    let collabs = try PRManager.parseCollaborators("[]")
+    #expect(collabs.isEmpty)
+}
+
+@Test func collaboratorsCacheSeeded() async {
+    let manager = PRManager()
+    let seed = [Collaborator(login: "alice", name: "Alice")]
+    await manager.seedCollaboratorsForTest(repo: "owner/repo", collabs: seed)
+    let cached = await manager.cachedCollaborators(for: "owner/repo")
+    #expect(cached?.map(\.login) == ["alice"])
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+swift test --filter "GitHubOperationsTests.(parseCollaborators|collaboratorsCache)"
+```
+Expected: FAIL.
+
+- [ ] **Step 3: Add the parser, cache, and method**
+
+In `Sources/GitHubOperations/PRManager.swift`, add to the actor state (near the whoami cache):
+
+```swift
+    private var cachedCollaboratorsByRepo: [String: (data: [Collaborator], fetchedAt: Date)] = [:]
+    private let collaboratorsTTL: TimeInterval = 600
+```
+
+Add a decodable helper struct near other GH JSON types (before `// MARK: - JSONDecoder for gh output`):
+
+```swift
+private struct GHCollaboratorPage: Decodable {
+    struct User: Decodable {
+        let login: String
+        let name: String?
+    }
+}
+
+// For --slurp output: [[{login,name},...], [...]]
+private struct GHCollaboratorUser: Decodable {
+    let login: String
+    let name: String?
+}
+```
+
+Add the public method and parser inside the actor (near whoami, before `// MARK: - Private`):
+
+```swift
+    /// Fetch the collaborator list for a repo. Cached per-repo with a 10-min TTL.
+    public func collaborators(repo: String, host: String? = nil) async throws -> [Collaborator] {
+        if let entry = cachedCollaboratorsByRepo[repo],
+           Date().timeIntervalSince(entry.fetchedAt) < collaboratorsTTL {
+            return entry.data
+        }
+        let output = try await runGH(
+            args: ["api", "repos/\(repo)/collaborators", "--paginate", "--slurp"],
+            host: host
+        )
+        let collabs = try Self.parseCollaborators(output)
+        cachedCollaboratorsByRepo[repo] = (collabs, Date())
+        return collabs
+    }
+
+    public func cachedCollaborators(for repo: String) -> [Collaborator]? {
+        guard let entry = cachedCollaboratorsByRepo[repo],
+              Date().timeIntervalSince(entry.fetchedAt) < collaboratorsTTL
+        else { return nil }
+        return entry.data
+    }
+
+    #if DEBUG
+    public func seedCollaboratorsForTest(repo: String, collabs: [Collaborator]) {
+        cachedCollaboratorsByRepo[repo] = (collabs, Date())
+    }
+    #endif
+
+    /// Parse `gh api repos/.../collaborators --paginate --slurp` output (array of pages).
+    /// Dedup by login, preserve first-occurrence order.
+    nonisolated static func parseCollaborators(_ json: String) throws -> [Collaborator] {
+        guard let data = json.data(using: .utf8) else { return [] }
+        let pages = try JSONDecoder().decode([[GHCollaboratorUser]].self, from: data)
+        var seen = Set<String>()
+        var result: [Collaborator] = []
+        for user in pages.flatMap({ $0 }) {
+            if seen.insert(user.login).inserted {
+                result.append(Collaborator(login: user.login, name: user.name))
+            }
+        }
+        return result
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+swift test --filter "GitHubOperationsTests.(parseCollaborators|collaboratorsCache)"
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/GitHubOperations/PRManager.swift Tests/GitHubOperationsTests/PRManagerTests.swift
+git commit -m "feat(github): add PRManager.collaborators with 10-min TTL cache"
+```
+
+---
+
+## Task 7: Decode `assignees` via `enrichChecks` + `fetchDetail`
+
+**Files:**
+- Modify: `Sources/GitHubOperations/PRManager.swift` (update `GHEnrichResponse`, `PREnrichResult`, `GHPRItem`, `GHPRDetailResponse`, `PRDetail`)
+- Modify: `Sources/Models/PullRequest.swift` (add `assignees` to `PRDetail`)
+- Test: `Tests/GitHubOperationsTests/PRManagerTests.swift`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `Tests/GitHubOperationsTests/PRManagerTests.swift`:
+
+```swift
+// MARK: - Assignee decoding
+
+@Test func enrichResultHasAssignees() {
+    let result = PREnrichResult()
+    #expect(result.assignees.isEmpty)
+}
+
+@Test func enrichResponseDecodesAssignees() throws {
+    let json = """
+    {
+      "statusCheckRollup": [],
+      "assignees": [{"login":"alice","name":"Alice"}, {"login":"bob","name":null}]
+    }
+    """
+    // Force-decode via the same path enrichChecks uses.
+    // We wrap in the real response shape so the test follows prod code.
+    let data = json.data(using: .utf8)!
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    // Use the public test-seam helper added below
+    let result = try PRManager.parseEnrichResponseForTest(data: data, excludeAuthor: nil)
+    #expect(result.assignees == ["alice", "bob"])
+}
+
+@Test func enrichResponseWithNoAssignees() throws {
+    let json = #"{"statusCheckRollup":[]}"#
+    let data = json.data(using: .utf8)!
+    let result = try PRManager.parseEnrichResponseForTest(data: data, excludeAuthor: nil)
+    #expect(result.assignees.isEmpty)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+swift test --filter "GitHubOperationsTests.(enrichResult|enrichResponse)"
+```
+Expected: FAIL.
+
+- [ ] **Step 3: Wire assignees through the enrichment path**
+
+In `Sources/GitHubOperations/PRManager.swift`:
+
+**(a)** Add `assignees` to `PREnrichResult` (around line 4-41):
+
+```swift
+public struct PREnrichResult: Sendable {
+    public var checks: CheckSummary
+    // ... existing fields ...
+    public var lastCommitDate: Date?
+    public var assignees: [String]
+
+    public init(
+        // ... existing params ...
+        lastCommitDate: Date? = nil,
+        assignees: [String] = []
+    ) {
+        // ... existing assigns ...
+        self.lastCommitDate = lastCommitDate
+        self.assignees = assignees
+    }
+}
+```
+
+**(b)** Add `assignees` to `GHEnrichResponse` (around line 768):
+
+```swift
+private struct GHEnrichResponse: Decodable {
+    // ... existing fields ...
+    let assignees: [GHAuthor]?
+
+    func toEnrichResult(excludeAuthor: String? = nil) -> PREnrichResult {
+        // ... existing decoding ...
+        let assigneeLogins = (assignees ?? []).map(\.login)
+        return PREnrichResult(
+            // ... existing args ...
+            lastCommitDate: lastCommitDate,
+            assignees: assigneeLogins
+        )
+    }
+}
+```
+
+**(c)** Add `assignees` to the JSON field list in `enrichChecks` (line 128-141):
+
+```swift
+        "statusCheckRollup,reviewDecision,headRefName,baseRefName,additions,deletions,changedFiles,mergeable,mergeStateStatus,autoMergeRequest,comments,commits,assignees",
+```
+
+**(d)** Add the test seam as a nonisolated static on `PRManager`:
+
+```swift
+    #if DEBUG
+    /// Test-only: parse an enrich response from raw JSON data.
+    nonisolated static func parseEnrichResponseForTest(data: Data, excludeAuthor: String?) throws -> PREnrichResult {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let resp = try decoder.decode(GHEnrichResponse.self, from: data)
+        return resp.toEnrichResult(excludeAuthor: excludeAuthor)
+    }
+    #endif
+```
+
+**(e)** Also do `fetchDetail`'s path:
+
+Add `assignees` to the JSON field list in `fetchDetail` (line 144-152):
+
+```swift
+        "body,reviews,comments,files,statusCheckRollup,reviewDecision,headRefName,baseRefName,additions,deletions,changedFiles,mergeable,mergeStateStatus,autoMergeRequest,assignees",
+```
+
+Add `assignees` to `PRDetail` (in `Sources/Models/PullRequest.swift:206-256`):
+
+```swift
+public struct PRDetail: Codable, Sendable {
+    // ... existing fields ...
+    public var autoMergeEnabled: Bool
+    public var assignees: [String]
+
+    public init(
+        // ... existing params ...
+        autoMergeEnabled: Bool = false,
+        assignees: [String] = []
+    ) {
+        // ... existing assigns ...
+        self.autoMergeEnabled = autoMergeEnabled
+        self.assignees = assignees
+    }
+}
+```
+
+Add `assignees` to `GHPRDetailResponse` (line 633-695):
+
+```swift
+private struct GHPRDetailResponse: Decodable {
+    // ... existing ...
+    let assignees: [GHAuthor]?
+
+    func toPRDetail() -> PRDetail {
+        // ... existing ...
+        return PRDetail(
+            // ... existing args ...
+            autoMergeEnabled: autoMergeRequest != nil,
+            assignees: (assignees ?? []).map(\.login)
+        )
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+swift test --filter "GitHubOperationsTests.(enrichResult|enrichResponse)"
+```
+Expected: PASS.
+
+- [ ] **Step 5: Run the full test suite**
+
+```bash
+swift test
+```
+Expected: PASS. Codable round-trip of `PRDetail` and `PREnrichResult` should not have broken.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/GitHubOperations/PRManager.swift Sources/Models/PullRequest.swift Tests/GitHubOperationsTests/PRManagerTests.swift
+git commit -m "feat(github): decode assignees via enrichChecks + fetchDetail"
+```
+
+---
+
+## Task 8: Add `assign` / `unassign` with a static arg builder
+
+**Files:**
+- Modify: `Sources/GitHubOperations/PRManager.swift` (add method + helper)
+- Test: `Tests/GitHubOperationsTests/PRManagerTests.swift`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `Tests/GitHubOperationsTests/PRManagerTests.swift`:
+
+```swift
+// MARK: - assign / unassign args
+
+@Test func buildAssignArgsAdd() {
+    let args = PRManager.buildAssignArgs(
+        repo: "owner/repo", number: 42, logins: ["alice", "bob"], add: true
+    )
+    #expect(args == ["pr", "edit", "42", "--repo", "owner/repo", "--add-assignee", "alice,bob"])
+}
+
+@Test func buildAssignArgsRemove() {
+    let args = PRManager.buildAssignArgs(
+        repo: "owner/repo", number: 42, logins: ["alice"], add: false
+    )
+    #expect(args == ["pr", "edit", "42", "--repo", "owner/repo", "--remove-assignee", "alice"])
+}
+
+@Test func buildAssignArgsSingle() {
+    let args = PRManager.buildAssignArgs(
+        repo: "o/r", number: 1, logins: ["me"], add: true
+    )
+    #expect(args.last == "me")
+    #expect(args.contains("--add-assignee"))
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+swift test --filter "GitHubOperationsTests.buildAssignArgs"
+```
+Expected: FAIL — method doesn't exist.
+
+- [ ] **Step 3: Add the builder and public methods**
+
+In `Sources/GitHubOperations/PRManager.swift`, near the other write operations (around line 220-280, after `approve`/`comment`/etc.):
+
+```swift
+    /// Assign the given logins to a PR. Single subprocess (gh accepts comma-joined list).
+    public func assign(repo: String, number: Int, logins: [String], host: String? = nil) async throws {
+        guard !logins.isEmpty else { return }
+        let args = Self.buildAssignArgs(repo: repo, number: number, logins: logins, add: true)
+        try await runGH(args: args, host: host)
+    }
+
+    /// Remove assignees from a PR. No-op if logins is empty.
+    public func unassign(repo: String, number: Int, logins: [String], host: String? = nil) async throws {
+        guard !logins.isEmpty else { return }
+        let args = Self.buildAssignArgs(repo: repo, number: number, logins: logins, add: false)
+        try await runGH(args: args, host: host)
+    }
+
+    nonisolated static func buildAssignArgs(repo: String, number: Int, logins: [String], add: Bool) -> [String] {
+        let flag = add ? "--add-assignee" : "--remove-assignee"
+        return ["pr", "edit", "\(number)", "--repo", repo, flag, logins.joined(separator: ",")]
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+swift test --filter "GitHubOperationsTests.buildAssignArgs"
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/GitHubOperations/PRManager.swift Tests/GitHubOperationsTests/PRManagerTests.swift
+git commit -m "feat(github): add assign / unassign PR operations"
+```
+
+---
+
+## Task 9: Extend `fetchAllPRs` with third `.assigned` search
+
+**Files:**
+- Modify: `Sources/GitHubOperations/PRManager.swift:80-107` (`fetchAllPRs`)
+- Test: `Tests/GitHubOperationsTests/PRManagerTests.swift`
+
+The existing merge logic handles two origin sets. Extend to three. This task is pure refactor + one added parallel call.
+
+- [ ] **Step 1: Write a merge-logic test**
+
+The existing code has no direct test for the origin-merge behavior (it's inline in `fetchAllPRs`). Extract to a static helper first for testability, then add a case for `.assigned`.
+
+Append to `Tests/GitHubOperationsTests/PRManagerTests.swift`:
+
+```swift
+// MARK: - fetchAllPRs merge
+
+@Test func mergeOriginsSingleList() {
+    let pr = PullRequest(
+        number: 1, title: "t", state: .open,
+        headBranch: "h", baseBranch: "m", author: "a", repo: "r"
+    )
+    let merged = PRManager.mergePRsByOrigin(
+        mine: [pr],
+        reviewRequested: [],
+        assigned: []
+    )
+    let out = merged.first!
+    #expect(out.origin == [.mine])
+}
+
+@Test func mergeOriginsAcrossAllThree() {
+    let pr = PullRequest(
+        number: 1, title: "t", state: .open,
+        headBranch: "h", baseBranch: "m", author: "a", repo: "r"
+    )
+    let merged = PRManager.mergePRsByOrigin(
+        mine: [pr],
+        reviewRequested: [pr],
+        assigned: [pr]
+    )
+    #expect(merged.count == 1)
+    #expect(merged.first!.origin == [.mine, .reviewRequested, .assigned])
+}
+
+@Test func mergeOriginsAssignedOnly() {
+    let pr = PullRequest(
+        number: 2, title: "t", state: .open,
+        headBranch: "h", baseBranch: "m", author: "a", repo: "r"
+    )
+    let merged = PRManager.mergePRsByOrigin(
+        mine: [],
+        reviewRequested: [],
+        assigned: [pr]
+    )
+    #expect(merged.first!.origin == [.assigned])
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+swift test --filter "GitHubOperationsTests.mergeOrigins"
+```
+Expected: FAIL — `mergePRsByOrigin` doesn't exist.
+
+- [ ] **Step 3: Extract the merge helper, add the third parallel call**
+
+Replace the body of `fetchAllPRs` (line 80-107):
+
+```swift
+    public func fetchAllPRs() async throws -> [PullRequest] {
+        let hosts = await discoverHosts()
+
+        async let minePRs: [PullRequest] = Self.fetchPRsNonisolated(hosts: hosts, filter: .mine)
+        async let reviewPRs: [PullRequest] = Self.fetchPRsNonisolated(hosts: hosts, filter: .reviewRequested)
+        async let assignedPRs: [PullRequest] = Self.fetchPRsNonisolated(hosts: hosts, filter: .assigned)
+
+        let (mine, review, assigned) = await (minePRs, reviewPRs, assignedPRs)
+        return Self.mergePRsByOrigin(mine: mine, reviewRequested: review, assigned: assigned)
+    }
+
+    nonisolated static func mergePRsByOrigin(
+        mine: [PullRequest],
+        reviewRequested: [PullRequest],
+        assigned: [PullRequest]
+    ) -> [PullRequest] {
+        var merged: [String: PullRequest] = [:]
+        for var pr in mine {
+            pr.origin = [.mine]
+            merged[pr.id] = pr
+        }
+        for var pr in reviewRequested {
+            pr.origin = [.reviewRequested]
+            if var existing = merged[pr.id] {
+                existing.origin.insert(.reviewRequested)
+                merged[pr.id] = existing
+            } else {
+                merged[pr.id] = pr
+            }
+        }
+        for var pr in assigned {
+            pr.origin = [.assigned]
+            if var existing = merged[pr.id] {
+                existing.origin.insert(.assigned)
+                merged[pr.id] = existing
+            } else {
+                merged[pr.id] = pr
+            }
+        }
+        return Array(merged.values)
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+swift test --filter "GitHubOperationsTests.mergeOrigins"
+```
+Expected: PASS.
+
+- [ ] **Step 5: Run the full test suite**
+
+```bash
+swift test
+```
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/GitHubOperations/PRManager.swift Tests/GitHubOperationsTests/PRManagerTests.swift
+git commit -m "feat(github): fetch assigned PRs in fetchAllPRs parallel merge"
+```
+
+---
+
+## Task 10: Add `PRCoordinator.myLogin(forHost:)` + whoami mirror
+
+**Files:**
+- Modify: `Sources/App/PRCoordinator.swift` (add mirror state + methods)
+
+This task is UI-facing but has no isolated unit test — the `@Observable` mirror is exercised by the drawer and column at runtime. Tests at the `PRCoordinator` level would require constructing a live store; we rely on the underlying `PRManager` tests + manual verification.
+
+- [ ] **Step 1: Add the whoami mirror state**
+
+In `Sources/App/PRCoordinator.swift`, add to the State section (around line 14-43):
+
+```swift
+    /// Mirror of PRManager whoami cache, observable to drive UI highlighting.
+    /// Populated lazily on first `myLogin(forHost:)` call per host.
+    var whoamiByHost: [String: String] = [:]
+```
+
+- [ ] **Step 2: Add the synchronous accessor and async warmer**
+
+Near the other methods (around the "PR Selection" or "PR Actions" section), add:
+
+```swift
+    // MARK: - Whoami
+
+    /// Synchronous accessor for the current user's login on a given host.
+    /// Returns nil until the first `warmWhoami(host:)` call resolves.
+    func myLogin(forHost host: String?) -> String? {
+        whoamiByHost[host ?? ""]
+    }
+
+    /// Populate the whoami mirror for a host if not already present. Safe to call repeatedly.
+    func warmWhoami(host: String?) {
+        let key = host ?? ""
+        guard whoamiByHost[key] == nil else { return }
+        Task { @MainActor in
+            if let login = try? await prManager.whoami(host: host) {
+                whoamiByHost[key] = login
+            }
+        }
+    }
+```
+
+- [ ] **Step 3: Build to verify compile**
+
+```bash
+swift build
+```
+Expected: Success.
+
+- [ ] **Step 4: Run the full test suite**
+
+```bash
+swift test
+```
+Expected: PASS (no new tests, but regression guard).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/App/PRCoordinator.swift
+git commit -m "feat(coordinator): add whoami mirror + myLogin(forHost:)"
+```
+
+---
+
+## Task 11: Add `PRCoordinator.loadCollaborators(for:)`
+
+**Files:**
+- Modify: `Sources/App/PRCoordinator.swift`
+
+- [ ] **Step 1: Add the state and loader**
+
+In `Sources/App/PRCoordinator.swift`, add to the State section:
+
+```swift
+    /// Observable mirror of PRManager collaborators cache. Keyed by repo.
+    var collaboratorsByRepo: [String: [Collaborator]] = [:]
+
+    /// Tracks which repos have a load in-flight to avoid duplicate fetches.
+    private var loadingCollaboratorsRepos: Set<String> = []
+```
+
+Near the other read-side methods, add:
+
+```swift
+    // MARK: - Collaborators
+
+    /// Load collaborators for a repo, caching the result. Deduplicates concurrent calls.
+    /// Hits the PRManager cache for instant re-reads within the 10-min TTL.
+    func loadCollaborators(for repo: String, host: String? = nil) async {
+        if let cached = await prManager.cachedCollaborators(for: repo) {
+            collaboratorsByRepo[repo] = cached
+            return
+        }
+        guard !loadingCollaboratorsRepos.contains(repo) else { return }
+        loadingCollaboratorsRepos.insert(repo)
+        defer { loadingCollaboratorsRepos.remove(repo) }
+        do {
+            let collabs = try await prManager.collaborators(repo: repo, host: host)
+            collaboratorsByRepo[repo] = collabs
+        } catch {
+            store?.statusMessage = .error("Couldn't load collaborators: \(error.localizedDescription)")
+        }
+    }
+```
+
+- [ ] **Step 2: Build + run tests**
+
+```bash
+swift build && swift test
+```
+Expected: Success.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/App/PRCoordinator.swift
+git commit -m "feat(coordinator): add loadCollaborators for picker"
+```
+
+---
+
+## Task 12: Add `PRCoordinator` write ops (`assignPRToMe`, `unassignMeFromPR`, `updateAssignees`)
+
+**Files:**
+- Modify: `Sources/App/PRCoordinator.swift`
+
+- [ ] **Step 1: Add the three write ops**
+
+In `Sources/App/PRCoordinator.swift`, near `approvePR` / `mergePR` (the `// MARK: - PR Actions` section):
+
+```swift
+    // MARK: - Assignee Actions
+
+    /// Assign the current user to the PR. Optimistic UI: mutates pr.assignees before refresh.
+    func assignPRToMe(_ pr: PullRequest) async {
+        let host = prManager.hostFromURL(pr.url)
+        guard let login = try? await prManager.whoami(host: host) else {
+            store?.statusMessage = .error("Couldn't resolve your GitHub login")
+            return
+        }
+        // Populate the mirror for UI
+        whoamiByHost[host ?? ""] = login
+        await updateAssignees(pr, adding: [login], removing: [])
+    }
+
+    /// Unassign the current user from the PR.
+    func unassignMeFromPR(_ pr: PullRequest) async {
+        let host = prManager.hostFromURL(pr.url)
+        guard let login = try? await prManager.whoami(host: host) else {
+            store?.statusMessage = .error("Couldn't resolve your GitHub login")
+            return
+        }
+        whoamiByHost[host ?? ""] = login
+        await updateAssignees(pr, adding: [], removing: [login])
+    }
+
+    /// Apply a set of assignee changes to a PR. Optimistic on success, reverts via re-enrichment
+    /// on failure. Skips the gh subprocess when both lists are empty.
+    func updateAssignees(_ pr: PullRequest, adding: [String], removing: [String]) async {
+        guard !adding.isEmpty || !removing.isEmpty else { return }
+
+        // Optimistic update
+        let originalAssignees: [String]?
+        if let idx = pullRequests.firstIndex(where: { $0.id == pr.id }) {
+            originalAssignees = pullRequests[idx].assignees
+            var current = pullRequests[idx].assignees
+            for login in adding where !current.contains(login) { current.append(login) }
+            current.removeAll { removing.contains($0) }
+            pullRequests[idx].assignees = current
+        } else {
+            originalAssignees = nil
+        }
+
+        let host = prManager.hostFromURL(pr.url)
+        do {
+            if !adding.isEmpty {
+                try await prManager.assign(repo: pr.repo, number: pr.number, logins: adding, host: host)
+            }
+            if !removing.isEmpty {
+                try await prManager.unassign(repo: pr.repo, number: pr.number, logins: removing, host: host)
+            }
+            let parts: [String] = [
+                adding.isEmpty ? nil : "+\(adding.joined(separator: ","))",
+                removing.isEmpty ? nil : "-\(removing.joined(separator: ","))",
+            ].compactMap { $0 }
+            store?.statusMessage = .success("Updated assignees on #\(pr.number): \(parts.joined(separator: " "))")
+            await refreshPRAfterAction(pr)
+        } catch {
+            // Revert optimistic update
+            if let original = originalAssignees,
+               let idx = pullRequests.firstIndex(where: { $0.id == pr.id }) {
+                pullRequests[idx].assignees = original
+            }
+            store?.statusMessage = .error("Assign failed: \(error.localizedDescription)")
+        }
+    }
+```
+
+- [ ] **Step 2: Build + run tests**
+
+```bash
+swift build && swift test
+```
+Expected: Success.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/App/PRCoordinator.swift
+git commit -m "feat(coordinator): add PR assignee write ops with optimistic UI"
+```
+
+---
+
+## Task 13: Surface `assignees` through `applyEnrichment`
+
+**Files:**
+- Modify: `Sources/App/PRCoordinator.swift:195-211` (`applyEnrichment`)
+
+Currently `applyEnrichment` copies ten fields from `PREnrichResult` to `PullRequest` but not `assignees`. This is the one-line wire-through.
+
+- [ ] **Step 1: Add the assign line**
+
+In `Sources/App/PRCoordinator.swift`, inside `applyEnrichment` (line 195-211), add after `pr.enrichedAt = Date()`:
+
+```swift
+    private func applyEnrichment(_ result: PREnrichResult, to pr: inout PullRequest) {
+        pr.checks = result.checks
+        pr.reviewDecision = result.reviewDecision
+        if !result.headBranch.isEmpty {
+            pr.headBranch = result.headBranch
+            pr.baseBranch = result.baseBranch
+        }
+        pr.additions = result.additions
+        pr.deletions = result.deletions
+        pr.changedFiles = result.changedFiles
+        pr.mergeable = result.mergeable
+        pr.mergeStateStatus = result.mergeStateStatus
+        pr.autoMergeEnabled = result.autoMergeEnabled
+        pr.commentsSinceLastCommit = result.commentsSinceLastCommit
+        pr.lastCommitDate = result.lastCommitDate
+        pr.assignees = result.assignees
+        pr.enrichedAt = Date()
+    }
+```
+
+- [ ] **Step 2: Build + run tests**
+
+```bash
+swift build && swift test
+```
+Expected: Success.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/App/PRCoordinator.swift
+git commit -m "feat(coordinator): surface assignees via applyEnrichment"
+```
+
+---
+
+## Task 14: Create `AssigneeAvatar` view + tests
+
+**Files:**
+- Create: `Sources/Views/Shared/AssigneeAvatar.swift`
+- Create: `Tests/ViewsTests/AssigneeAvatarTests.swift`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `Tests/ViewsTests/AssigneeAvatarTests.swift`:
+
+```swift
+import Foundation
+import Testing
+
+@testable import Views
+
+// MARK: - Initials extraction
+
+@Test func initialsHyphenSplit() {
+    #expect(AssigneeAvatar.initials(for: "alice-bailey") == "AB")
+}
+
+@Test func initialsNoHyphenUsesFirstTwo() {
+    #expect(AssigneeAvatar.initials(for: "mnicholson") == "MN")
+}
+
+@Test func initialsShortName() {
+    #expect(AssigneeAvatar.initials(for: "mn") == "MN")
+}
+
+@Test func initialsSingleChar() {
+    #expect(AssigneeAvatar.initials(for: "a") == "A")
+}
+
+@Test func initialsEmpty() {
+    #expect(AssigneeAvatar.initials(for: "") == "?")
+}
+
+@Test func initialsMultipleHyphens() {
+    // Only the first two hyphen-separated parts matter
+    #expect(AssigneeAvatar.initials(for: "a-b-c") == "AB")
+}
+
+// MARK: - Stable color index
+
+@Test func colorIndexDeterministic() {
+    let i1 = AssigneeAvatar.colorIndex(for: "alice", paletteCount: 8)
+    let i2 = AssigneeAvatar.colorIndex(for: "alice", paletteCount: 8)
+    #expect(i1 == i2)
+}
+
+@Test func colorIndexWithinPalette() {
+    let idx = AssigneeAvatar.colorIndex(for: "alice", paletteCount: 8)
+    #expect(idx >= 0)
+    #expect(idx < 8)
+}
+
+@Test func colorIndexDoesNotUseHashValue() {
+    // Swift's .hashValue is randomized per-launch. Our hash must be stable.
+    // Simulating a "restart" by computing the same input — should match.
+    let input = "mnicholson"
+    let expected = input.utf8.reduce(0) { ($0 &* 31 &+ Int($1)) & Int.max }
+    #expect(AssigneeAvatar.colorIndex(for: input, paletteCount: 8) == expected % 8)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+swift test --filter "ViewsTests.(initials|colorIndex)"
+```
+Expected: FAIL — `AssigneeAvatar` doesn't exist.
+
+- [ ] **Step 3: Create the view**
+
+Create `Sources/Views/Shared/AssigneeAvatar.swift`:
+
+```swift
+import SwiftUI
+import Theme
+
+/// Small circular avatar rendering two-letter initials.
+/// Color is deterministically hashed from the login so the same user
+/// always gets the same color. The `isMe` variant uses the theme green.
+public struct AssigneeAvatar: View {
+    public let login: String
+    public let isMe: Bool
+    public let size: CGFloat
+
+    @Environment(\.theme) private var theme
+
+    public init(login: String, isMe: Bool = false, size: CGFloat = 18) {
+        self.login = login
+        self.isMe = isMe
+        self.size = size
+    }
+
+    public var body: some View {
+        ZStack {
+            Circle()
+                .fill(backgroundColor)
+            Text(Self.initials(for: login))
+                .font(.system(size: size * 0.5, weight: .semibold))
+                .foregroundColor(.white)
+        }
+        .frame(width: size, height: size)
+        .overlay(
+            Circle().stroke(theme.chrome.background, lineWidth: 1)
+        )
+    }
+
+    private var backgroundColor: Color {
+        if isMe { return theme.chrome.green }
+        let idx = Self.colorIndex(for: login, paletteCount: Self.palette.count)
+        return Self.palette[idx]
+    }
+
+    // MARK: - Pure helpers (testable)
+
+    /// Two-letter initials. Splits on '-' first (alice-bailey → AB), else first two chars.
+    /// Returns "?" for empty strings so the UI never renders a blank circle.
+    public static func initials(for login: String) -> String {
+        guard !login.isEmpty else { return "?" }
+        let parts = login.split(separator: "-", maxSplits: 2, omittingEmptySubsequences: true)
+        if parts.count >= 2,
+           let a = parts[0].first, let b = parts[1].first {
+            return "\(a)\(b)".uppercased()
+        }
+        let chars = Array(login)
+        if chars.count >= 2 {
+            return "\(chars[0])\(chars[1])".uppercased()
+        }
+        return String(chars[0]).uppercased()
+    }
+
+    /// Deterministic palette index for a login. Uses a stable UTF-8 FNV-like hash
+    /// so color is consistent across app launches. **Do not use `String.hashValue`**:
+    /// Swift randomizes the seed per process, which would change colors every launch.
+    public static func colorIndex(for login: String, paletteCount: Int) -> Int {
+        guard paletteCount > 0 else { return 0 }
+        let hash = login.utf8.reduce(0) { ($0 &* 31 &+ Int($1)) & Int.max }
+        return hash % paletteCount
+    }
+
+    private static let palette: [Color] = [
+        Color(red: 0.48, green: 0.38, blue: 1.00),  // purple
+        Color(red: 0.37, green: 0.77, blue: 0.89),  // cyan
+        Color(red: 0.96, green: 0.56, blue: 0.33),  // orange
+        Color(red: 0.87, green: 0.37, blue: 0.54),  // pink
+        Color(red: 0.37, green: 0.56, blue: 0.89),  // blue
+        Color(red: 0.89, green: 0.72, blue: 0.37),  // amber
+        Color(red: 0.56, green: 0.37, blue: 0.78),  // violet
+        Color(red: 0.37, green: 0.78, blue: 0.56),  // teal
+    ]
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+swift test --filter "ViewsTests.(initials|colorIndex)"
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/Views/Shared/AssigneeAvatar.swift Tests/ViewsTests/AssigneeAvatarTests.swift
+git commit -m "feat(views): add AssigneeAvatar with stable color hash + initials"
+```
+
+---
+
+## Task 15: Add `assigneeSortKey` to `PRSortFilter`
+
+**Files:**
+- Modify: `Sources/Views/PRDashboard/PRSortFilter.swift` (append to the extension that holds `reviewSortRank`)
+- Test: `Tests/ViewsTests/PRSortFilterTests.swift`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `Tests/ViewsTests/PRSortFilterTests.swift`:
+
+```swift
+// MARK: - assigneeSortKey
+
+@Test func assigneeSortKeyEmpty() {
+    let pr = PullRequest(
+        number: 1, title: "t", state: .open,
+        headBranch: "h", baseBranch: "m", author: "a", repo: "r"
+    )
+    #expect(pr.assigneeSortKey == 0)
+}
+
+@Test func assigneeSortKeyCount() {
+    var pr = PullRequest(
+        number: 1, title: "t", state: .open,
+        headBranch: "h", baseBranch: "m", author: "a", repo: "r"
+    )
+    pr.assignees = ["alice", "bob", "carol"]
+    #expect(pr.assigneeSortKey == 3)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+swift test --filter "ViewsTests.assigneeSortKey"
+```
+Expected: FAIL.
+
+- [ ] **Step 3: Add the sort key**
+
+In `Sources/Views/PRDashboard/PRSortFilter.swift`, in the `PullRequest` extension (near line 128-150), add:
+
+```swift
+    /// Sort key for the "Assignees" table column — count of assignees.
+    /// PRs with no assignees sort first when ascending.
+    public var assigneeSortKey: Int {
+        assignees.count
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+swift test --filter "ViewsTests.assigneeSortKey"
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/Views/PRDashboard/PRSortFilter.swift Tests/ViewsTests/PRSortFilterTests.swift
+git commit -m "feat(views): add assigneeSortKey computed property"
+```
+
+---
+
+## Task 16: Create `AssigneePickerView`
+
+**Files:**
+- Create: `Sources/Views/PRDashboard/AssigneePicker.swift`
+
+This task has no isolated unit test — SwiftUI view rendering is validated manually. The internal filtering logic is trivially testable via a static helper.
+
+- [ ] **Step 1: Write failing tests for the static filter helper**
+
+Append to `Tests/ViewsTests/AssigneeAvatarTests.swift` (or a new file, but keep co-located for now):
+
+```swift
+// MARK: - AssigneePicker filter
+
+@Test func pickerFilterMatchesLogin() {
+    let collabs = [
+        Collaborator(login: "alice-bailey", name: "Alice B"),
+        Collaborator(login: "bob-chen", name: "Bob C"),
+    ]
+    let filtered = AssigneePickerView.filter(collaborators: collabs, query: "alice")
+    #expect(filtered.count == 1)
+    #expect(filtered.first?.login == "alice-bailey")
+}
+
+@Test func pickerFilterMatchesName() {
+    let collabs = [
+        Collaborator(login: "ab", name: "Alice B"),
+        Collaborator(login: "bc", name: "Bob C"),
+    ]
+    let filtered = AssigneePickerView.filter(collaborators: collabs, query: "bob")
+    #expect(filtered.first?.login == "bc")
+}
+
+@Test func pickerFilterEmptyQueryReturnsAll() {
+    let collabs = [
+        Collaborator(login: "a", name: nil),
+        Collaborator(login: "b", name: nil),
+    ]
+    let filtered = AssigneePickerView.filter(collaborators: collabs, query: "")
+    #expect(filtered.count == 2)
+}
+
+@Test func pickerFilterCaseInsensitive() {
+    let collabs = [Collaborator(login: "Alice", name: "Alice")]
+    let filtered = AssigneePickerView.filter(collaborators: collabs, query: "ALICE")
+    #expect(filtered.count == 1)
+}
+```
+
+You'll also need to update the import: at the top of the test file, add `import GitHubOperations` so `Collaborator` is visible.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+swift test --filter "ViewsTests.pickerFilter"
+```
+Expected: FAIL.
+
+- [ ] **Step 3: Create the view**
+
+Create `Sources/Views/PRDashboard/AssigneePicker.swift`:
+
+```swift
+import GitHubOperations
+import Models
+import SwiftUI
+import Theme
+
+/// Popover-hosted picker for PR assignees. Shows a top "Assign to me" pill,
+/// a search field, and a scrollable list of repo collaborators with
+/// check indicators for currently-assigned logins.
+public struct AssigneePickerView: View {
+    let pr: PullRequest
+    let myLogin: String?
+    let collaborators: [Collaborator]
+    let isLoading: Bool
+    let onAssignToMe: () -> Void
+    let onUnassignMe: () -> Void
+    let onToggle: (String) -> Void
+
+    @State private var query: String = ""
+    @Environment(\.theme) private var theme
+
+    public init(
+        pr: PullRequest,
+        myLogin: String?,
+        collaborators: [Collaborator],
+        isLoading: Bool,
+        onAssignToMe: @escaping () -> Void,
+        onUnassignMe: @escaping () -> Void,
+        onToggle: @escaping (String) -> Void
+    ) {
+        self.pr = pr
+        self.myLogin = myLogin
+        self.collaborators = collaborators
+        self.isLoading = isLoading
+        self.onAssignToMe = onAssignToMe
+        self.onUnassignMe = onUnassignMe
+        self.onToggle = onToggle
+    }
+
+    public var body: some View {
+        VStack(spacing: 8) {
+            mePill
+            Divider()
+            searchField
+            Divider()
+            listContent
+        }
+        .padding(12)
+        .frame(width: 360, height: 420)
+        .background(theme.chrome.surface)
+    }
+
+    // MARK: - Pill
+
+    @ViewBuilder
+    private var mePill: some View {
+        if let myLogin {
+            let isAssigned = pr.assignees.contains(myLogin)
+            Button {
+                if isAssigned { onUnassignMe() } else { onAssignToMe() }
+            } label: {
+                HStack {
+                    Image(systemName: isAssigned ? "person.crop.circle.badge.minus" : "person.crop.circle.badge.plus")
+                    Text(isAssigned ? "Unassign me" : "Assign to me")
+                        .fontWeight(.medium)
+                    Spacer()
+                }
+                .padding(.vertical, 6)
+                .padding(.horizontal, 10)
+                .frame(maxWidth: .infinity)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(theme.chrome.green.opacity(0.15))
+                )
+                .foregroundColor(theme.chrome.green)
+            }
+            .buttonStyle(.plain)
+        } else {
+            Text("Resolving your login…")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    // MARK: - Search
+
+    private var searchField: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "magnifyingglass").foregroundStyle(.secondary)
+            TextField("Filter collaborators…", text: $query)
+                .textFieldStyle(.plain)
+        }
+        .padding(.horizontal, 6)
+        .padding(.vertical, 4)
+        .background(RoundedRectangle(cornerRadius: 6).fill(theme.chrome.background))
+    }
+
+    // MARK: - List
+
+    @ViewBuilder
+    private var listContent: some View {
+        if isLoading && collaborators.isEmpty {
+            VStack { Spacer(); ProgressView("Loading collaborators…"); Spacer() }
+        } else {
+            let filtered = Self.filter(collaborators: collaborators, query: query)
+            if filtered.isEmpty {
+                VStack { Spacer(); Text("No matches").foregroundStyle(.secondary); Spacer() }
+            } else {
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 2) {
+                        ForEach(filtered) { c in
+                            row(for: c)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func row(for c: Collaborator) -> some View {
+        let isAssigned = pr.assignees.contains(c.login)
+        let isMe = c.login == myLogin
+        return Button {
+            onToggle(c.login)
+        } label: {
+            HStack(spacing: 8) {
+                AssigneeAvatar(login: c.login, isMe: isMe, size: 20)
+                VStack(alignment: .leading, spacing: 0) {
+                    Text(c.login).font(.callout)
+                    if let name = c.name, !name.isEmpty {
+                        Text(name).font(.caption).foregroundStyle(.secondary)
+                    }
+                }
+                Spacer()
+                if isAssigned {
+                    Image(systemName: "checkmark").foregroundColor(theme.chrome.green)
+                }
+            }
+            .padding(.vertical, 4)
+            .padding(.horizontal, 6)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Pure helper (testable)
+
+    public static func filter(collaborators: [Collaborator], query: String) -> [Collaborator] {
+        let q = query.trimmingCharacters(in: .whitespaces).lowercased()
+        guard !q.isEmpty else { return collaborators }
+        return collaborators.filter { c in
+            if c.login.lowercased().contains(q) { return true }
+            if let name = c.name?.lowercased(), name.contains(q) { return true }
+            return false
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+swift test --filter "ViewsTests.pickerFilter"
+```
+Expected: PASS.
+
+- [ ] **Step 5: Build to verify the view compiles**
+
+```bash
+swift build
+```
+Expected: Success.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/Views/PRDashboard/AssigneePicker.swift Tests/ViewsTests/AssigneeAvatarTests.swift
+git commit -m "feat(views): add AssigneePickerView with search + Assign to me pill"
+```
+
+---
+
+## Task 17: Add assignees row to `PRDetailDrawer`
+
+**Files:**
+- Modify: `Sources/Views/PRDashboard/PRDetailDrawer.swift`
+
+- [ ] **Step 1: Add callback parameters**
+
+In `Sources/Views/PRDashboard/PRDetailDrawer.swift`, extend the struct's fields (around line 16-21):
+
+```swift
+    var onEnableAutoMerge: ((MergeStrategy) -> Void)?
+    var onDisableAutoMerge: (() -> Void)?
+    var onClosePR: (() -> Void)?
+    var onAssignToMe: (() -> Void)?
+    var onUnassignMe: (() -> Void)?
+    var onToggleAssignee: ((String) -> Void)?
+    var myLogin: String?
+    var collaborators: [Collaborator] = []
+    var isLoadingCollaborators: Bool = false
+    var onLoadCollaborators: (() -> Void)?
+```
+
+Extend the `init` signature (around line 39-67) similarly — add matching params with defaults.
+
+Add new state:
+
+```swift
+    @State private var showAssigneePicker: Bool = false
+```
+
+Also add `import GitHubOperations` at the top.
+
+- [ ] **Step 2: Add the row view**
+
+In the drawer body, between the metadata row and the merge status badge (around line 136, after the `// Review decision` section), add:
+
+```swift
+            // Assignees
+            assigneesRow
+```
+
+Then, in the `// MARK: - Header` section (near the `detailReviewBadge` helper), add:
+
+```swift
+    @ViewBuilder
+    private var assigneesRow: some View {
+        HStack(spacing: 8) {
+            Text("Assignees")
+                .font(.callout)
+                .foregroundColor(theme.chrome.textDim)
+            ForEach(pr.assignees, id: \.self) { login in
+                AssigneeAvatar(login: login, isMe: login == myLogin, size: 18)
+                    .help(login)
+            }
+            Button {
+                onLoadCollaborators?()
+                showAssigneePicker = true
+            } label: {
+                Image(systemName: "plus.circle")
+                    .font(.callout)
+                    .foregroundColor(theme.chrome.textDim)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Edit assignees")
+            .popover(isPresented: $showAssigneePicker, arrowEdge: .bottom) {
+                AssigneePickerView(
+                    pr: pr,
+                    myLogin: myLogin,
+                    collaborators: collaborators,
+                    isLoading: isLoadingCollaborators,
+                    onAssignToMe: { onAssignToMe?(); showAssigneePicker = false },
+                    onUnassignMe: { onUnassignMe?(); showAssigneePicker = false },
+                    onToggle: { login in onToggleAssignee?(login) }
+                )
+            }
+            Spacer()
+        }
+        .font(.callout)
+    }
+```
+
+- [ ] **Step 3: Build to verify**
+
+```bash
+swift build
+```
+Expected: Success.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/Views/PRDashboard/PRDetailDrawer.swift
+git commit -m "feat(views): add assignees row + picker popover to PRDetailDrawer"
+```
+
+---
+
+## Task 18: Wire drawer callbacks through `RunwayStore`
+
+**Files:**
+- Modify: `Sources/App/RunwayStore.swift` (or wherever `PRDetailDrawer` is instantiated)
+- Modify: `Sources/App/RunwayApp.swift` (likely the call site — confirm via grep)
+
+Before writing, confirm the actual call site — the drawer may be constructed in multiple places.
+
+- [ ] **Step 1: Find every `PRDetailDrawer(` call site**
+
+```bash
+grep -rn "PRDetailDrawer(" Sources/
+```
+
+Typical result (confirm before editing): `Sources/App/RunwayApp.swift` or `Sources/Views/PRDashboard/PRDashboardView.swift`.
+
+- [ ] **Step 2: Add the new callbacks at each call site**
+
+For each `PRDetailDrawer(...)` invocation, add:
+
+```swift
+PRDetailDrawer(
+    pr: pr,
+    detail: detail,
+    // ... existing params ...
+    onAssignToMe: { [weak store] in Task { await store?.prCoordinator.assignPRToMe(pr) } },
+    onUnassignMe: { [weak store] in Task { await store?.prCoordinator.unassignMeFromPR(pr) } },
+    onToggleAssignee: { [weak store] login in
+        Task {
+            guard let store else { return }
+            if pr.assignees.contains(login) {
+                await store.prCoordinator.updateAssignees(pr, adding: [], removing: [login])
+            } else {
+                await store.prCoordinator.updateAssignees(pr, adding: [login], removing: [])
+            }
+        }
+    },
+    myLogin: store.prCoordinator.myLogin(forHost: store.prCoordinator.prManager.hostFromURL(pr.url)),
+    collaborators: store.prCoordinator.collaboratorsByRepo[pr.repo] ?? [],
+    isLoadingCollaborators: false,  // loading state reflected by empty list + in-flight task
+    onLoadCollaborators: { [weak store] in
+        Task { await store?.prCoordinator.loadCollaborators(for: pr.repo) }
+    }
+)
+```
+
+Use the form that matches the surrounding code (e.g., `self` instead of `[weak store]` if the caller is non-optional).
+
+Also, at a point where the drawer first appears, trigger `warmWhoami`:
+
+```swift
+.task {
+    store.prCoordinator.warmWhoami(host: store.prCoordinator.prManager.hostFromURL(pr.url))
+}
+```
+
+- [ ] **Step 3: Build**
+
+```bash
+swift build
+```
+Expected: Success.
+
+- [ ] **Step 4: Run the full test suite**
+
+```bash
+swift test
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/App/ Sources/Views/
+git commit -m "feat(app): wire assignee callbacks from drawer to PRCoordinator"
+```
+
+---
+
+## Task 19: Add `PRTab.assigned` + filter logic
+
+**Files:**
+- Modify: `Sources/Views/PRDashboard/PRDashboardView.swift:478-482` (`PRTab` enum)
+- Modify: `Sources/Views/PRDashboard/PRDashboardView.swift:110-127` (`applyFilters`)
+- Test: `Tests/ViewsTests/PRGroupingTests.swift` (or a new `PRTabFilterTests.swift`)
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `Tests/ViewsTests/PRGroupingTests.swift`:
+
+```swift
+// MARK: - PRTab.assigned
+
+@Test func prTabAssignedCaseExists() {
+    let tabs = PRTab.allCases
+    #expect(tabs.contains(.assigned))
+    #expect(tabs.count == 4)
+}
+
+@Test func prTabAssignedRawValue() {
+    #expect(PRTab.assigned.rawValue == "Assigned")
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+swift test --filter "ViewsTests.prTab"
+```
+Expected: FAIL.
+
+- [ ] **Step 3: Add the case and filter branch**
+
+In `Sources/Views/PRDashboard/PRDashboardView.swift`, line 478-482:
+
+```swift
+public enum PRTab: String, CaseIterable, Sendable {
+    case all = "All"
+    case mine = "Mine"
+    case reviewRequested = "Review Requests"
+    case assigned = "Assigned"
+}
+```
+
+In the same file, `applyFilters` (line 110-120), add the case:
+
+```swift
+    private func applyFilters(to prs: [PullRequest], tab: PRTab) -> [PullRequest] {
+        var result = prs
+
+        switch tab {
+        case .all:
+            break
+        case .mine:
+            result = result.filter { $0.origin.contains(.mine) }
+        case .reviewRequested:
+            result = result.filter { $0.origin.contains(.reviewRequested) }
+        case .assigned:
+            result = result.filter { $0.origin.contains(.assigned) }
+        }
+
+        if showSessionPRsOnly {
+            result = result.filter { sessionPRIDs.contains($0.id) }
+        }
+
+        return result
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+swift test --filter "ViewsTests.prTab"
+```
+Expected: PASS.
+
+- [ ] **Step 5: Run the full test suite**
+
+```bash
+swift test
+```
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/Views/PRDashboard/PRDashboardView.swift Tests/ViewsTests/PRGroupingTests.swift
+git commit -m "feat(views): add Assigned tab to PR dashboard"
+```
+
+---
+
+## Task 20: Add "Assignees" `TableColumn` to `PRDashboardView`
+
+**Files:**
+- Modify: `Sources/Views/PRDashboard/PRDashboardView.swift` (insert a new `TableColumn` between Author and Age)
+
+- [ ] **Step 1: Ensure the view has access to `PRCoordinator`**
+
+Grep for how `PRDashboardView` currently accesses the coordinator:
+
+```bash
+grep -n "prCoordinator\|PRCoordinator" Sources/Views/PRDashboard/PRDashboardView.swift
+```
+
+If it isn't already wired in, add a `@Environment` or injected binding for `myLogin(forHost:)` lookups. Looking at the existing fields (around line 6-105), use whatever pattern matches (e.g., if the view already takes callbacks like `onSelectPR`, add a `myLoginForHost: (String?) -> String?` closure).
+
+Preferred approach — add a closure parameter rather than a strong `@Environment` reference (keeps Views module independent of App):
+
+```swift
+    let myLoginForHost: (String?) -> String?
+```
+
+Plumb it through the init + call site (`RunwayApp.swift` or wherever `PRDashboardView(…)` is invoked) as:
+
+```swift
+myLoginForHost: { host in store.prCoordinator.myLogin(forHost: host) }
+```
+
+- [ ] **Step 2: Insert the new TableColumn**
+
+In `Sources/Views/PRDashboard/PRDashboardView.swift`, between the "Author" column (line 240-246) and the "Age" column (line 248-253), add:
+
+```swift
+            TableColumn("Assignees", value: \.assigneeSortKey) { pr in
+                if !pr.assignees.isEmpty {
+                    let me = myLoginForHost(hostFromURL(pr.url))
+                    HStack(spacing: -4) {
+                        ForEach(pr.assignees.prefix(3), id: \.self) { login in
+                            AssigneeAvatar(login: login, isMe: login == me, size: 14)
+                        }
+                        if pr.assignees.count > 3 {
+                            Text("+\(pr.assignees.count - 3)")
+                                .font(.caption2)
+                                .frame(width: 14, height: 14)
+                                .background(Circle().fill(theme.chrome.surface))
+                                .foregroundColor(theme.chrome.textDim)
+                        }
+                    }
+                }
+            }
+            .width(min: 40, ideal: 80, max: 140)
+```
+
+Add a tiny helper in the same file (near the other cell helpers around line 366):
+
+```swift
+    private func hostFromURL(_ url: String) -> String? {
+        guard let parsed = URL(string: url), let host = parsed.host else { return nil }
+        return host == "github.com" ? nil : host
+    }
+```
+
+- [ ] **Step 3: Update call site**
+
+At the `PRDashboardView(…)` call site, add the new closure:
+
+```swift
+PRDashboardView(
+    // ... existing params ...
+    myLoginForHost: { host in store.prCoordinator.myLogin(forHost: host) }
+)
+```
+
+- [ ] **Step 4: Build**
+
+```bash
+swift build
+```
+Expected: Success.
+
+- [ ] **Step 5: Run the full test suite**
+
+```bash
+swift test
+```
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/Views/PRDashboard/PRDashboardView.swift Sources/App/
+git commit -m "feat(views): add Assignees TableColumn to PR dashboard"
+```
+
+---
+
+## Task 21: Final verification — tests + manual smoke
+
+**Files:** none
+
+- [ ] **Step 1: Full test suite**
+
+```bash
+swift test
+```
+Expected: PASS. No new warnings.
+
+- [ ] **Step 2: Format + lint**
+
+```bash
+make check
+```
+Expected: All checks pass (build + test + lint + format).
+
+- [ ] **Step 3: Manual smoke test**
+
+Launch the app:
+
+```bash
+swift run Runway
+```
+
+Checklist:
+
+- [ ] PR dashboard loads with four tabs: All, Mine, Review Requests, Assigned.
+- [ ] "Assigned" tab shows only PRs you're assigned to (verify by assigning yourself via GitHub web UI to a PR, wait <60s for poll, see it appear).
+- [ ] The "Assignees" column shows avatars for PRs with assignees, nothing for PRs without.
+- [ ] Hovering an avatar shows the login in a tooltip (macOS `.help()`).
+- [ ] Opening a PR drawer shows the "Assignees" row with avatars.
+- [ ] Clicking "+" opens the popover picker. "Assign to me" pill is visible.
+- [ ] Clicking "Assign to me" closes the popover, updates the avatar row instantly (optimistic), and the PR appears in the "Assigned" tab after refresh.
+- [ ] Clicking "Unassign me" reverses the action.
+- [ ] Searching the picker filters by login and name (type "alice" — only "alice-*" matches).
+- [ ] Toggling a non-me collaborator's row adds/removes them.
+- [ ] Closing and reopening the picker within 10 minutes loads instantly (collaborator cache hit).
+- [ ] The "me" avatar uses the theme green; other avatars use the hash palette.
+- [ ] Avatar colors stay the same after restarting the app (stable hash — do `Cmd+Q` then relaunch).
+
+- [ ] **Step 4: Final push**
+
+```bash
+git push
+```
+
+Create PR via the project's normal flow (`/simplify` → `/pre-ship` → `/ship-it`, or manual `gh pr create`).
+
+---
+
+## Notes for Implementers
+
+- **TDD discipline:** Write the failing test first, run it to see the failure, then implement. Skipping the red step hides bugs in the test itself.
+- **Commit granularity:** Each task ends in one commit. If a task grows, split it — don't batch.
+- **Optimistic UI revert:** The revert path in `updateAssignees` is best-effort. If `refreshPRAfterAction` runs and the server state disagrees, enrichment will overwrite — which is the desired safety net.
+- **`whoami` host semantics:** `nil` host maps to `""` in the cache dictionary (canonical for github.com). Keep this consistent across reads and writes.
+- **Test fixtures:** JSON test fixtures use real GitHub response shapes. If a test fails after a `gh` version bump, check whether the CLI's JSON output changed shape.
+- **Existing `ManageAssigneesSheet`:** The Issues view has a similar component. For v1, keep the PR picker separate to avoid coupling two unrelated flows. A future refactor can extract shared primitives if both surfaces evolve together.

--- a/docs/superpowers/specs/2026-04-17-pr-assign-to-self-design.md
+++ b/docs/superpowers/specs/2026-04-17-pr-assign-to-self-design.md
@@ -1,0 +1,331 @@
+# PR Assignment — Design
+
+**Date:** 2026-04-17
+**Branch:** `feature-pr-assign`
+**Status:** Draft
+
+## Problem
+
+Runway's PR view today lets you approve, comment, request changes, merge, toggle draft, and close a pull request. It does not let you manage **assignees** — neither assigning yourself to take ownership of a PR nor assigning a repo collaborator. GitHub treats assignment as an independent dimension from authorship and review requests: a PR you authored is not automatically assigned to you, and you may be assigned to a PR you are neither reviewing nor authoring. Users who rely on the "assigned to me" lens to triage work currently have to leave Runway and open the PR page in a browser.
+
+## Goal
+
+Add first-class assignee support to the PR surface:
+
+- See who is currently assigned to a PR at a glance (drawer row + dashboard card).
+- Assign or unassign yourself with one click.
+- Assign or unassign any repo collaborator via a searchable picker.
+- Surface PRs assigned to you as a dedicated tab in the dashboard.
+
+## Non-Goals
+
+- Dashboard right-click "Assign to me" quick action (deferred — can be added if frequently needed).
+- Fetching and rendering GitHub avatar images. Initials in a colored circle are used instead. Deferred until real avatars become worth the network cost and image-caching complexity.
+- Suggesting assignees from outside the repo collaborator list (code owners, recent contributors, Copilot suggestions).
+- Persisting assignees in SQLite across launches. Assignees populate on the first enrichment after launch, matching how `checks` already behaves.
+- Bulk assign across multiple PRs.
+
+## Design
+
+### Architecture
+
+The feature uses the existing three-layer PR architecture. No new layers are introduced.
+
+```
+PRDetailDrawer (View)           → new AssigneesRow + popover-hosted AssigneePickerView
+PRDashboardView (View)          → new "Assigned" tab + avatar stack on card footer
+PRCoordinator (@Observable)     → orchestrates assign/unassign, caches collaborators
+PRManager (actor)               → shells out to `gh` for assignee + collaborator ops
+```
+
+Four new `gh` operations wrap into `PRManager`:
+
+| Operation | Command | Cache |
+|-----------|---------|-------|
+| `assign(repo, number, logins)` | `gh pr edit <n> --add-assignee <login,...>` | — |
+| `unassign(repo, number, logins)` | `gh pr edit <n> --remove-assignee <login,...>` | — |
+| `collaborators(repo)` | `gh api repos/<repo>/collaborators --paginate` | per-repo, 10-min TTL |
+| `whoami(host)` | `gh api user -q .login` | per-host, indefinite |
+
+Existing `enrichChecks` and `fetchDetail` calls learn a new `assignees` JSON field — no extra subprocesses for list display. `fetchAllPRs` fires three parallel searches (Mine, ReviewRequested, Assigned) instead of two, merging `origin: Set<PROrigin>` with the existing dedup logic.
+
+### Data Model
+
+**`PullRequest` (`Sources/Models/PullRequest.swift`)** — one new field:
+
+```swift
+public var assignees: [String] = []   // GitHub logins
+```
+
+Represented as `[String]` rather than a struct: we only need the login for API calls and to derive initials for display. Avoids a data-type ripple and keeps `Codable` round-trips simple.
+
+**`PROrigin`** — one new case:
+
+```swift
+public enum PROrigin: String, Codable, Sendable, Hashable {
+    case mine, reviewRequested, assigned
+}
+```
+
+**`PRFilter` (`Sources/GitHubOperations/PRManager.swift`)** — one new case:
+
+```swift
+public enum PRFilter: Sendable {
+    case mine, reviewRequested, assigned, all
+}
+```
+
+`buildSearchArgs` and `buildListArgs` gain a `.assigned` branch that adds `--assignee @me`.
+
+**`PRTab` (`Sources/Views/PRDashboard/PRDashboardView.swift`)** — one new case:
+
+```swift
+public enum PRTab: String, CaseIterable, Sendable {
+    case all = "All"
+    case mine = "Mine"
+    case reviewRequested = "Review Requests"
+    case assigned = "Assigned"
+}
+```
+
+**`PREnrichResult`** — one new field:
+
+```swift
+public var assignees: [String] = []
+```
+
+Populated by the existing `gh pr view --json ...` call — the JSON field list adds `assignees`, and `GHEnrichResponse` decodes the array of `{login}` objects.
+
+**`Collaborator` (new type, in `PRManager.swift`)** — for the picker:
+
+```swift
+public struct Collaborator: Identifiable, Sendable, Hashable {
+    public let login: String
+    public let name: String?        // optional, for search matching
+    public var id: String { login }
+}
+```
+
+**No database migration.** Assignees are enrichment-derived. A cold start shows blank avatars for ~2s until enrichment completes, matching how `checks` already behaves. Skipping the migration keeps the feature tight.
+
+**`PRManager` state additions (actor-isolated):**
+
+```swift
+private var cachedWhoami: [String: String] = [:]               // host → login
+private var cachedCollaborators: [String: (data: [Collaborator], fetchedAt: Date)] = [:]  // repo → ...
+private let collaboratorsTTL: TimeInterval = 600
+```
+
+### PRManager — New Methods
+
+```swift
+public func assign(
+    repo: String, number: Int, logins: [String], host: String? = nil
+) async throws
+
+public func unassign(
+    repo: String, number: Int, logins: [String], host: String? = nil
+) async throws
+
+public func whoami(host: String? = nil) async throws -> String
+
+public func collaborators(repo: String, host: String? = nil) async throws -> [Collaborator]
+```
+
+Both write ops join `logins` with commas and pass as a single `--add-assignee` / `--remove-assignee` argument (gh accepts comma-separated lists).
+
+`whoami` caches per host indefinitely — the user's login rarely changes in a session, and invalidation is a cold-start concern.
+
+`collaborators` paginates and caches per repo with a 10-minute TTL. The popover triggers a fetch on appear; a stale cache is served instantly and refreshed in the background.
+
+### PRManager — Extended Methods
+
+- **`enrichChecks`** — add `"assignees"` to the `--json` field list; `GHEnrichResponse` decodes `assignees: [GHAuthor]` and maps to `[String]` via `login`.
+- **`fetchDetail`** — same one-line addition.
+- **`fetchAllPRs`** — adds a third parallel fetch for `.assigned`, merges `.assigned` into `pr.origin` before inserting into the dedup dictionary.
+- **`buildSearchArgs` / `buildListArgs`** — new `.assigned` branch: `args += ["--assignee", "@me"]`.
+
+### PRCoordinator — New Methods
+
+```swift
+@MainActor
+func assignPRToMe(_ pr: PullRequest) async
+
+@MainActor
+func unassignMeFromPR(_ pr: PullRequest) async
+
+@MainActor
+func updateAssignees(_ pr: PullRequest, adding: [String], removing: [String]) async
+
+@MainActor
+func loadCollaborators(for repo: String) async -> [Collaborator]
+
+@MainActor
+func myLogin(forHost host: String?) -> String?      // synchronous — reads the PRManager whoami cache
+```
+
+The sync `myLogin(forHost:)` reads an @Observable mirror of `PRManager.cachedWhoami` that `PRCoordinator` keeps in step. On first access for a host, a background task warms the cache; the mirror triggers a view refresh when it populates. This avoids requiring every card to spawn an async task just to check "is this me".
+
+Each write path follows the existing error-handling pattern: `store?.statusMessage = .success/.error(...)` + `refreshPRAfterAction(pr)` on success.
+
+**Optimistic UI.** Before the `gh` subprocess returns, `pr.assignees` is mutated locally so the avatar row updates instantly. On failure, the re-enrichment round overwrites the optimistic state. Assignment is a visually immediate action where a 1s delay feels sluggish; approve/merge don't do this today but aren't as visually tight.
+
+### UI Components
+
+**1. `AssigneeAvatar` (new shared view, `Sources/Views/Shared/AssigneeAvatar.swift`)**
+
+Reusable initials-in-circle. Deterministic color hashed from the login so `alice-bailey` always renders the same hue. Two-letter initials split on `-` first (`alice-bailey` → "AB"), else first two chars of the login (`mnicholson` → "MN"). Single-character logins pad with a space.
+
+```swift
+public struct AssigneeAvatar: View {
+    let login: String
+    let isMe: Bool          // triggers the green theme gradient
+    let size: CGFloat       // 18 default (drawer), 14 for card footer
+}
+```
+
+The "me" variant uses `theme.chrome.green` gradient for instant recognition. Other avatars draw from a fixed palette indexed by a **stable hash of the login** — e.g., summing UTF-8 code units modulo palette size — so colors stay consistent across app launches. **Do not use Swift's built-in `.hashValue`**: it's randomized per-launch and colors would change every time the app opens.
+
+**2. `AssigneesRow` (new private view inside `PRDetailDrawer`)**
+
+Placed below the metadata row in the drawer header, rendered only when `pr.state == .open` or `.draft`. Matches the visual weight of the existing check/review/merge status rows.
+
+```swift
+@ViewBuilder
+private var assigneesRow: some View {
+    HStack(spacing: 8) {
+        Text("Assignees").font(.callout).foregroundColor(theme.chrome.textDim)
+        ForEach(pr.assignees, id: \.self) { login in
+            AssigneeAvatar(login: login, isMe: login == myLogin, size: 18)
+                .help(login)
+        }
+        Button {
+            showAssigneePicker = true
+        } label: {
+            Image(systemName: "plus.circle")
+                .foregroundColor(theme.chrome.textDim)
+        }
+        .buttonStyle(.plain)
+        .popover(isPresented: $showAssigneePicker) {
+            AssigneePickerView(pr: pr, myLogin: myLogin)
+        }
+        Spacer()
+    }
+}
+```
+
+`myLogin` is resolved per-PR from `PRManager.whoami(host:)` using the PR's host (extracted via `prManager.hostFromURL(pr.url)`). Held in the drawer as `@State private var myLogin: String?` and populated in `.task`. This is host-aware because the same user may have different logins on different GHE instances (e.g., `mnicholson` on github.com vs `m-nicholson` on ghe.spotify.net); comparing a github.com login against a GHE PR's assignees would mis-identify "me".
+
+**3. `AssigneePickerView` (new file, `Sources/Views/PRDashboard/AssigneePicker.swift`)**
+
+Fixed-frame popover content (`360 × 420`). Structure:
+
+```
+┌──────────────────────────────────────┐
+│    [⚡ Assign to me / Unassign me]   │  ← full-width green pill
+├──────────────────────────────────────┤
+│ 🔍 [Filter collaborators…          ] │
+├──────────────────────────────────────┤
+│ ● alice-bailey               Alice B.│  ← ✓ if assigned
+│   bob-chen                   Bob C.  │
+│   carlos-dev                 Carlos  │
+│ ...                                  │
+└──────────────────────────────────────┘
+```
+
+- **Top pill** — full-width rounded button. Label and action flip based on `pr.assignees.contains(myLogin)`:
+  - `"Assign to me"` → calls `prCoordinator.assignPRToMe(pr)`
+  - `"Unassign me"` → calls `prCoordinator.unassignMeFromPR(pr)`
+- **Search field** — `TextField` that filters both `login` and `name` case-insensitively.
+- **Collaborator list** — scrollable `LazyVStack`. Each row shows avatar, login, optional name. Tapping toggles the login via `prCoordinator.updateAssignees(pr, adding:[login])` or `removing:[login]`.
+- **Loading state** — `ProgressView("Loading collaborators…")` while `loadCollaborators` is in flight.
+- **Error state** — `Text("Couldn't load collaborators").foregroundStyle(theme.chrome.red)` with a retry button.
+- **Empty search state** — `Text("No matches").foregroundStyle(.secondary)` centered.
+
+Collaborator fetch triggers in `.task { await prCoordinator.loadCollaborators(for: pr.repo) }`. The cache ensures reopening the picker is instant within the 10-minute window.
+
+**4. Card footer avatars (`PRDashboardView`)**
+
+In the existing PR card footer row, add a small `HStack` of `AssigneeAvatar(size: 14)` between the branch name and the checks pill. Shown only when `!pr.assignees.isEmpty`. Max 3 visible; remaining count rendered as `"+N"` in a dim circle of the same size.
+
+```swift
+if !pr.assignees.isEmpty {
+    let myLogin = prCoordinator.myLogin(forHost: prManager.hostFromURL(pr.url))
+    HStack(spacing: -4) {
+        ForEach(pr.assignees.prefix(3), id: \.self) { login in
+            AssigneeAvatar(login: login, isMe: login == myLogin, size: 14)
+        }
+        if pr.assignees.count > 3 {
+            Text("+\(pr.assignees.count - 3)")
+                .font(.caption2)
+                .frame(width: 14, height: 14)
+                .background(Circle().fill(theme.chrome.surface))
+                .foregroundColor(theme.chrome.textDim)
+        }
+    }
+}
+```
+
+`PRCoordinator` exposes `myLogin(forHost:)` returning the cached whoami for that host (or `nil` if not yet resolved, in which case the "me" highlight is skipped gracefully). The slight negative spacing (`-4`) creates an overlapping-avatar stack familiar from GitHub/Linear.
+
+**5. "Assigned" dashboard tab**
+
+`PRTab.assigned = "Assigned"` adds the fourth tab. The grouping/filtering logic filters `pullRequests` where `origin.contains(.assigned)`. `PRCoordinator.fetchAllPRs` already populates origins from all three searches, so the new tab is pure filtering — no additional fetch when the tab is switched.
+
+Tab counts (if displayed by the existing `PRColumnHeader`) use the same filter logic.
+
+## Testing
+
+Extensions to the existing 338-test suite:
+
+**`PRManagerTests` (GitHubOperationsTests)**
+
+- `assign` builds `["pr", "edit", "42", "--repo", "owner/repo", "--add-assignee", "alice,bob"]`.
+- `unassign` symmetric.
+- `whoami` returns cached value without re-running `gh api user` on second call.
+- `collaborators` parses paginated `--slurp` output and dedups across pages.
+- `collaborators` serves stale cache within TTL window.
+- `buildSearchArgs(.assigned)` includes `--assignee @me`.
+- `fetchAllPRs` merges three origins correctly when the same PR appears in multiple searches.
+- `enrichChecks` decodes the `assignees` field from a fixture JSON payload.
+
+**`PullRequestTests` (ModelsTests)**
+
+- `assignees` field encodes/decodes round-trip.
+- `PROrigin.assigned` encode/decode.
+- `origin: Set<PROrigin>` merge behavior with `.assigned`.
+
+**`ViewsTests` (new `AssigneeAvatarTests`)**
+
+- Initials: `alice-bailey` → "AB", `mnicholson` → "MN", `mn` → "MN", `a` → "A ", `` `` → "".
+- Color hash determinism: same login yields same color across calls **and across simulated app restarts** (regression guard against accidentally reverting to `login.hashValue`).
+- `isMe=true` uses theme green regardless of hash.
+
+**`ViewsTests` (update `PRGroupingTests`, `PRSortFilterTests`)**
+
+- New `assigned` tab filter includes PRs where `origin.contains(.assigned)` and excludes others.
+- `all` tab continues to include assigned-only PRs.
+
+**`ViewsTests` (new `AssigneePickerTests`)**
+
+- Loading state renders ProgressView.
+- Empty list renders "No collaborators".
+- Search filters on both login and name.
+- Pill label flips between "Assign to me" and "Unassign me" based on `pr.assignees`.
+
+## Rollout
+
+Single PR. No feature flag. No migration. Behind-the-scenes changes (extra JSON field in `enrichChecks`, third parallel search in `fetchAllPRs`) are additive — if the `gh` command doesn't return assignees for some reason, the field defaults to `[]` and the UI hides the row.
+
+## Open Questions
+
+None at design time.
+
+## References
+
+- `Sources/GitHubOperations/PRManager.swift` — PR operations actor
+- `Sources/App/PRCoordinator.swift` — PR state orchestrator
+- `Sources/Views/PRDashboard/PRDetailDrawer.swift` — drawer UI
+- `Sources/Views/PRDashboard/PRDashboardView.swift` — dashboard UI and `PRTab` enum
+- `Sources/Models/PullRequest.swift` — model layer
+- GitHub CLI docs for `gh pr edit --add-assignee` and `gh api repos/:owner/:repo/collaborators`

--- a/docs/superpowers/specs/2026-04-17-pr-assign-to-self-design.md
+++ b/docs/superpowers/specs/2026-04-17-pr-assign-to-self-design.md
@@ -244,29 +244,43 @@ Fixed-frame popover content (`360 × 420`). Structure:
 
 Collaborator fetch triggers in `.task { await prCoordinator.loadCollaborators(for: pr.repo) }`. The cache ensures reopening the picker is instant within the 10-minute window.
 
-**4. Card footer avatars (`PRDashboardView`)**
+**4. "Assignees" column in `PRDashboardView` Table**
 
-In the existing PR card footer row, add a small `HStack` of `AssigneeAvatar(size: 14)` between the branch name and the checks pill. Shown only when `!pr.assignees.isEmpty`. Max 3 visible; remaining count rendered as `"+N"` in a dim circle of the same size.
+The dashboard uses SwiftUI `Table` with columns (not cards). Add a new `TableColumn("Assignees")` between the existing "Author" and "Age" columns, sortable by assignee count.
 
 ```swift
-if !pr.assignees.isEmpty {
-    let myLogin = prCoordinator.myLogin(forHost: prManager.hostFromURL(pr.url))
-    HStack(spacing: -4) {
-        ForEach(pr.assignees.prefix(3), id: \.self) { login in
-            AssigneeAvatar(login: login, isMe: login == myLogin, size: 14)
-        }
-        if pr.assignees.count > 3 {
-            Text("+\(pr.assignees.count - 3)")
-                .font(.caption2)
-                .frame(width: 14, height: 14)
-                .background(Circle().fill(theme.chrome.surface))
-                .foregroundColor(theme.chrome.textDim)
+TableColumn("Assignees", value: \.assigneeSortKey) { pr in
+    if !pr.assignees.isEmpty {
+        let myLogin = prCoordinator.myLogin(forHost: prManager.hostFromURL(pr.url))
+        HStack(spacing: -4) {
+            ForEach(pr.assignees.prefix(3), id: \.self) { login in
+                AssigneeAvatar(login: login, isMe: login == myLogin, size: 14)
+            }
+            if pr.assignees.count > 3 {
+                Text("+\(pr.assignees.count - 3)")
+                    .font(.caption2)
+                    .frame(width: 14, height: 14)
+                    .background(Circle().fill(theme.chrome.surface))
+                    .foregroundColor(theme.chrome.textDim)
+            }
         }
     }
+}
+.width(min: 40, ideal: 80, max: 140)
+```
+
+`assigneeSortKey` is a new computed property on `PullRequest` (via the existing `PullRequest+ViewHelpers.swift` extension pattern that already hosts `reviewSortRank` / `mergeSortRank` / `checksPassRatio`):
+
+```swift
+public extension PullRequest {
+    /// Sort key for the "Assignees" column — count ascending (PRs without assignees first).
+    var assigneeSortKey: Int { assignees.count }
 }
 ```
 
 `PRCoordinator` exposes `myLogin(forHost:)` returning the cached whoami for that host (or `nil` if not yet resolved, in which case the "me" highlight is skipped gracefully). The slight negative spacing (`-4`) creates an overlapping-avatar stack familiar from GitHub/Linear.
+
+The cell renders nothing (empty view) when `pr.assignees.isEmpty`, keeping the Table visually tidy for PRs with no assignees.
 
 **5. "Assigned" dashboard tab**
 


### PR DESCRIPTION
## Summary

Adds first-class assignee support to the PR surface so you can assign yourself or any repo collaborator without leaving Runway:

- **Drawer**: new assignees row with a popover-hosted searchable picker ("Assign to me" / "Unassign me" pill on top, filter field, scrollable list with check indicators).
- **Dashboard**: new "Assigned" tab (driven by `gh search prs --assignee @me`) and a new "Assignees" column rendering overlapping 14pt avatar stacks with "+N" overflow.
- **Shared UI**: `AssigneeAvatar` view with deterministic color hashing (stable across app launches) and two-letter initials extraction.

## Architecture

Pure additions to the existing three-layer PR stack — no new layers:

`PRManager (actor)` → `PRCoordinator (@Observable @MainActor)` → SwiftUI views.

Four new `gh` CLI wrappers on `PRManager` (`assign`, `unassign`, `whoami`, `collaborators`) with per-host + per-repo caching. Assignees arrive via the existing enrichment pipeline (one extra JSON field on `gh pr view`), so the dashboard gets them without a new subprocess per PR. `fetchAllPRs` now merges three origins (`.mine`, `.reviewRequested`, `.assigned`) in parallel.

Optimistic UI: `updateAssignees` mutates `pr.assignees` before the subprocess returns, with revert-on-failure via re-enrichment. Self-assign/unassign also immediately inserts/removes `.assigned` in the PR's origin set so the Assigned tab updates without waiting for the 30s poll.

## Implementation notes

- 21-task TDD plan at [`docs/superpowers/plans/2026-04-17-pr-assign-to-self.md`](docs/superpowers/plans/2026-04-17-pr-assign-to-self.md); spec at [`docs/superpowers/specs/2026-04-17-pr-assign-to-self-design.md`](docs/superpowers/specs/2026-04-17-pr-assign-to-self-design.md).
- Avatar color hash uses a UTF-8 FNV-like rolling hash; `String.hashValue` is intentionally avoided (Swift randomizes the seed per-launch, which would change colors every time the app opens).
- `whoami` is per-host because the same user may have different logins on github.com vs. GHE instances.
- Collaborator cache TTL is 10 minutes; whoami cache is indefinite (invalidated only by `gh` re-auth).
- No database migration — assignees are enrichment-derived and populate on first fetch after launch, matching how `checks` already behaves.

## Scope gap (tracked for follow-up)

`ProjectPRsTab` (project-page PR drawer) is intentionally not wired for assignees. It already omits several other drawer callbacks (`onClosePR`, `onSendToSession`, `onReviewPR`), so the feature-parity gap pre-existed this change. The drawer degrades gracefully there (assignees row renders as read-only avatars + inert "+" button).

## Test plan

- [x] Unit: 43 new tests (Models, GitHubOperations, Views) — full suite 381 passing, zero regressions.
- [x] Build: `swift build` clean, `make check` clean (0 swiftlint + 0 swift-format violations across 118 files).
- [ ] Manual smoke: run the app, verify on a real PR:
  - Four tabs present: All / Mine / Review Requests / Assigned
  - Opening a PR drawer shows the new Assignees row with any existing assignees as avatars
  - Click "+" → popover opens with "Assign to me" pill and collaborator list
  - Assign to me → PR instantly appears in Assigned tab, avatar appears on the row in the Table
  - Unassign me → PR disappears from Assigned tab immediately
  - Search filter matches login and name case-insensitively
  - Reopening the picker within 10 min loads instantly (cache)
  - Avatar colors remain the same after `Cmd+Q` and relaunch (stable hash regression)